### PR TITLE
fix: populate room history on successful connection

### DIFF
--- a/crates/visio-desktop/src/lib.rs
+++ b/crates/visio-desktop/src/lib.rs
@@ -442,10 +442,7 @@ async fn connect(
     let room = state.room.lock().await;
     room.connect(&meet_url, username.as_deref(), cookie.as_deref())
         .await
-        .map_err(|e| e.to_string())?;
-
-    state.settings.add_room_to_history(meet_url);
-    Ok(())
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/crates/visio-ffi/src/lib.rs
+++ b/crates/visio-ffi/src/lib.rs
@@ -716,16 +716,10 @@ impl visio_core::VisioEventListener for BridgeListener {
         if let CoreVisioEvent::ConnectionStateChanged(visio_core::ConnectionState::Connected) = &event {
             let rm = self.room_manager.clone();
             let settings = self.settings.clone();
-            std::thread::spawn(move || {
-                let rt = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .unwrap();
-                rt.block_on(async {
-                    if let Some((url, _)) = rm.last_connection_info().await {
-                        settings.add_room_to_history(url);
-                    }
-                });
+            tokio::spawn(async move {
+                if let Some((url, _)) = rm.last_connection_info().await {
+                    settings.add_room_to_history(url);
+                }
             });
         }
 


### PR DESCRIPTION
## Summary

Closes #53 — Room history was partially broken: mobile direct connects worked (existing call at `visio-ffi/lib.rs:805`), but the lobby acceptance path on mobile and all desktop paths never recorded history.

### Changes

**visio-desktop (`crates/visio-desktop/src/lib.rs`):**
- Wrap `SettingsStore` in `Arc` to share with event listener
- Add `settings` field to `DesktopEventListener`
- On `ConnectionStateChanged(Connected)`, retrieve `last_meet_url` from `RoomManager` and call `add_room_to_history(url)`

**visio-ffi (`crates/visio-ffi/src/lib.rs`):**
- Wrap `SettingsStore` in `Arc` to share with `BridgeListener`
- Add `room_manager` and `settings` fields to `BridgeListener`
- On `ConnectionStateChanged(Connected)`, same pattern — covers the lobby acceptance path that bypasses `VisioClient::connect()`'s return-value path

**No changes to visio-core** — the existing `add_room_to_history()` already handles deduplication and max-10 truncation.

### Before / After

| Path | Before | After |
|------|--------|-------|
| Mobile direct connect | Works (line 805) | Works (line 805 + event handler, dedup handles double call) |
| Mobile lobby accept | Missing | Fixed via BridgeListener event handler |
| Desktop direct connect | Missing | Fixed via DesktopEventListener event handler |
| Desktop lobby accept | Missing | Fixed via DesktopEventListener event handler |

## Test plan

- [x] 121 Rust unit tests pass
- [x] `cargo build -p visio-ffi` succeeds
- [x] `cargo build -p visio-desktop --no-default-features` succeeds
- [ ] Manual: join room on desktop → verify URL appears in history
- [ ] Manual: join room via lobby → verify URL appears in history
- [ ] Manual: restart app → verify history persists