### PR TITLE
fix: lobby bypass, background filters and camera preview (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 
 ### Fixed
 
+- Fix lobby bypass, background filters and camera in call (#106)
 - Fix 12 SonarCloud reliability issues in desktop frontend (#92)
 - Lobby camera/mic/Bluetooth settings now applied when joining room (#98)
 - Auto-fallback to default audio device when Bluetooth disconnects (#83)

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
@@ -689,8 +689,11 @@ fun CallScreen(
                     } catch (_: Exception) {
                         null
                     }
-                micEnabled = s?.micEnabledOnJoin ?: VisioManager.client.isMicrophoneEnabled()
-                cameraEnabled = s?.cameraEnabledOnJoin ?: VisioManager.client.isCameraEnabled()
+                // Apply mic/camera on join so Rust-side capture is started
+                applyMicOnJoin(context, s?.micEnabledOnJoin ?: false)
+                micEnabled = VisioManager.client.isMicrophoneEnabled()
+                applyCameraOnJoin(context, s?.cameraEnabledOnJoin ?: false)
+                cameraEnabled = VisioManager.client.isCameraEnabled()
                 return@withContext
             }
 

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/PreJoinScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/PreJoinScreen.kt
@@ -582,6 +582,7 @@ fun PreJoinScreen(
                 isFrontCamera = isFrontCamera,
                 isDark = isDark,
                 lang = lang,
+                backgroundMode = backgroundMode,
                 cameraPreviewRef = cameraPreviewRef,
                 onToggleCamera = { newEnabled ->
                     if (newEnabled) {
@@ -966,6 +967,7 @@ private fun PreJoinCameraSection(
     isFrontCamera: Boolean,
     isDark: Boolean,
     lang: String,
+    backgroundMode: String,
     cameraPreviewRef: androidx.compose.runtime.MutableState<LocalCameraPreview?>,
     onToggleCamera: (Boolean) -> Unit,
     onFlipCamera: () -> Unit,

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -4938,23 +4938,6 @@ export default function App() {
     setLobbyRoomUrl(meetUrl)
     setLobbyUsername(username ?? null)
     setView('lobby')
-
-    // Auto-enable mic/camera based on user settings
-    const s = settingsRef.current
-    if (s?.mic_enabled_on_join) {
-      setMicEnabled(true)
-      invoke('toggle_mic', { enabled: true }).catch((e) => {
-        console.error('auto mic enable failed:', e)
-        setMicEnabled(false)
-      })
-    }
-    if (s?.camera_enabled_on_join) {
-      setCamEnabled(true)
-      invoke('toggle_camera', { enabled: true }).catch((e) => {
-        console.error('auto camera enable failed:', e)
-        setCamEnabled(false)
-      })
-    }
   }
 
   const handleToggleMic = async () => {


### PR DESCRIPTION
## Summary

- **Desktop**: Remove premature `toggle_mic`/`toggle_camera` calls from `handleJoin` that fired before any room connection existed, causing errors and interfering with PreJoinScreen previews
- **Android**: Pass `backgroundMode` state to `PreJoinCameraSection` so filter changes trigger recomposition of the camera preview
- **Android**: Call `applyCameraOnJoin()`/`applyMicOnJoin()` when CallScreen mounts with an already-connected room (e.g. after PreJoinScreen), ensuring Rust-side capture is started and `cameraEnabled` state reflects reality

## Test plan

- [ ] Desktop: create a room, verify pre-lobby screen shows with camera/mic controls, click Join to enter call
- [ ] Android: open pre-lobby, toggle background filter (blur/image), verify preview updates
- [ ] Android: join a room from pre-lobby with camera enabled, verify camera is visible immediately without needing to toggle