### PR TITLE
fix(desktop): fix home tabs layout and segmented control

### DIFF
--- a/crates/visio-desktop/frontend/src/App.css
+++ b/crates/visio-desktop/frontend/src/App.css
@@ -135,11 +135,25 @@ main {
 /* -- Home / Join ----------------------------------------------------------- */
 
 #home {
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
-  padding: 40px 20px;
+  padding: 0;
   position: relative;
+  overflow: hidden;
+}
+
+#home .home-tabs {
+  flex-shrink: 0;
+}
+
+#home .home-tab-content {
+  flex: 1;
   overflow-y: auto;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 20px 20px;
 }
 
 .join-form {
@@ -468,9 +482,6 @@ main {
 /* -- Settings gear --------------------------------------------------------- */
 
 .settings-gear {
-  position: absolute;
-  top: 16px;
-  right: 16px;
   background: none;
   border: none;
   color: var(--text-secondary);
@@ -480,6 +491,7 @@ main {
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-left: auto;
   transition:
     color 0.2s,
     background 0.2s;
@@ -2829,24 +2841,35 @@ main {
 
 .home-tabs {
   display: flex;
-  gap: 0;
+  align-items: center;
+  gap: 4px;
+  margin: 0;
+  padding: 10px 12px;
+  width: 100%;
   border-bottom: 1px solid var(--border);
-  margin: 0 0 16px 0;
+}
+
+.home-tabs-group {
+  display: flex;
+  gap: 2px;
+  background: var(--bg-tertiary);
+  border-radius: 10px;
+  padding: 3px;
 }
 
 .home-tab {
-  flex: 1;
-  padding: 10px 16px;
+  padding: 8px 20px;
   background: none;
   border: none;
-  border-bottom: 2px solid transparent;
+  border-radius: 8px;
   color: var(--text-secondary);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 500;
   cursor: pointer;
   transition:
     color 0.15s,
-    border-color 0.15s;
+    background 0.15s,
+    box-shadow 0.15s;
 }
 
 .home-tab:hover {
@@ -2855,7 +2878,8 @@ main {
 
 .home-tab-active {
   color: var(--accent);
-  border-bottom-color: var(--accent);
+  background: var(--bg);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
 /* ---------------------------------------------------------------------------

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -936,28 +936,31 @@ function HomeView({
 
   return (
     <div id="home" className="section active">
-      <button
-        className="settings-gear"
-        onClick={onOpenSettings}
-        data-testid="home-settings-button"
-      >
-        <RiSettings3Line size={24} />
-      </button>
       <div className="home-tabs">
+        <div className="home-tabs-group">
+          <button
+            className={`home-tab${activeTab === 'join' ? ' home-tab-active' : ''}`}
+            onClick={() => setActiveTab('join')}
+          >
+            {t('home.tab.join')}
+          </button>
+          <button
+            className={`home-tab${activeTab === 'meetings' ? ' home-tab-active' : ''}`}
+            onClick={() => setActiveTab('meetings')}
+          >
+            {t('home.tab.meetings')}
+            {meetingCount > 0 && <span className="tab-badge">{meetingCount}</span>}
+          </button>
+        </div>
         <button
-          className={`home-tab${activeTab === 'join' ? ' home-tab-active' : ''}`}
-          onClick={() => setActiveTab('join')}
+          className="settings-gear"
+          onClick={onOpenSettings}
+          data-testid="home-settings-button"
         >
-          {t('home.tab.join')}
-        </button>
-        <button
-          className={`home-tab${activeTab === 'meetings' ? ' home-tab-active' : ''}`}
-          onClick={() => setActiveTab('meetings')}
-        >
-          {t('home.tab.meetings')}
-          {meetingCount > 0 && <span className="tab-badge">{meetingCount}</span>}
+          <RiSettings3Line size={20} />
         </button>
       </div>
+      <div className="home-tab-content">
       {activeTab === 'meetings' ? (
         <MeetingsTab onJoin={onJoin} displayName={displayName} onMeetingCountChange={setMeetingCount} />
       ) : (
@@ -1258,6 +1261,7 @@ function HomeView({
           )}
         </div>
       )}
+      </div>
       {showCreateRoom && authenticatedMeetInstance && (
         <CreateRoomDialog
           meetInstance={authenticatedMeetInstance}
@@ -4028,7 +4032,7 @@ function PreJoinScreen({
                 <div
                   className="prejoin-vu-bar"
                   data-testid="prejoin-vu-bar"
-                  style={{ width: `${Math.round(Math.min(micLevel * 5, 1) * 100)}%` }}
+                  style={{ width: `${Math.round(Math.min(micLevel * 25, 1) * 100)}%` }}
                 />
               </div>
 


### PR DESCRIPTION
## Summary

Fixes the vertical shift between the "Rejoindre" and "Réunions planifiées" tabs on the Desktop home screen.

- Tabs + settings gear stay fixed at the top of the screen
- Only the content below scrolls (join form or meetings list)
- Settings gear moved inline with tabs (right-aligned, same row)
- Tabs styled as a segmented control (pill buttons) for better visual affordance

## Test plan

- [x] Visual: tabs don't shift when switching between Join and Meetings
- [x] Visual: settings gear aligned with tab text
- [x] Meetings list scrolls independently
- [x] Join form content scrolls if window is small