### PR TITLE
fix(android): Crash on room join

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
@@ -756,7 +756,7 @@ fun ParticipantTile(
     ) {
         // Video surface or avatar fallback
         if (participant.hasVideo && participant.videoTrackSid != null) {
-            val trackSid = participant.videoTrackSid
+            val trackSid = participant.videoTrackSid!!
             AndroidView(
                 factory = { ctx -> VideoSurfaceView(ctx, trackSid) },
                 modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
Android 14+ requires MANAGE_OWN_CALLS for FOREGROUND_SERVICE_TYPE_PHONE_CALL. Without it, startForeground() throws a SecurityException that crashes the app immediately after joining a room.

Also fix Kotlin smart cast issue where videoTrackSid nullable type was not narrowed despite a prior null check.