### PR TITLE
docs: improve build instructions with per-platform prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,27 +71,30 @@ Native video conferencing client for [La Suite Meet](https://meet.numerique.gouv
 ## Prerequisites
 
 - **Rust** nightly (edition 2024) — `rustup default nightly`
-- **Android**: NDK 27+, SDK 26+, `cargo-ndk`, `rustup target add aarch64-linux-android`
-- **iOS**: Xcode 16+, `rustup target add aarch64-apple-ios aarch64-apple-ios-sim`
-- **Desktop**: Node.js 18+, Tauri CLI (`cargo install tauri-cli`)
+- Platform-specific requirements are listed in each build section below
 
 ## Building
 
 ### Desktop (macOS / Linux / Windows)
 
+**Prerequisites:** Node.js 18+, Tauri CLI (`cargo install tauri-cli@^2`)
+
 ```bash
-# Dev mode — start Vite and Tauri separately:
-cd crates/visio-desktop/frontend && npm install && npm run dev &
+# Install frontend dependencies (first time only)
+cd crates/visio-desktop/frontend && npm install
+
+# Dev mode (Tauri auto-starts Vite via beforeDevCommand)
 cd crates/visio-desktop && cargo tauri dev
 
 # Production build
-cd crates/visio-desktop/frontend && npm run build
 cd crates/visio-desktop && cargo tauri build
 ```
 
-The frontend dev server (Vite) must be running on `http://localhost:5173` **before** `cargo tauri dev` — Tauri's `devUrl` points to it. If Vite is not running, the window will be blank. Make sure no other Vite instance (e.g. from a git worktree) is occupying port 5173.
+Tauri automatically runs `npm run dev` (dev mode) or `npm run build` (production) via its `beforeDevCommand`/`beforeBuildCommand` config. Make sure no other Vite instance (e.g. from a git worktree) is occupying port 5173.
 
 ### Android
+
+**Prerequisites:** NDK 27+, SDK 26+, `cargo-ndk` (`cargo install cargo-ndk`), `rustup target add aarch64-linux-android`
 
 ```bash
 # 1. Build Rust libraries for arm64
@@ -107,6 +110,8 @@ adb install app/build/outputs/apk/debug/app-debug.apk
 The Gradle `copyI18nAssets` task runs automatically before build, copying `i18n/*.json` into `src/main/assets/i18n/`.
 
 ### iOS
+
+**Prerequisites:** Xcode 16+, `rustup target add aarch64-apple-ios aarch64-apple-ios-sim`
 
 ```bash
 # 1. Build Rust libraries
@@ -206,7 +211,6 @@ crates/
 android/            Kotlin/Compose app
 ios/                SwiftUI app
 scripts/            Build scripts (Android NDK, iOS fat libs)
-docs/plans/         Design docs and implementation plans
 ```
 
 ## What works


### PR DESCRIPTION
## Summary
- Add **Prerequisites** section to each platform's build instructions (Desktop, Android, iOS)
- Simplify desktop build commands (Tauri handles npm automatically via `beforeDevCommand`)
- Specify `tauri-cli@^2` version requirement
- Add `cargo install cargo-ndk` command for Android prerequisites
- Remove obsolete `docs/plans/` from project structure listing

## Motivation
The previous instructions for desktop were confusing because `cargo tauri` requires `tauri-cli` to be installed first, and users had to manually start Vite before Tauri. The new instructions are clearer and leverage Tauri's built-in `beforeDevCommand` configuration.

## Test plan
- [ ] Verify desktop build works with new instructions
- [ ] Verify Android build works with new instructions
- [ ] Verify iOS build works with new instructions