### PR TITLE
fix(e2e): bot media file support and ADB reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,9 @@ and this project adheres to
 - Semantic test tags for layout assertions
 - 4 test suites, 11 scenarios
 - HTML/JSON/terminal reporting with screenshots
+
+### Fixed
+
+- Bot interactive mode now uses --media-file audio
+- UIAutomator dump uses temp file for device compat
+- Deep link URL escaping no longer corrupts params

--- a/e2e/framework/utils/adb.ts
+++ b/e2e/framework/utils/adb.ts
@@ -17,16 +17,17 @@ export function isDeviceConnected(): boolean {
  * Dump the current UI hierarchy via uiautomator and return the raw XML string.
  */
 export function dumpUiTree(): string {
-  const out = execSync("adb shell uiautomator dump /dev/tty", {
-    encoding: "utf-8",
+  // Dump to a temp file on the device, then read its contents.
+  // /dev/tty does not work reliably on all devices (e.g. Pixel Fold).
+  const dumpPath = "/sdcard/e2e-ui-dump.xml";
+  execSync(`adb shell uiautomator dump ${dumpPath}`, {
     timeout: 15_000,
+    stdio: "pipe",
   });
-  // uiautomator prints the XML followed by "UI hierachy dumped to: /dev/tty"
-  // Strip the trailing status line if present.
-  const idx = out.lastIndexOf("</hierarchy>");
-  if (idx !== -1) {
-    return out.slice(0, idx + "</hierarchy>".length);
-  }
+  const out = execSync(`adb shell cat ${dumpPath}`, {
+    encoding: "utf-8",
+    timeout: 10_000,
+  });
   return out;
 }
 
@@ -135,10 +136,10 @@ export function screencap(outputPath: string): void {
  * Launch the Visio Mobile app with the given deep link URL.
  */
 export function launchDeepLink(url: string): void {
-  // Escape shell metacharacters for the Android shell (adb shell concatenates args into a command).
-  const escaped = url.replace(/[&;|$`"\\(){}]/g, "\\$&");
+  // Wrap the URL in single quotes so the Android shell does not interpret & or other metacharacters.
+  // The URL must not contain single quotes itself (safe for our use case).
   execFileSync("adb", [
-    "shell", `am start -a android.intent.action.VIEW -d '${escaped}' io.visio.mobile`,
+    "shell", `am start -a android.intent.action.VIEW -d '${url}' io.visio.mobile`,
   ], { timeout: 10_000, stdio: "pipe" });
 }
 

--- a/e2e/visio-bot/src/main.rs
+++ b/e2e/visio-bot/src/main.rs
@@ -1012,7 +1012,12 @@ async fn main() {
         if args.audio {
             match controls.publish_microphone().await {
                 Ok(source) => {
-                    spawn_synthetic_audio(source);
+                    if let Some(ref path) = args.media_file {
+                        tracing::info!("Publishing audio from file: {path} (muted)");
+                        spawn_file_audio(source, path.clone(), args.loop_media);
+                    } else {
+                        spawn_synthetic_audio(source);
+                    }
                     controls.set_microphone_enabled(false).await.ok();
                     tracing::info!("Audio track published (muted)");
                 }
@@ -1024,7 +1029,11 @@ async fn main() {
         if args.video {
             match controls.publish_camera("720p").await {
                 Ok(source) => {
-                    spawn_synthetic_video(source);
+                    if let Some(ref path) = args.media_file {
+                        spawn_file_video(source, path.clone(), args.loop_media);
+                    } else {
+                        spawn_synthetic_video(source);
+                    }
                     controls.set_camera_enabled(false).await.ok();
                     tracing::info!("Video track published (muted)");
                 }


### PR DESCRIPTION
## Summary

Fixes 3 issues found during the first real E2E smoke test on a physical Pixel Fold Pro device.

- **Bot interactive mode ignores `--media-file`**: In `--interactive` mode, the bot always used synthetic 440Hz audio regardless of `--media-file`. LiveKit's Voice Activity Detection (VAD) doesn't detect a constant sine wave as speech, so `ActiveSpeakersChanged` events never fire. Now the bot uses the media file audio when provided, enabling real speech detection.
- **UIAutomator dump fails on Pixel Fold**: `adb shell uiautomator dump /dev/tty` returns empty output on some devices. Replaced with dump to `/sdcard/e2e-ui-dump.xml` temp file then `adb shell cat`.
- **Deep link URL corruption**: `\&` escaping in the deep link added a literal backslash to the `livekit_url` parameter (`ws://192.168.1.60:7880\`), causing connection failure. Replaced with single-quote wrapping which correctly protects `&` from Android shell interpretation.

## Test plan

- [x] Manually verified: bot speaks real speech → LiveKit detects active speaker → Android layout switches to FOCUS mode → `main-tile:<bot-sid>` visible in UIAutomator dump