### PR TITLE
fix(android): remote video not displayed until user touches screen

### DIFF
--- a/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
@@ -784,6 +784,7 @@ fun CallScreen(
                                     if (hasTrack) {
                                         AndroidView(
                                             factory = { ctx -> VideoSurfaceView(ctx, focusedDisplayItem.trackSid!!) },
+                                            update = { view -> view.requestLayout() },
                                             modifier = Modifier.fillMaxSize(),
                                         )
                                     } else {
@@ -1704,6 +1705,12 @@ fun ParticipantTile(
             androidx.compose.runtime.key(trackSid) {
                 AndroidView(
                     factory = { ctx -> VideoSurfaceView(ctx, trackSid) },
+                    update = { view ->
+                        // Force layout pass when SurfaceView is first inserted
+                        // into the Compose hierarchy. Without this, the surface
+                        // may not be visible until the user touches the screen.
+                        view.requestLayout()
+                    },
                     modifier = Modifier.fillMaxSize(),
                 )
             }


### PR DESCRIPTION
## Summary
- When a remote participant activates their camera, the video is not displayed until the user touches the screen
- Root cause: `SurfaceView` inside Compose `AndroidView` needs an explicit layout pass to become visible — it uses a separate surface layer that requires the parent view hierarchy to complete layout before the compositor shows the surface
- Fix: add `update = { view -> view.requestLayout() }` to both grid and focus mode `AndroidView` wrappers

Fixes #33

## Test plan
- [ ] Connect Android to room with desktop participant (camera off)
- [ ] Desktop activates camera → verify video appears immediately on Android
- [ ] Test in both grid mode and focus mode
- [ ] Verify no regression on camera switch, screen share, or avatar fallback