### PR TITLE
fix(android): prevent keyboard from hiding settings content

### DIFF
--- a/android/app/src/main/kotlin/io/visio/mobile/ui/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/SettingsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -89,7 +90,8 @@ fun SettingsScreen(onBack: () -> Unit) {
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background)
                 .statusBarsPadding()
-                .navigationBarsPadding(),
+                .navigationBarsPadding()
+                .imePadding(),
     ) {
         TopAppBar(
             title = {


### PR DESCRIPTION
## Summary
Add `imePadding()` modifier to SettingsScreen to ensure the content adjusts when the virtual keyboard appears.

## Problem
On Android 15, when tapping a TextField in the Settings screen (e.g., Display Name or Add Instance), the virtual keyboard would cover the bottom portion of the screen, making it impossible to see or interact with fields near the bottom.

## Solution
Added `.imePadding()` to the root Column modifier chain. This Compose modifier automatically adds padding equal to the IME (Input Method Editor / keyboard) height, pushing the content up when the keyboard is visible.

## Test plan
- [ ] Open Settings screen on Android 15 device
- [ ] Tap on "Display Name" TextField
- [ ] Verify the entire form remains visible and scrollable above the keyboard
- [ ] Tap on "Add Instance" TextField (near bottom)
- [ ] Verify the input field is not hidden by the keyboard

Fixes #2