### PR TITLE
fix(ios): make home page scrollable with collapsing header

### DIFF
--- a/ios/VisioMobile/Views/HomeView.swift
+++ b/ios/VisioMobile/Views/HomeView.swift
@@ -40,7 +40,7 @@ struct HomeView: View {
             ScrollView {
                 VStack(spacing: 32) {
                     VStack(spacing: 8) {
-                    VisioLogo(size: 96)
+                        VisioLogo(size: 96)
                         Text(Strings.t("app.title", lang: lang))
                             .font(.largeTitle)
                             .fontWeight(.bold)
@@ -48,8 +48,8 @@ struct HomeView: View {
                     }
                     .padding(.top, 16)
                     .background(GeometryReader { geo in
-                        Color.clear.onChange(of: geo.frame(in: .named("scroll")).minY) {
-                            showCompactHeader = $0 < -20
+                        Color.clear.onChange(of: geo.frame(in: .named("scroll")).minY) { _, newValue in
+                            showCompactHeader = newValue < -20
                         }
                     })
 


### PR DESCRIPTION
## Summary

- Make the home page scrollable so room history items at the bottom are reachable
- Replace the duplicate "Visio Mobile" title (in-body + navigation bar) with a collapsing header: the branding (logo + title) scrolls with content, and a compact version (small logo + title) fades into the toolbar when the branding scrolls out of view

## Changes

**Scrollable home page** (`HomeView.swift`)
- Wrap content in `ScrollView`
- Replace `Spacer()`s (non-functional in scroll context) with explicit padding

**Collapsing header** (`HomeView.swift`)
- Remove `.navigationTitle` — replaced with a `.principal` toolbar item (small logo + title) that fades in when the main branding scrolls away
- Track scroll position via `GeometryReader` on the branding block
- Toolbar background transitions from hidden to visible in sync with the compact header