### PR TITLE
fix(audio): resolve choppy sound by fixing stereo/mono mismatch

### DIFF
--- a/vendor/webrtc-sys/src/audio_device.cpp
+++ b/vendor/webrtc-sys/src/audio_device.cpp
@@ -17,7 +17,7 @@
 #include "livekit/audio_device.h"
 
 const int kSampleRate = 48000;
-const int kChannels = 2;
+const int kChannels = 1;
 const int kBytesPerSample = kChannels * sizeof(int16_t);
 const int kSamplesPer10Ms = kSampleRate / 100;
 
@@ -263,7 +263,7 @@ int32_t AudioDevice::MicrophoneMute(bool* enabled) const {
 }
 
 int32_t AudioDevice::StereoPlayoutIsAvailable(bool* available) const {
-  *available = true;
+  *available = false;  // Using mono playout
   return 0;
 }
 
@@ -289,6 +289,8 @@ int32_t AudioDevice::StereoRecording(bool* enabled) const {
 }
 
 int32_t AudioDevice::PlayoutDelay(uint16_t* delayMS) const {
+  // Set a reasonable delay estimate for real-time audio (10ms buffer interval)
+  *delayMS = 10;
   return 0;
 }
 


### PR DESCRIPTION
## Summary
- Fix stereo/mono channel mismatch in WebRTC AudioDevice module (was configured for stereo but pipeline expects mono)
- Report playout delay (10ms) to enable WebRTC jitter buffer adaptation
- Update `StereoPlayoutIsAvailable` to return false for consistency

## Root cause
The `kChannels` constant was set to 2 (stereo) while the entire downstream audio pipeline expected mono:
- `NativeAudioStream::new()` uses 1 channel
- Android/iOS/Desktop audio playout all configured for mono

This caused every other sample to be misinterpreted, producing aliasing artifacts (choppy/hacky sound).

## Test plan
- [ ] Test audio playback on Android device
- [ ] Test audio playback on iOS device  
- [ ] Test audio playback on desktop
- [ ] Verify no more choppy/hacky sound during calls

Fixes #3