### PR TITLE
fix: auto-fallback to default audio device on Bluetooth disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Auto-fallback to default audio device when Bluetooth disconnects (#83)
+
 ### Added
 
 - Pre-join lobby screen with live camera preview,

--- a/android/app/src/main/kotlin/io/visio/mobile/VisioManager.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/VisioManager.kt
@@ -3,6 +3,7 @@ package io.visio.mobile
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.media.AudioDeviceCallback
 import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.os.Build
@@ -141,6 +142,9 @@ object VisioManager : VisioEventListener {
 
     // Track previous audio device to restore after car mode
     private var previousAudioDevice: AudioDeviceInfo? = null
+
+    // Bluetooth device removal callback for mid-session fallback
+    private var bluetoothDeviceCallback: AudioDeviceCallback? = null
 
     // Audio focus monitoring for phone call detection
     private var audioFocusListener: AudioManager.OnAudioFocusChangeListener? = null
@@ -606,9 +610,32 @@ object VisioManager : VisioEventListener {
     /**
      * Start monitoring audio focus changes to detect phone calls.
      * When a phone call starts, Android requests audio focus and we lose ours.
+     * Also registers an AudioDeviceCallback to fall back to default audio when
+     * a Bluetooth device disconnects mid-session.
      */
     private fun startAudioFocusMonitoring() {
         val am = appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+        // Register Bluetooth disconnect fallback callback
+        bluetoothDeviceCallback =
+            object : AudioDeviceCallback() {
+                override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>) {
+                    val btRemoved =
+                        removedDevices.any { device ->
+                            device.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO ||
+                                device.type == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP ||
+                                device.type == AudioDeviceInfo.TYPE_BLE_HEADSET
+                        }
+                    if (btRemoved && _connectionState.value is ConnectionState.Connected) {
+                        Log.i("VisioManager", "Bluetooth audio device removed mid-session — falling back to system default")
+                        scope.launch(Dispatchers.IO) {
+                            restoreDefaultAudioRoute()
+                        }
+                    }
+                }
+            }
+        am.registerAudioDeviceCallback(bluetoothDeviceCallback, null)
+
         audioFocusListener =
             AudioManager.OnAudioFocusChangeListener { focusChange ->
                 when (focusChange) {
@@ -660,6 +687,11 @@ object VisioManager : VisioEventListener {
      */
     private fun stopAudioFocusMonitoring() {
         val am = appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+        // Unregister Bluetooth disconnect fallback callback
+        bluetoothDeviceCallback?.let { am.unregisterAudioDeviceCallback(it) }
+        bluetoothDeviceCallback = null
+
         audioFocusListener?.let { listener ->
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 val request =
@@ -1130,46 +1162,50 @@ object VisioManager : VisioEventListener {
                 _calendarLoading.value = false
             }
             is VisioEvent.AdaptiveModeChanged -> {
-                val previousMode = _adaptiveMode.value
-                _adaptiveMode.value = event.mode
-                Log.d("VISIO", "Adaptive mode changed: $previousMode -> ${event.mode}")
-                if (event.mode == uniffi.visio.AdaptiveMode.CAR) {
-                    scope.launch(Dispatchers.IO) {
-                        // If we just connected, wait for camera-on-join to settle
-                        val elapsed = System.currentTimeMillis() - connectionTimestampMs
-                        if (elapsed < CONNECTION_GRACE_MS) {
-                            val delayMs = CONNECTION_GRACE_MS - elapsed
-                            Log.d("VISIO", "CAR mode: waiting ${delayMs}ms for connection grace period")
-                            kotlinx.coroutines.delay(delayMs)
-                        }
-                        cameraWasEnabledBeforeCar = client.isCameraEnabled()
-                        if (cameraWasEnabledBeforeCar) {
-                            stopCameraCapture()
-                            client.setCameraEnabled(false)
-                        }
-                        // Small delay to let audio session settle after camera state change
-                        kotlinx.coroutines.delay(200)
-                        routeAudioToBluetooth()
-                        // Verify Bluetooth routing was applied
-                        val am = appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                            val commDevice = am.communicationDevice
-                            Log.i("VisioManager", "CAR mode: communication device after routing = ${commDevice?.productName ?: "none"}")
-                        }
+                handleAdaptiveModeChanged(event.mode)
+            }
+        }
+    }
+
+    private fun handleAdaptiveModeChanged(newMode: uniffi.visio.AdaptiveMode) {
+        val previousMode = _adaptiveMode.value
+        _adaptiveMode.value = newMode
+        Log.d("VISIO", "Adaptive mode changed: $previousMode -> $newMode")
+        if (newMode == uniffi.visio.AdaptiveMode.CAR) {
+            scope.launch(Dispatchers.IO) {
+                // If we just connected, wait for camera-on-join to settle
+                val elapsed = System.currentTimeMillis() - connectionTimestampMs
+                if (elapsed < CONNECTION_GRACE_MS) {
+                    val delayMs = CONNECTION_GRACE_MS - elapsed
+                    Log.d("VISIO", "CAR mode: waiting ${delayMs}ms for connection grace period")
+                    kotlinx.coroutines.delay(delayMs)
+                }
+                cameraWasEnabledBeforeCar = client.isCameraEnabled()
+                if (cameraWasEnabledBeforeCar) {
+                    stopCameraCapture()
+                    client.setCameraEnabled(false)
+                }
+                // Small delay to let audio session settle after camera state change
+                kotlinx.coroutines.delay(200)
+                routeAudioToBluetooth()
+                // Verify Bluetooth routing was applied
+                val am = appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    val commDevice = am.communicationDevice
+                    Log.i("VisioManager", "CAR mode: communication device after routing = ${commDevice?.productName ?: "none"}")
+                }
+            }
+        } else if (previousMode == uniffi.visio.AdaptiveMode.CAR) {
+            scope.launch(Dispatchers.IO) {
+                restoreDefaultAudioRoute()
+                if (cameraWasEnabledBeforeCar) {
+                    try {
+                        client.setCameraEnabled(true)
+                        startCameraCapture()
+                    } catch (e: Exception) {
+                        Log.e("VISIO", "Failed to restore camera after car mode", e)
                     }
-                } else if (previousMode == uniffi.visio.AdaptiveMode.CAR) {
-                    scope.launch(Dispatchers.IO) {
-                        restoreDefaultAudioRoute()
-                        if (cameraWasEnabledBeforeCar) {
-                            try {
-                                client.setCameraEnabled(true)
-                                startCameraCapture()
-                            } catch (e: Exception) {
-                                Log.e("VISIO", "Failed to restore camera after car mode", e)
-                            }
-                            cameraWasEnabledBeforeCar = false
-                        }
-                    }
+                    cameraWasEnabledBeforeCar = false
                 }
             }
         }

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/MeetingsTab.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/MeetingsTab.kt
@@ -276,24 +276,34 @@ private fun MeetingCard(
     onJoin: () -> Unit,
 ) {
     val isAccent = isInProgress || isImminent
-    val accentGradient = Brush.linearGradient(
-        colors = listOf(VisioColors.Primary500, Color(0xFF5C3CDC)),
-    )
+    val accentGradient =
+        Brush.linearGradient(
+            colors = listOf(VisioColors.Primary500, Color(0xFF5C3CDC)),
+        )
 
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(10.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = if (isAccent) Color.Transparent else if (isDark) VisioColors.PrimaryDark100 else VisioColors.LightSurfaceVariant,
-        ),
+        colors =
+            CardDefaults.cardColors(
+                containerColor =
+                    if (isAccent) {
+                        Color.Transparent
+                    } else if (isDark) {
+                        VisioColors.PrimaryDark100
+                    } else {
+                        VisioColors.LightSurfaceVariant
+                    },
+            ),
     ) {
         Row(
-            modifier = Modifier
-                .then(
-                    if (isAccent) Modifier.background(accentGradient, RoundedCornerShape(10.dp)) else Modifier
-                )
-                .fillMaxWidth()
-                .padding(12.dp),
+            modifier =
+                Modifier
+                    .then(
+                        if (isAccent) Modifier.background(accentGradient, RoundedCornerShape(10.dp)) else Modifier,
+                    )
+                    .fillMaxWidth()
+                    .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(modifier = Modifier.weight(1f)) {
@@ -308,21 +318,42 @@ private fun MeetingCard(
                         text = meeting.summary,
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.Bold,
-                        color = if (isAccent) VisioColors.White else if (isDark) VisioColors.White else VisioColors.LightOnBackground,
+                        color =
+                            if (isAccent) {
+                                VisioColors.White
+                            } else if (isDark) {
+                                VisioColors.White
+                            } else {
+                                VisioColors.LightOnBackground
+                            },
                     )
                 }
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = formatMeetingTime(meeting, now, lang),
                     style = MaterialTheme.typography.bodySmall,
-                    color = if (isAccent) VisioColors.White.copy(alpha = 0.8f) else if (isDark) VisioColors.Greyscale400 else VisioColors.LightTextSecondary,
+                    color =
+                        if (isAccent) {
+                            VisioColors.White.copy(alpha = 0.8f)
+                        } else if (isDark) {
+                            VisioColors.Greyscale400
+                        } else {
+                            VisioColors.LightTextSecondary
+                        },
                 )
                 if (meeting.serverName.isNotBlank()) {
                     Spacer(modifier = Modifier.height(2.dp))
                     Text(
                         text = meeting.serverName,
                         style = MaterialTheme.typography.bodySmall,
-                        color = if (isAccent) VisioColors.White.copy(alpha = 0.8f) else if (isDark) VisioColors.Greyscale400 else VisioColors.LightTextSecondary,
+                        color =
+                            if (isAccent) {
+                                VisioColors.White.copy(alpha = 0.8f)
+                            } else if (isDark) {
+                                VisioColors.Greyscale400
+                            } else {
+                                VisioColors.LightTextSecondary
+                            },
                     )
                 }
             }
@@ -330,13 +361,15 @@ private fun MeetingCard(
             OutlinedButton(
                 onClick = onJoin,
                 shape = RoundedCornerShape(8.dp),
-                colors = ButtonDefaults.outlinedButtonColors(
-                    contentColor = if (isAccent) VisioColors.White else VisioColors.Primary500,
-                ),
-                border = androidx.compose.foundation.BorderStroke(
-                    1.5.dp,
-                    if (isAccent) VisioColors.White else VisioColors.Primary500,
-                ),
+                colors =
+                    ButtonDefaults.outlinedButtonColors(
+                        contentColor = if (isAccent) VisioColors.White else VisioColors.Primary500,
+                    ),
+                border =
+                    androidx.compose.foundation.BorderStroke(
+                        1.5.dp,
+                        if (isAccent) VisioColors.White else VisioColors.Primary500,
+                    ),
             ) {
                 Text(
                     if (lang == "fr") "Rejoindre" else "Join",

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -554,8 +554,14 @@ function MeetingsTab({
   const handleRefresh = async () => {
     setStatus('loading')
     setLoadingMessage('Téléchargement du calendrier...')
-    const t2 = setTimeout(() => setLoadingMessage('Analyse des événements...'), 2000)
-    const t5 = setTimeout(() => setLoadingMessage('Mise à jour... (fichier volumineux)'), 5000)
+    const t2 = setTimeout(
+      () => setLoadingMessage('Analyse des événements...'),
+      2000
+    )
+    const t5 = setTimeout(
+      () => setLoadingMessage('Mise à jour... (fichier volumineux)'),
+      5000
+    )
     try {
       await invoke('refresh_calendar_now')
       clearTimeout(t2)
@@ -614,25 +620,42 @@ function MeetingsTab({
     if (minutesUntil < 240) {
       const hours = Math.floor(minutesUntil / 60)
       const mins = minutesUntil % 60
-      return mins > 0 ? `Dans ${hours}h${mins.toString().padStart(2, '0')}` : `Dans ${hours}h`
+      return mins > 0
+        ? `Dans ${hours}h${mins.toString().padStart(2, '0')}`
+        : `Dans ${hours}h`
     }
     if (isToday) {
-      return start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+      return start.toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      })
     }
-    return start.toLocaleDateString([], { weekday: 'short' }) +
+    return (
+      start.toLocaleDateString([], { weekday: 'short' }) +
       ' ' +
       start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    )
   }
 
   const getDayLabel = (ts: number): string => {
     const date = new Date(ts * 1000)
     const now = new Date()
     const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-    const meetDay = new Date(date.getFullYear(), date.getMonth(), date.getDate())
-    const diffDays = Math.round((meetDay.getTime() - today.getTime()) / 86400000)
+    const meetDay = new Date(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate()
+    )
+    const diffDays = Math.round(
+      (meetDay.getTime() - today.getTime()) / 86400000
+    )
     if (diffDays === 0) return t('meetings.today')
     if (diffDays === 1) return t('meetings.tomorrow')
-    return date.toLocaleDateString([], { weekday: 'long', day: 'numeric', month: 'long' })
+    return date.toLocaleDateString([], {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+    })
   }
 
   const groupMeetingsByDay = (list: Meeting[]) => {
@@ -718,9 +741,7 @@ function MeetingsTab({
                     {imminent && <span className="meeting-imminent-dot" />}
                     {m.summary || t('meetings.noTitle')}
                   </span>
-                  <span className="meeting-time">
-                    {formatRelativeTime(m)}
-                  </span>
+                  <span className="meeting-time">{formatRelativeTime(m)}</span>
                   <span className="meeting-server">{m.server_name}</span>
                 </div>
                 <button
@@ -949,7 +970,9 @@ function HomeView({
             onClick={() => setActiveTab('meetings')}
           >
             {t('home.tab.meetings')}
-            {meetingCount > 0 && <span className="tab-badge">{meetingCount}</span>}
+            {meetingCount > 0 && (
+              <span className="tab-badge">{meetingCount}</span>
+            )}
           </button>
         </div>
         <button
@@ -961,164 +984,238 @@ function HomeView({
         </button>
       </div>
       <div className="home-tab-content">
-      {activeTab === 'meetings' ? (
-        <MeetingsTab onJoin={onJoin} displayName={displayName} onMeetingCountChange={setMeetingCount} />
-      ) : (
-        <div className="join-form">
-          <img src="/logo.png?v=2" alt="Visio Mobile" className="home-logo" />
-          <h2>{t('app.title')}</h2>
-          <p>{t('home.subtitle')}</p>
-          {isAuthenticated ? (
-            <div className="auth-card">
-              <div className="auth-avatar">
-                {(() => {
-                  const parts = displayNameFromOidc
-                    .split(' ')
-                    .filter(Boolean)
-                    .slice(0, 2)
-                  const initials = parts
-                    .map((p) => p[0]?.toUpperCase())
-                    .join('')
-                  return initials || emailFromOidc?.[0]?.toUpperCase() || '?'
-                })()}
+        {activeTab === 'meetings' ? (
+          <MeetingsTab
+            onJoin={onJoin}
+            displayName={displayName}
+            onMeetingCountChange={setMeetingCount}
+          />
+        ) : (
+          <div className="join-form">
+            <img src="/logo.png?v=2" alt="Visio Mobile" className="home-logo" />
+            <h2>{t('app.title')}</h2>
+            <p>{t('home.subtitle')}</p>
+            {isAuthenticated ? (
+              <div className="auth-card">
+                <div className="auth-avatar">
+                  {(() => {
+                    const parts = displayNameFromOidc
+                      .split(' ')
+                      .filter(Boolean)
+                      .slice(0, 2)
+                    const initials = parts
+                      .map((p) => p[0]?.toUpperCase())
+                      .join('')
+                    return initials || emailFromOidc?.[0]?.toUpperCase() || '?'
+                  })()}
+                </div>
+                <div className="auth-info">
+                  <span className="auth-name">
+                    {displayNameFromOidc || emailFromOidc}
+                  </span>
+                  {emailFromOidc && displayNameFromOidc && (
+                    <span className="auth-email">{emailFromOidc}</span>
+                  )}
+                </div>
+                <button
+                  className="auth-logout"
+                  onClick={onLogout}
+                  title={t('home.logout')}
+                >
+                  <RiLogoutBoxRLine size={20} />
+                </button>
               </div>
-              <div className="auth-info">
-                <span className="auth-name">
-                  {displayNameFromOidc || emailFromOidc}
-                </span>
-                {emailFromOidc && displayNameFromOidc && (
-                  <span className="auth-email">{emailFromOidc}</span>
-                )}
-              </div>
-              <button
-                className="auth-logout"
-                onClick={onLogout}
-                title={t('home.logout')}
-              >
-                <RiLogoutBoxRLine size={20} />
-              </button>
-            </div>
-          ) : (
-            <div className="auth-status">
-              <button
-                className="btn btn-primary"
-                data-testid="home-connect-button"
-                onClick={() => {
-                  if (meetInstances.length <= 1) {
-                    if (meetInstances.length > 0) onLaunchOidc(meetInstances[0])
-                  } else {
-                    setCustomServer('')
-                    setShowServerPicker(true)
-                  }
-                }}
-              >
-                <RiAccountCircleLine size={18} /> {t('home.connect')}
-              </button>
-              {showServerPicker && (
-                <div
-                  className="server-picker-overlay"
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => setShowServerPicker(false)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ')
-                      setShowServerPicker(false)
+            ) : (
+              <div className="auth-status">
+                <button
+                  className="btn btn-primary"
+                  data-testid="home-connect-button"
+                  onClick={() => {
+                    if (meetInstances.length <= 1) {
+                      if (meetInstances.length > 0)
+                        onLaunchOidc(meetInstances[0])
+                    } else {
+                      setCustomServer('')
+                      setShowServerPicker(true)
+                    }
                   }}
                 >
+                  <RiAccountCircleLine size={18} /> {t('home.connect')}
+                </button>
+                {showServerPicker && (
                   <div
-                    className="server-picker"
+                    className="server-picker-overlay"
                     role="button"
                     tabIndex={0}
-                    onClick={(e) => e.stopPropagation()}
+                    onClick={() => setShowServerPicker(false)}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter' || e.key === ' ')
-                        e.stopPropagation()
+                        setShowServerPicker(false)
                     }}
                   >
-                    <h3>{t('home.serverPicker.title')}</h3>
-                    <div className="server-list">
-                      {meetInstances.map((instance) => (
+                    <div
+                      className="server-picker"
+                      role="button"
+                      tabIndex={0}
+                      onClick={(e) => e.stopPropagation()}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ')
+                          e.stopPropagation()
+                      }}
+                    >
+                      <h3>{t('home.serverPicker.title')}</h3>
+                      <div className="server-list">
+                        {meetInstances.map((instance) => (
+                          <button
+                            key={instance}
+                            className="server-item"
+                            onClick={() => {
+                              setShowServerPicker(false)
+                              onLaunchOidc(instance)
+                            }}
+                          >
+                            {instance}
+                          </button>
+                        ))}
+                      </div>
+                      <div className="server-custom">
+                        <input
+                          type="text"
+                          placeholder="meet.example.com"
+                          value={customServer}
+                          onChange={(e) => setCustomServer(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' && customServer.trim()) {
+                              setShowServerPicker(false)
+                              onLaunchOidc(customServer.trim())
+                            }
+                          }}
+                        />
                         <button
-                          key={instance}
-                          className="server-item"
+                          className="btn btn-secondary"
+                          disabled={!customServer.trim()}
                           onClick={() => {
-                            setShowServerPicker(false)
-                            onLaunchOidc(instance)
+                            if (customServer.trim()) {
+                              setShowServerPicker(false)
+                              onLaunchOidc(customServer.trim())
+                            }
                           }}
                         >
-                          {instance}
+                          {t('home.connect')}
                         </button>
-                      ))}
-                    </div>
-                    <div className="server-custom">
-                      <input
-                        type="text"
-                        placeholder="meet.example.com"
-                        value={customServer}
-                        onChange={(e) => setCustomServer(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' && customServer.trim()) {
-                            setShowServerPicker(false)
-                            onLaunchOidc(customServer.trim())
-                          }
-                        }}
-                      />
+                      </div>
                       <button
-                        className="btn btn-secondary"
-                        disabled={!customServer.trim()}
-                        onClick={() => {
-                          if (customServer.trim()) {
-                            setShowServerPicker(false)
-                            onLaunchOidc(customServer.trim())
-                          }
-                        }}
+                        className="btn btn-cancel"
+                        onClick={() => setShowServerPicker(false)}
                       >
-                        {t('home.connect')}
+                        {t('home.serverPicker.cancel')}
                       </button>
                     </div>
-                    <button
-                      className="btn btn-cancel"
-                      onClick={() => setShowServerPicker(false)}
-                    >
-                      {t('home.serverPicker.cancel')}
-                    </button>
                   </div>
+                )}
+              </div>
+            )}
+            <div className="form-group">
+              <label htmlFor="meetUrl">{t('home.meetUrl')}</label>
+              <input
+                id="meetUrl"
+                type="text"
+                placeholder="abc-defg-hij"
+                autoComplete="off"
+                data-testid="home-room-url-input"
+                value={meetUrl}
+                onChange={(e) => setMeetUrl(e.target.value)}
+                onKeyDown={handleKeyDown}
+              />
+              {roomStatus === 'checking' && (
+                <div
+                  className="room-status checking"
+                  data-testid="home-room-status"
+                >
+                  {t('home.room.checking')}
+                </div>
+              )}
+              {roomStatus === 'valid' && (
+                <div
+                  className="room-status valid"
+                  data-testid="home-room-status"
+                >
+                  {t('home.room.valid')}
+                </div>
+              )}
+              {roomStatus === 'not_found' && (
+                <div
+                  className="room-status not-found"
+                  data-testid="home-room-status"
+                >
+                  {t('home.room.notFound')}
+                </div>
+              )}
+              {roomStatus === 'auth_required' && (
+                <div
+                  className="room-status auth-required"
+                  data-testid="home-room-status"
+                >
+                  {t('home.room.authRequired')}
+                </div>
+              )}
+              {roomStatus === 'authenticating' && (
+                <div
+                  className="room-status checking"
+                  data-testid="home-room-status"
+                >
+                  {t('home.room.authenticating')}
+                </div>
+              )}
+              {roomStatus === 'error' && (
+                <div
+                  className="room-status error"
+                  data-testid="home-room-status"
+                >
+                  {t('home.room.error')}
                 </div>
               )}
             </div>
-          )}
-          <div className="form-group">
-            <label htmlFor="meetUrl">{t('home.meetUrl')}</label>
-            <input
-              id="meetUrl"
-              type="text"
-              placeholder="abc-defg-hij"
-              autoComplete="off"
-              data-testid="home-room-url-input"
-              value={meetUrl}
-              onChange={(e) => setMeetUrl(e.target.value)}
-              onKeyDown={handleKeyDown}
-            />
-            {roomStatus === 'checking' && (
-              <div
-                className="room-status checking"
-                data-testid="home-room-status"
+            <div className="form-group">
+              <label htmlFor="username">{t('home.displayName')}</label>
+              <input
+                id="username"
+                type="text"
+                placeholder={t('home.displayName.placeholder')}
+                autoComplete="off"
+                data-testid="home-display-name-input"
+                value={displayName}
+                onChange={(e) => onDisplayNameChange(e.target.value)}
+                onKeyDown={handleKeyDown}
+              />
+            </div>
+            {roomStatus === 'auth_required' ? (
+              <button className="btn btn-primary" onClick={handleAuth}>
+                {t('home.signIn')}
+              </button>
+            ) : (
+              <button
+                className="btn btn-primary"
+                disabled={joining || roomStatus !== 'valid'}
+                onClick={handleJoin}
+                data-testid="home-join-button"
               >
-                {t('home.room.checking')}
-              </div>
+                {joining ? t('home.connecting') : t('home.join')}
+              </button>
             )}
-            {roomStatus === 'valid' && (
-              <div className="room-status valid" data-testid="home-room-status">
-                {t('home.room.valid')}
-              </div>
-            )}
-            {roomStatus === 'not_found' && (
-              <div
-                className="room-status not-found"
-                data-testid="home-room-status"
+            {isAuthenticated && authenticatedMeetInstance && (
+              <button
+                className="btn btn-primary"
+                style={{
+                  marginTop: '8px',
+                  background: 'var(--bg-tertiary)',
+                  color: 'var(--text)',
+                }}
+                onClick={() => setShowCreateRoom(true)}
+                data-testid="home-create-room-button"
               >
-                {t('home.room.notFound')}
-              </div>
+                {t('home.createRoom')}
+              </button>
             )}
             {roomStatus === 'auth_required' && (
               <div
@@ -1141,126 +1238,63 @@ function HomeView({
                 {t('home.room.error')}
               </div>
             )}
-          </div>
-          <div className="form-group">
-            <label htmlFor="username">{t('home.displayName')}</label>
-            <input
-              id="username"
-              type="text"
-              placeholder={t('home.displayName.placeholder')}
-              autoComplete="off"
-              data-testid="home-display-name-input"
-              value={displayName}
-              onChange={(e) => onDisplayNameChange(e.target.value)}
-              onKeyDown={handleKeyDown}
-            />
-          </div>
-          {roomStatus === 'auth_required' ? (
-            <button className="btn btn-primary" onClick={handleAuth}>
-              {t('home.signIn')}
-            </button>
-          ) : (
-            <button
-              className="btn btn-primary"
-              disabled={joining || roomStatus !== 'valid'}
-              onClick={handleJoin}
-              data-testid="home-join-button"
-            >
-              {joining ? t('home.connecting') : t('home.join')}
-            </button>
-          )}
-          {isAuthenticated && authenticatedMeetInstance && (
-            <button
-              className="btn btn-primary"
-              style={{
-                marginTop: '8px',
-                background: 'var(--bg-tertiary)',
-                color: 'var(--text)',
-              }}
-              onClick={() => setShowCreateRoom(true)}
-              data-testid="home-create-room-button"
-            >
-              {t('home.createRoom')}
-            </button>
-          )}
-          {roomStatus === 'auth_required' && (
-            <div
-              className="room-status auth-required"
-              data-testid="home-room-status"
-            >
-              {t('home.room.authRequired')}
-            </div>
-          )}
-          {roomStatus === 'authenticating' && (
-            <div
-              className="room-status checking"
-              data-testid="home-room-status"
-            >
-              {t('home.room.authenticating')}
-            </div>
-          )}
-          {roomStatus === 'error' && (
-            <div className="room-status error" data-testid="home-room-status">
-              {t('home.room.error')}
-            </div>
-          )}
-          <div className="error-msg">{error}</div>
-          {roomHistory.length > 0 && (
-            <div className="room-history">
-              <h4>{t('home.recentRooms')}</h4>
-              {roomHistory.map((url, i) => {
-                const slug = url.includes('/') ? url.split('/').pop() : url
-                let host = ''
-                try {
-                  host = new URL(url).host
-                } catch {}
-                return (
-                  <button
-                    key={i}
-                    className="room-history-item"
-                    disabled={joining}
-                    onClick={async () => {
-                      setMeetUrl(url)
-                      setError('')
-                      setJoining(true)
-                      try {
-                        const uname = displayName.trim() || null
-                        const result = await invoke<{ status: string }>(
-                          'validate_room',
-                          { url, username: uname }
-                        )
-                        if (result.status === 'valid') {
-                          await invoke('set_display_name', { name: uname })
-                          onJoin(url, uname)
-                        } else {
-                          // Validation failed — fall back to filling the URL field so the user can see the status
+            <div className="error-msg">{error}</div>
+            {roomHistory.length > 0 && (
+              <div className="room-history">
+                <h4>{t('home.recentRooms')}</h4>
+                {roomHistory.map((url, i) => {
+                  const slug = url.includes('/') ? url.split('/').pop() : url
+                  let host = ''
+                  try {
+                    host = new URL(url).host
+                  } catch {}
+                  return (
+                    <button
+                      key={i}
+                      className="room-history-item"
+                      disabled={joining}
+                      onClick={async () => {
+                        setMeetUrl(url)
+                        setError('')
+                        setJoining(true)
+                        try {
+                          const uname = displayName.trim() || null
+                          const result = await invoke<{ status: string }>(
+                            'validate_room',
+                            { url, username: uname }
+                          )
+                          if (result.status === 'valid') {
+                            await invoke('set_display_name', { name: uname })
+                            onJoin(url, uname)
+                          } else {
+                            // Validation failed — fall back to filling the URL field so the user can see the status
+                            setJoining(false)
+                          }
+                        } catch (e) {
+                          setError(String(e))
                           setJoining(false)
                         }
-                      } catch (e) {
-                        setError(String(e))
-                        setJoining(false)
-                      }
-                    }}
-                    data-testid={`home_room_history_item_${i}`}
-                  >
-                    {joining && meetUrl === url ? (
-                      <span className="room-history-spinner" />
-                    ) : (
-                      <RiGlobalLine size={16} />
-                    )}
-                    <div className="room-history-info">
-                      <span className="room-history-slug">{slug}</span>
-                      {host && (
-                        <span className="room-history-host">{host}</span>
+                      }}
+                      data-testid={`home_room_history_item_${i}`}
+                    >
+                      {joining && meetUrl === url ? (
+                        <span className="room-history-spinner" />
+                      ) : (
+                        <RiGlobalLine size={16} />
                       )}
-                    </div>
-                  </button>
-                )
-              })}
-            </div>
-          )}
-        </div>
-      )}
+                      <div className="room-history-info">
+                        <span className="room-history-slug">{slug}</span>
+                        {host && (
+                          <span className="room-history-host">{host}</span>
+                        )}
+                      </div>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )}
       </div>
       {showCreateRoom && authenticatedMeetInstance && (
         <CreateRoomDialog
@@ -3522,13 +3556,80 @@ function SettingsModal({
 }
 
 // ---------------------------------------------------------------------------
+// Shared hook: audio device fallback on Bluetooth connect/disconnect
+// ---------------------------------------------------------------------------
+
+/**
+ * Subscribes to the `audio-devices-changed` Tauri event and:
+ *  1. Re-enumerates input/output audio devices.
+ *  2. Falls back to the default device if the currently selected one disappears.
+ *
+ * @param setInputs   - Setter for the input device list state.
+ * @param setOutputs  - Setter for the output device list state.
+ * @param setSelected - Setters for the currently selected device names.
+ * @param onInputFallback - Optional callback invoked after an input fallback
+ *                          (e.g. to restart a mic preview).
+ */
+function useAudioDeviceFallback({
+  setInputs,
+  setOutputs,
+  setSelectedInput,
+  setSelectedOutput,
+  onInputFallback,
+}: {
+  setInputs: (devices: NativeAudioDevice[]) => void
+  setOutputs: (devices: NativeAudioDevice[]) => void
+  setSelectedInput: (updater: (prev: string) => string) => void
+  setSelectedOutput: (updater: (prev: string) => string) => void
+  onInputFallback?: () => void
+}) {
+  useEffect(() => {
+    let unlistenFn: (() => void) | null = null
+    listen('audio-devices-changed', async () => {
+      try {
+        const [inputs, outputs] = await Promise.all([
+          invoke<NativeAudioDevice[]>('list_audio_input_devices'),
+          invoke<NativeAudioDevice[]>('list_audio_output_devices'),
+        ])
+        setInputs(inputs)
+        setOutputs(outputs)
+
+        setSelectedInput((prev) => {
+          if (!prev || inputs.some((d) => d.name === prev)) return prev
+          const def = inputs.find((d) => d.is_default)
+          const fallback = def ? def.name : (inputs[0]?.name ?? '')
+          invoke('select_audio_input', { deviceName: fallback }).catch(() => {})
+          onInputFallback?.()
+          return fallback
+        })
+
+        setSelectedOutput((prev) => {
+          if (!prev || outputs.some((d) => d.name === prev)) return prev
+          const def = outputs.find((d) => d.is_default)
+          const fallback = def ? def.name : (outputs[0]?.name ?? '')
+          invoke('select_audio_output', { deviceName: fallback }).catch(
+            () => {}
+          )
+          return fallback
+        })
+      } catch (e) {
+        console.warn('Failed to re-enumerate audio devices after change:', e)
+      }
+    }).then((fn) => {
+      unlistenFn = fn
+    })
+    return () => {
+      unlistenFn?.()
+    }
+  }, [])
+}
+
+// ---------------------------------------------------------------------------
 // Pre-Join Screen
 // ---------------------------------------------------------------------------
 
-interface AudioDeviceInfo {
-  name: string
-  is_default: boolean
-}
+// AudioDeviceInfo is an alias for NativeAudioDevice (same shape, local name).
+type AudioDeviceInfo = NativeAudioDevice
 
 interface VideoDeviceInfo {
   name: string
@@ -3682,6 +3783,21 @@ function PreJoinScreen({
       }
     }
   }, [isMicOn, audioMode])
+
+  // ---- Effect: audio device changes (Bluetooth connect/disconnect) ---------
+  // Restart mic preview when the input falls back to a new device.
+  useAudioDeviceFallback({
+    setInputs: setInputDevices,
+    setOutputs: setOutputDevices,
+    setSelectedInput,
+    setSelectedOutput,
+    onInputFallback: () => {
+      invoke('stop_mic_preview')
+        .catch(() => {})
+        .then(() => invoke('start_mic_preview'))
+        .catch(() => {})
+    },
+  })
 
   // ---- Handlers -----------------------------------------------------------
   const handleSelectCamera = async (uniqueId: string) => {
@@ -4032,7 +4148,9 @@ function PreJoinScreen({
                 <div
                   className="prejoin-vu-bar"
                   data-testid="prejoin-vu-bar"
-                  style={{ width: `${Math.round(Math.min(micLevel * 25, 1) * 100)}%` }}
+                  style={{
+                    width: `${Math.round(Math.min(micLevel * 25, 1) * 100)}%`,
+                  }}
                 />
               </div>
 
@@ -4144,7 +4262,12 @@ function PreJoinScreen({
                   src={`/backgrounds/thumbnails/${n}.jpg`}
                   alt={`Background ${n}`}
                   draggable={false}
-                  style={{ width: '100%', height: '100%', objectFit: 'cover', borderRadius: 6 }}
+                  style={{
+                    width: '100%',
+                    height: '100%',
+                    objectFit: 'cover',
+                    borderRadius: 6,
+                  }}
                 />
                 <span>{n}</span>
               </button>
@@ -4441,6 +4564,17 @@ export default function App() {
 
   const viewRef = useRef(view)
   viewRef.current = view
+
+  // ---- Audio device change listener (in-call) -----------------------------
+  // Handles Bluetooth headset connect/disconnect during an active call.
+  // Re-enumerates devices and falls back to default if the selected device
+  // is no longer available.
+  useAudioDeviceFallback({
+    setInputs: setAudioInputs,
+    setOutputs: setAudioOutputs,
+    setSelectedInput: setSelectedAudioInput,
+    setSelectedOutput: setSelectedAudioOutput,
+  })
 
   // ---- Device enumeration -------------------------------------------------
   // WORKAROUND: Defer device enumeration to avoid USB blocking at startup.

--- a/crates/visio-desktop/src/lib.rs
+++ b/crates/visio-desktop/src/lib.rs
@@ -1521,6 +1521,12 @@ async fn start_mic_preview(state: tauri::State<'_, VisioState>) -> Result<(), St
         .unwrap_or_else(|e| e.into_inner())
         .clone();
     let mut engine = state.audio_engine.lock().unwrap_or_else(|e| e.into_inner());
+    engine.set_device_change_callback(Arc::new(|| {
+        tracing::info!("audio devices changed (lobby) — re-enumerating");
+        if let Some(app) = APP_HANDLE.get() {
+            let _ = app.emit("audio-devices-changed", ());
+        }
+    }));
     engine.start_preview_capture(device_name.as_deref())
 }
 

--- a/docs/superpowers/plans/2026-03-22-bluetooth-audio-fallback.md
+++ b/docs/superpowers/plans/2026-03-22-bluetooth-audio-fallback.md
@@ -1,0 +1,243 @@
+# Bluetooth Audio Device Fallback — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-fallback to the default audio device when a Bluetooth device disconnects, in both the pre-join lobby and active rooms.
+
+**Architecture:** The macOS backend already emits `audio-devices-changed` Tauri events on device add/remove (via CoreAudio HAL listener). The frontend needs to listen for this event, re-enumerate devices, and if the selected device is gone, switch to the default. For the pre-join lobby, also register the device change callback since it's currently only set during `connect()`.
+
+**Tech Stack:** Rust (cpal, CoreAudio HAL), React (Tauri events), Kotlin (AudioDeviceCallback), Swift (AVAudioSession)
+
+**Issue:** [#83](https://github.com/mmaudet/visio-mobile/issues/83)
+
+---
+
+## File Structure
+
+### Modified Files
+- `crates/visio-desktop/src/lib.rs` — register device change callback in `start_mic_preview` (lobby)
+- `crates/visio-desktop/frontend/src/App.tsx` — listen to `audio-devices-changed`, re-enumerate, fallback to default
+- `android/app/src/main/kotlin/io/visio/mobile/VisioManager.kt` — register AudioDeviceCallback for fallback
+- `ios/VisioMobile/VisioManager.swift` — handle routeChangeNotification for fallback
+
+---
+
+## Task 1: Desktop — Register device change callback in pre-join lobby
+
+**Files:**
+- Modify: `crates/visio-desktop/src/lib.rs:1517-1524` (start_mic_preview command)
+
+Currently, the `set_device_change_callback` is only called during `connect()` (line 473) and `connect_with_token()` (line 505). The pre-join lobby uses `start_mic_preview()` but never registers the callback, so device changes during lobby are invisible.
+
+- [ ] **Step 1: Add device change callback registration in start_mic_preview**
+
+In `crates/visio-desktop/src/lib.rs`, find `start_mic_preview` (around line 1517) and add callback registration:
+
+```rust
+#[tauri::command]
+fn start_mic_preview(state: tauri::State<'_, VisioState>) -> Result<(), String> {
+    let mut engine = state.audio_engine.lock().unwrap_or_else(|e| e.into_inner());
+    let device = state.selected_input_device.lock().unwrap().clone();
+    // Register device change callback so frontend is notified during lobby
+    engine.set_device_change_callback(Arc::new(|| {
+        tracing::info!("audio devices changed (lobby) — re-enumerating");
+        if let Some(app) = APP_HANDLE.get() {
+            let _ = app.emit("audio-devices-changed", ());
+        }
+    }));
+    engine.start_preview_capture(device.as_deref())
+        .map_err(|e| e.to_string())
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `cargo build -p visio-desktop`
+Expected: compiles
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/visio-desktop/src/lib.rs
+git commit -m "fix(desktop): register device change callback in pre-join lobby"
+```
+
+---
+
+## Task 2: Desktop — Frontend listens to device changes and auto-fallback
+
+**Files:**
+- Modify: `crates/visio-desktop/frontend/src/App.tsx` (PreJoinScreen component, around line 3596)
+
+The backend emits `audio-devices-changed` but the PreJoinScreen never listens for it. When a Bluetooth device disconnects, the frontend needs to re-enumerate devices and switch to the default if the selected device is gone.
+
+- [ ] **Step 1: Add useEffect to listen for audio-devices-changed in PreJoinScreen**
+
+In the PreJoinScreen component (after the existing useEffect that loads device lists on mount), add:
+
+```tsx
+  // Listen for device changes (Bluetooth disconnect, etc.)
+  useEffect(() => {
+    let unlisten: (() => void) | null = null
+    listen('audio-devices-changed', async () => {
+      try {
+        const [inputs, outputs] = await Promise.all([
+          invoke<AudioDeviceInfo[]>('list_audio_input_devices'),
+          invoke<AudioDeviceInfo[]>('list_audio_output_devices'),
+        ])
+        setInputDevices(inputs)
+        setOutputDevices(outputs)
+
+        // If selected input device is no longer available, fallback to default
+        if (selectedInput && !inputs.find((d) => d.name === selectedInput)) {
+          const defaultInput = inputs.find((d) => d.is_default)
+          if (defaultInput) {
+            setSelectedInput(defaultInput.name)
+            await invoke('select_audio_input', { deviceName: defaultInput.name })
+            // Restart mic preview with new device
+            if (isMicOn) {
+              await invoke('stop_mic_preview')
+              await invoke('start_mic_preview')
+            }
+          }
+        }
+
+        // If selected output device is no longer available, fallback to default
+        if (selectedOutput && !outputs.find((d) => d.name === selectedOutput)) {
+          const defaultOutput = outputs.find((d) => d.is_default)
+          if (defaultOutput) {
+            setSelectedOutput(defaultOutput.name)
+            await invoke('select_audio_output', { deviceName: defaultOutput.name })
+          }
+        }
+      } catch (e) {
+        console.warn('Failed to re-enumerate audio devices:', e)
+      }
+    }).then((fn) => {
+      unlisten = fn
+    })
+    return () => {
+      if (unlisten) unlisten()
+    }
+  }, [selectedInput, selectedOutput, isMicOn])
+```
+
+- [ ] **Step 2: Also add the same listener in the call view (App component)**
+
+Find the main App component's call view section. Add a similar listener for `audio-devices-changed` that re-enumerates and falls back during active calls. Look for where `audio-devices-changed` might already be referenced in the in-call settings, and if not, add a top-level listener in App that handles fallback during calls.
+
+- [ ] **Step 3: Verify build**
+
+The frontend auto-rebuilds via Vite. Check the browser console for TypeScript errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/visio-desktop/frontend/src/App.tsx
+git commit -m "fix(desktop): auto-fallback to default device on Bluetooth disconnect"
+```
+
+---
+
+## Task 3: Android — Register AudioDeviceCallback for fallback
+
+**Files:**
+- Modify: `android/app/src/main/kotlin/io/visio/mobile/VisioManager.kt`
+
+Android already has `AudioDeviceCallback` in `ContextDetector.kt` for adaptive mode, but `VisioManager` doesn't react to device removal by falling back. Add a callback that detects when the active Bluetooth device disappears and switches to the default.
+
+- [ ] **Step 1: Add AudioDeviceCallback in VisioManager**
+
+In `VisioManager.kt`, add a device callback that triggers on device removal:
+
+```kotlin
+private val audioDeviceCallback = object : AudioDeviceCallback() {
+    override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>?) {
+        // If a Bluetooth device was removed, restart audio with default device
+        val hadBluetooth = removedDevices?.any {
+            it.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO ||
+            it.type == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP ||
+            it.type == AudioDeviceInfo.TYPE_BLE_HEADSET
+        } == true
+        if (hadBluetooth) {
+            tracing.info("Bluetooth device removed — falling back to default")
+            audioCapture?.setPreferredDevice(null) // null = system default
+            audioPlayout?.setPreferredDevice(null)
+        }
+    }
+}
+```
+
+Register it in `initialize()`:
+
+```kotlin
+val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+audioManager.registerAudioDeviceCallback(audioDeviceCallback, null)
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd android && ./gradlew compileDebugKotlin`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add android/app/src/main/kotlin/io/visio/mobile/VisioManager.kt
+git commit -m "fix(android): auto-fallback to default audio on Bluetooth disconnect"
+```
+
+---
+
+## Task 4: iOS — Handle route change for fallback
+
+**Files:**
+- Modify: `ios/VisioMobile/VisioManager.swift`
+
+iOS already observes `routeChangeNotification` in `ContextDetector.swift` for adaptive mode. Add handling in `VisioManager` to detect when a Bluetooth route becomes unavailable and reset to the built-in device.
+
+- [ ] **Step 1: Add route change observer in VisioManager**
+
+In `VisioManager.swift`, add in the initializer or `connect()` method:
+
+```swift
+NotificationCenter.default.addObserver(
+    forName: AVAudioSession.routeChangeNotification,
+    object: nil,
+    queue: .main
+) { [weak self] notification in
+    guard let reason = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt,
+          reason == AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue else {
+        return
+    }
+    // Bluetooth device disconnected — iOS automatically routes to built-in
+    // but we should log and update any UI state
+    print("Audio route changed: old device unavailable, falling back to default")
+}
+```
+
+Note: iOS automatically falls back to the built-in speaker when Bluetooth disconnects. The main concern is ensuring the UI reflects this change. If there's a device selector UI, it should update.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add ios/VisioMobile/VisioManager.swift
+git commit -m "fix(ios): log audio route change on Bluetooth disconnect"
+```
+
+---
+
+## Task 5: Test and verify
+
+- [ ] **Step 1: Desktop test**
+
+1. Connect Bluetooth headset
+2. Open pre-join lobby → verify Bluetooth shown as selected device
+3. Disconnect Bluetooth → verify dropdown switches to default built-in device
+4. Verify VU meter continues working with the new device
+
+- [ ] **Step 2: Build all platforms**
+
+```bash
+cargo build -p visio-desktop
+cd android && ./gradlew assembleDebug
+```

--- a/ios/VisioMobile/VisioManager.swift
+++ b/ios/VisioMobile/VisioManager.swift
@@ -119,6 +119,21 @@ class VisioManager: ObservableObject {
         } else {
             NSLog("VisioManager: selfie_segmentation.onnx not found in bundle")
         }
+
+        // Observe Bluetooth audio device disconnection so we can log the
+        // iOS automatic fallback to built-in speaker.
+        NotificationCenter.default.addObserver(
+            forName: AVAudioSession.routeChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let reason = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt,
+                  reason == AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue else {
+                return
+            }
+            _ = self  // capture self to silence unused-capture warning
+            print("Audio route changed: Bluetooth device disconnected, iOS auto-fallback to built-in")
+        }
     }
 
     // MARK: - Public API


### PR DESCRIPTION
## Summary

Fixes #83 — When a Bluetooth audio device disconnects, the app now automatically falls back to the default system audio device.

### Desktop (Tauri)
- Register device change callback in pre-join lobby (was only registered during `connect()`)
- Frontend listens to `audio-devices-changed` events, re-enumerates devices, and auto-selects default if selected device disappeared
- Works in both lobby and active call

### Android
- Register `AudioDeviceCallback` in `VisioManager` to detect Bluetooth removal
- On disconnect, reset `AudioCapture` and `AudioPlayout` to system default via `restoreDefaultAudioRoute()`

### iOS
- Observe `AVAudioSession.routeChangeNotification` for `oldDeviceUnavailable`
- iOS handles fallback automatically; observer logs the event for debugging

## Test plan

- [ ] Desktop: connect Bluetooth → enter lobby → disconnect Bluetooth → verify device dropdown switches to built-in
- [ ] Desktop: connect Bluetooth → join room → disconnect Bluetooth → verify audio continues on built-in
- [ ] Android: same test flow
- [ ] iOS: same test flow