### PR TITLE
fix(ios): crash when Bluetooth audio device sets sample rate below 48 kHz

### DIFF
--- a/ios/VisioMobile/AudioCapture.swift
+++ b/ios/VisioMobile/AudioCapture.swift
@@ -1,16 +1,16 @@
 import AVFoundation
 import visioFFI
 
-/// Captures real microphone audio via AVAudioEngine and pushes 48 kHz mono
-/// Int16 PCM frames to Rust via visio_push_ios_audio_frame().
+/// Captures microphone audio via AVAudioEngine, resamples to 48 kHz if the
+/// hardware rate differs (e.g. Bluetooth HFP), and pushes Int16 PCM frames
+/// to Rust via visio_push_ios_audio_frame().
 final class AudioCapture {
     private let engine = AVAudioEngine()
     private var isRunning = false
 
-    private let sampleRate: Double = 48_000
+    private let outputSampleRate: Double = 48_000
     private let channels: UInt32 = 1
-    /// 10ms frames = 480 samples at 48kHz
-    private let samplesPerFrame: Int = 480
+    private let outputSamplesPerFrame: Int = 480 // 10ms at 48 kHz
 
     func start() {
         guard !isRunning else { return }
@@ -19,52 +19,103 @@ final class AudioCapture {
         let hwFormat = inputNode.inputFormat(forBus: 0)
         NSLog("AudioCapture: hardware format: %@", hwFormat.description)
 
-        // Request 48kHz mono — AVAudioEngine will resample from hardware format.
-        guard let desiredFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: sampleRate,
-            channels: AVAudioChannelCount(channels),
-            interleaved: false
-        ) else {
-            NSLog("AudioCapture: failed to create desired format")
+        guard hwFormat.sampleRate > 0 else {
+            NSLog("AudioCapture: no input device available (sample rate = 0)")
             return
         }
 
-        // Install a tap on the input node to receive mic audio.
-        let samplesPerFrame = self.samplesPerFrame
-        let sampleRate = UInt32(self.sampleRate)
+        guard let tapFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: hwFormat.sampleRate,
+            channels: AVAudioChannelCount(channels),
+            interleaved: false
+        ) else {
+            NSLog("AudioCapture: failed to create tap format")
+            return
+        }
+
+        let needsResample = hwFormat.sampleRate != outputSampleRate
+        var converter: AVAudioConverter?
+        var outputFormat: AVAudioFormat?
+        if needsResample {
+            guard let outFmt = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: outputSampleRate,
+                channels: AVAudioChannelCount(channels),
+                interleaved: false
+            ) else {
+                NSLog("AudioCapture: failed to create output format")
+                return
+            }
+            outputFormat = outFmt
+            converter = AVAudioConverter(from: tapFormat, to: outFmt)
+            NSLog("AudioCapture: resampling from %.0f Hz to %.0f Hz", hwFormat.sampleRate, outputSampleRate)
+        }
+
+        let outputSamplesPerFrame = self.outputSamplesPerFrame
+        let outputRate = UInt32(self.outputSampleRate)
         let channels = self.channels
 
-        inputNode.installTap(onBus: 0, bufferSize: AVAudioFrameCount(samplesPerFrame), format: desiredFormat) { buffer, _ in
-            guard let floatData = buffer.floatChannelData?[0] else { return }
-            let frameCount = Int(buffer.frameLength)
+        let tapBufferSize = AVAudioFrameCount(hwFormat.sampleRate * 0.01) // 10ms
 
-            // Convert Float32 → Int16 and push in chunks of samplesPerFrame
+        inputNode.installTap(onBus: 0, bufferSize: tapBufferSize, format: tapFormat) { buffer, _ in
+            let floatBuffer: AVAudioPCMBuffer
+
+            if needsResample, let converter = converter, let outputFormat = outputFormat {
+                let ratio = outputFormat.sampleRate / tapFormat.sampleRate
+                let outputCapacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1
+                guard let resampledBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: outputCapacity) else {
+                    return
+                }
+                var error: NSError?
+                var consumed = false
+                converter.convert(to: resampledBuffer, error: &error) { _, outStatus in
+                    if consumed {
+                        outStatus.pointee = .noDataNow
+                        return nil
+                    }
+                    consumed = true
+                    outStatus.pointee = .haveData
+                    return buffer
+                }
+                if let error = error {
+                    NSLog("AudioCapture: resample error: %@", error.localizedDescription)
+                    return
+                }
+                floatBuffer = resampledBuffer
+            } else {
+                floatBuffer = buffer
+            }
+
+            guard let floatData = floatBuffer.floatChannelData?[0] else { return }
+            let frameCount = Int(floatBuffer.frameLength)
+
+            // Float32 → Int16, push in 10ms chunks
             var i16Buf = [Int16](repeating: 0, count: frameCount)
             for i in 0..<frameCount {
                 i16Buf[i] = Int16(clamping: Int(floatData[i] * 32767.0))
             }
 
-            // Push complete frames
             var offset = 0
-            while offset + samplesPerFrame <= frameCount {
+            while offset + outputSamplesPerFrame <= frameCount {
                 i16Buf.withUnsafeBufferPointer { ptr in
                     guard let base = ptr.baseAddress else { return }
                     visio_push_ios_audio_frame(
                         base.advanced(by: offset),
-                        UInt32(samplesPerFrame),
-                        sampleRate,
+                        UInt32(outputSamplesPerFrame),
+                        outputRate,
                         channels
                     )
                 }
-                offset += samplesPerFrame
+                offset += outputSamplesPerFrame
             }
         }
 
         do {
             try engine.start()
             isRunning = true
-            NSLog("AudioCapture: started (48kHz mono, %d samples/frame)", samplesPerFrame)
+            NSLog("AudioCapture: started (hw=%.0f Hz, output=48000 Hz, %d samples/frame)",
+                  hwFormat.sampleRate, outputSamplesPerFrame)
         } catch {
             NSLog("AudioCapture: failed to start engine: %@", error.localizedDescription)
         }


### PR DESCRIPTION
## Summary

Fix a fatal crash when joining a call with a Bluetooth HFP/SCO audio device connected. This also resolves the lack of audio when connecting a bluetooth device after joining a meeting.

## Root cause

`AVAudioInputNode.installTap` requires the tap format's sample rate to match the hardware input rate. The code hardcoded 48 kHz, but Bluetooth HFP/SCO devices can force rates as low as 8 kHz — `setPreferredSampleRate` is only a hint that iOS is free to ignore.

## Fix

Install the tap at the hardware's native rate and resample to 48 kHz via `AVAudioConverter` when they differ. The Rust/LiveKit pipeline continues to receive 48 kHz frames unchanged.