### PR TITLE
fix(ci): use x86_64 arch for Android emulator API 34

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,5 @@ jobs:
       - uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
+          arch: x86_64
           script: cd android && ./gradlew connectedAndroidTest


### PR DESCRIPTION
## Summary
Fix the Android UI test CI job by specifying `arch: x86_64` for the emulator.

## Problem
The CI was failing with:
```
Warning: Failed to find package 'system-images;android-34;default;x86'
```

Android API 34 system images are not available for x86 architecture, only x86_64. The `android-emulator-runner` action defaults to `x86`, which doesn't exist for API 34.

## Solution
Explicitly set `arch: x86_64` in the emulator configuration.

## Test plan
- [ ] CI should pass after this fix is merged