### PR TITLE
fix(ios): show blurred local preview instead of raw camera feed

### DIFF
--- a/crates/visio-ffi/src/lib.rs
+++ b/crates/visio-ffi/src/lib.rs
@@ -2057,6 +2057,23 @@ pub unsafe extern "C" fn visio_push_ios_camera_frame(
         );
     }
 
+    // Deliver post-blur frame to local preview.
+    {
+        let strides = i420.strides();
+        let (y_data, u_data, v_data) = i420.data();
+        visio_video::deliver_i420_to_ios_callback(
+            width,
+            height,
+            y_data.as_ptr(),
+            strides.0,
+            u_data.as_ptr(),
+            strides.1,
+            v_data.as_ptr(),
+            strides.2,
+            "local-camera",
+        );
+    }
+
     let frame = VideoFrame {
         rotation: VideoRotation::VideoRotation0,
         timestamp_us: 0,

--- a/crates/visio-video/src/ios.rs
+++ b/crates/visio-video/src/ios.rs
@@ -53,6 +53,43 @@ pub unsafe extern "C" fn visio_video_set_ios_callback(
     });
 }
 
+/// Send I420 planes to the iOS callback for a given track SID.
+pub fn deliver_i420_to_ios_callback(
+    width: u32,
+    height: u32,
+    y_ptr: *const u8,
+    y_stride: u32,
+    u_ptr: *const u8,
+    u_stride: u32,
+    v_ptr: *const u8,
+    v_stride: u32,
+    track_sid: &str,
+) {
+    let Some(cb) = IOS_CALLBACK.get() else {
+        return;
+    };
+
+    let sid_cstr = match std::ffi::CString::new(track_sid) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    unsafe {
+        (cb.callback)(
+            width,
+            height,
+            y_ptr,
+            y_stride,
+            u_ptr,
+            u_stride,
+            v_ptr,
+            v_stride,
+            sid_cstr.as_ptr(),
+            cb.user_data,
+        );
+    }
+}
+
 /// Render a single I420 frame by passing plane pointers to the iOS callback.
 ///
 /// The Swift callback receives raw Y/U/V plane pointers and strides so it can

--- a/crates/visio-video/src/lib.rs
+++ b/crates/visio-video/src/lib.rs
@@ -43,6 +43,9 @@ fn android_log(msg: &str) {
 #[cfg(target_os = "ios")]
 mod ios;
 
+#[cfg(target_os = "ios")]
+pub use ios::deliver_i420_to_ios_callback;
+
 #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 mod desktop;
 

--- a/ios/VisioMobile/CameraCapture.swift
+++ b/ios/VisioMobile/CameraCapture.swift
@@ -205,6 +205,5 @@ final class CameraCapture: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
         }
 
         pushNV12FrameToRust(pixelBuffer, uPlane: &uPlane, vPlane: &vPlane)
-        VideoFrameRouter.shared.deliverLocalPreviewBuffer(sampleBuffer)
     }
 }


### PR DESCRIPTION
## Summary

- Feed local camera preview from the post-blur I420 buffer via the iOS video callback instead of the raw `AVCaptureSession` output
- Add `deliver_i420_to_ios_callback()` in `visio-video` and call it from `visio_push_ios_camera_frame` after blur processing
- Remove `deliverLocalPreviewBuffer()` call from `CameraCapture.swift`

Fixes #37