### PR TITLE
fix(ios): fix infinite recursion in effectiveAdaptiveMode crashing on join

### DIFF
--- a/ios/VisioMobile/Views/CallView.swift
+++ b/ios/VisioMobile/Views/CallView.swift
@@ -79,7 +79,7 @@ struct CallView: View {
     private var isDark: Bool { manager.currentTheme == "dark" }
     /// When adaptive mode is disabled in settings, force Office mode everywhere.
     private var effectiveAdaptiveMode: AdaptiveMode {
-        manager.client.isAdaptiveModeEnabled() ? effectiveAdaptiveMode : .office
+        manager.client.isAdaptiveModeEnabled() ? manager.adaptiveMode : .office
     }
     private var isAdaptiveModeEnabled: Bool { manager.client.isAdaptiveModeEnabled() }
 


### PR DESCRIPTION
## Summary

- Fix infinite recursion in `effectiveAdaptiveMode` computed property that caused a stack overflow crash when joining a room with adaptive mode enabled
- The property referenced itself (`effectiveAdaptiveMode`) instead of `manager.adaptiveMode`, introduced in 641ddf8

This meant the application was completely unusable on iOS.

Fixes #39

## Details

When `isAdaptiveModeEnabled()` returns `true`, the computed property called itself recursively, overflowing the stack. This killed the main thread during SwiftUI body evaluation on room join, producing `Reporter disconnected` and `Result accumulator timeout` errors in Xcode logs.

**One-line fix:** `effectiveAdaptiveMode` → `manager.adaptiveMode` in the truthy branch.