### PR TITLE
fix(desktop): resolve 12 SonarCloud reliability issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Fixed
 
+- Fix 12 SonarCloud reliability issues in desktop frontend (#92)
 - Auto-fallback to default audio device when Bluetooth disconnects (#83)
 - Migrate all hardcoded UI strings to i18n system (Android, iOS, Desktop) (#89)
 - Fix adaptive mode defaulting to enabled on Desktop (#89)

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -327,7 +327,9 @@ function getInitials(name: string | null | undefined): string {
 }
 
 function getHue(name: string | null | undefined): number {
-  return [...(name || '')].reduce((h, c) => h + c.charCodeAt(0), 0) % 360
+  return (
+    [...(name || '')].reduce((h, c) => h + (c.codePointAt(0) ?? 0), 0) % 360
+  )
 }
 
 function formatTime(timestampMs: number): string {
@@ -1452,10 +1454,11 @@ function CreateRoomDialog({
                 <div className="access-level-options">
                   <label
                     className={`access-option ${accessLevel === 'public' ? 'selected' : ''}`}
-                    onClick={() => setAccessLevel('public')}
+                    htmlFor="access-public"
                   >
                     <input
                       type="radio"
+                      id="access-public"
                       name="accessLevel"
                       value="public"
                       checked={accessLevel === 'public'}
@@ -1477,10 +1480,11 @@ function CreateRoomDialog({
                   </label>
                   <label
                     className={`access-option ${accessLevel === 'trusted' ? 'selected' : ''}`}
-                    onClick={() => setAccessLevel('trusted')}
+                    htmlFor="access-trusted"
                   >
                     <input
                       type="radio"
+                      id="access-trusted"
                       name="accessLevel"
                       value="trusted"
                       checked={accessLevel === 'trusted'}
@@ -1502,10 +1506,11 @@ function CreateRoomDialog({
                   </label>
                   <label
                     className={`access-option ${accessLevel === 'restricted' ? 'selected' : ''}`}
-                    onClick={() => setAccessLevel('restricted')}
+                    htmlFor="access-restricted"
                   >
                     <input
                       type="radio"
+                      id="access-restricted"
                       name="accessLevel"
                       value="restricted"
                       checked={accessLevel === 'restricted'}
@@ -2358,7 +2363,7 @@ function CallView({
   const handleBgMode = async (mode: string) => {
     try {
       if (mode.startsWith('image:')) {
-        const id = parseInt(mode.slice(6), 10)
+        const id = Number.parseInt(mode.slice(6), 10)
         const path = await resolveResource(`backgrounds/${id}.jpg`)
         await invoke('load_background_image', { id, jpegPath: path })
       }
@@ -3871,7 +3876,7 @@ function PreJoinScreen({
     setBackgroundMode(mode)
     try {
       if (mode.startsWith('image:')) {
-        const id = parseInt(mode.slice(6), 10)
+        const id = Number.parseInt(mode.slice(6), 10)
         const path = await resolveResource(`backgrounds/${id}.jpg`)
         await invoke('load_background_image', { id, jpegPath: path })
       }


### PR DESCRIPTION
## Summary
- Replace `onClick` on `<label>` elements with proper `htmlFor`/`id` binding on radio inputs — fixes accessibility issues at lines 1445, 1470, 1495 (S1082, S6847, S6853)
- Use `String#codePointAt()` instead of `charCodeAt()` at line 330 (S7758)
- Use `Number.parseInt()` instead of global `parseInt()` at lines 2351, 3864 (S7773)

## Test plan
- [ ] Desktop: verify room creation dialog radio buttons (public/trusted/restricted) still work correctly with keyboard and mouse
- [ ] SonarCloud: verify 12 reliability issues are resolved after merge

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)