### PR TITLE
fix(desktop): use 720p camera preset to match NativeVideoSource resolution

### DIFF
--- a/crates/visio-desktop/src/camera_macos.rs
+++ b/crates/visio-desktop/src/camera_macos.rs
@@ -184,7 +184,7 @@ unsafe extern "C" {
 #[link(name = "AVFoundation", kind = "framework")]
 unsafe extern "C" {
     static AVMediaTypeVideo: *const AnyObject;
-    static AVCaptureSessionPresetHigh: *const AnyObject;
+    static AVCaptureSessionPreset1280x720: *const AnyObject;
 }
 
 /// NV12 full-range: kCVPixelFormatType_420YpCbCr8BiPlanarFullRange = '420f'
@@ -431,7 +431,7 @@ impl MacCameraCapture {
         let session: Retained<AnyObject> = unsafe { msg_send![session_cls, new] };
 
         // Set session preset
-        let _: () = unsafe { msg_send![&*session, setSessionPreset: AVCaptureSessionPresetHigh] };
+        let _: () = unsafe { msg_send![&*session, setSessionPreset: AVCaptureSessionPreset1280x720] };
 
         // --- Find camera device by uniqueID ---
         let device_cls =
@@ -530,7 +530,7 @@ impl MacCameraCapture {
         let session: Retained<AnyObject> = unsafe { msg_send![session_cls, new] };
 
         // Set session preset
-        let _: () = unsafe { msg_send![&*session, setSessionPreset: AVCaptureSessionPresetHigh] };
+        let _: () = unsafe { msg_send![&*session, setSessionPreset: AVCaptureSessionPreset1280x720] };
 
         // --- Find camera device ---
         let device_cls =


### PR DESCRIPTION
## Summary
- Remote participants see a frozen image from the macOS desktop client
- Root cause: `AVCaptureSessionPresetHigh` captures at native resolution (often 1920x1080) but the `NativeVideoSource` is created at 1280x720, causing the VP8 encoder to stall after the initial keyframe
- Fix: use `AVCaptureSessionPreset1280x720` to match the declared resolution

Fixes #57

## Test plan
- [ ] Join room from macOS desktop with camera enabled
- [ ] Verify remote participants see live video (not frozen)
- [ ] Verify local preview still works
- [ ] Test with built-in and external cameras