### PR TITLE
fix(ios): eliminate transient error banner flash on room join

### DIFF
--- a/ios/VisioMobile/VisioManager.swift
+++ b/ios/VisioMobile/VisioManager.swift
@@ -114,6 +114,10 @@ class VisioManager: ObservableObject {
     // MARK: - Public API
 
     func connect(url: String, username: String?) {
+        // Set connecting state immediately so CallView never renders the
+        // "Disconnected" banner before the async event arrives from Rust.
+        self.connectionState = .connecting
+
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
             do {
@@ -177,6 +181,8 @@ class VisioManager: ObservableObject {
     }
 
     func connectWithToken(livekitUrl: String, token: String) {
+        self.connectionState = .connecting
+
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
             do {


### PR DESCRIPTION
## Summary
- When joining a room, `CallView` briefly flashes a "Disconnected" banner (~1s) before the connection state updates
- Root cause: `connect()` dispatches to a background thread, leaving `connectionState` at `.disconnected` until the Rust event arrives
- Fix: set `connectionState = .connecting` synchronously before the async dispatch, so `CallView` never renders the disconnected state

Fixes #35

## Test plan
- [ ] Join a room on iOS — verify no error/disconnected banner flashes on entry
- [ ] Verify connection banner shows "Connecting..." then disappears on success
- [ ] Verify actual connection errors still display correctly