### PR TITLE
fix: video freeze and orientation distortion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,10 @@ and this project adheres to
 - Convert desktop settings from modal to full-page view (#80)
 - Reduce all functions to cognitive complexity <=15 (#103)
 - Reduce cognitive complexity across all platforms (#94)
-- Address SonarCloud MAJOR and MINOR maintainability issues (#95, #96)
 
 ### Fixed
 
-- Fix lobby bypass, background filters and camera in call (#106)
+- Fix video freeze after surface destruction and orientation distortion (#100)
 - Fix 12 SonarCloud reliability issues in desktop frontend (#92)
 - Lobby camera/mic/Bluetooth settings now applied when joining room (#98)
 - Auto-fallback to default audio device when Bluetooth disconnects (#83)

--- a/android/app/src/main/kotlin/io/visio/mobile/CameraCapture.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/CameraCapture.kt
@@ -98,19 +98,20 @@ class CameraCapture(private val context: Context) {
                                 (sensorOrientation - displayDegrees + 360) % 360
                             }
 
-                        val frame =
-                            YuvFrame(
-                                y = yPlane.buffer, u = uPlane.buffer, v = vPlane.buffer,
-                                yStride = yPlane.rowStride, uStride = uPlane.rowStride,
-                                vStride = vPlane.rowStride,
-                                uPixelStride = uPlane.pixelStride,
-                                vPixelStride = vPlane.pixelStride,
-                                width = image.width, height = image.height,
-                            )
                         if (previewMode) {
-                            NativeVideo.nativeProcessPreviewFrame(frame, rotation)
+                            NativeVideo.nativeProcessPreviewFrame(
+                                yPlane.buffer, uPlane.buffer, vPlane.buffer,
+                                yPlane.rowStride, uPlane.rowStride, vPlane.rowStride,
+                                uPlane.pixelStride, vPlane.pixelStride,
+                                image.width, image.height, rotation,
+                            )
                         } else {
-                            NativeVideo.nativePushCameraFrame(frame, rotation)
+                            NativeVideo.nativePushCameraFrame(
+                                yPlane.buffer, uPlane.buffer, vPlane.buffer,
+                                yPlane.rowStride, uPlane.rowStride, vPlane.rowStride,
+                                uPlane.pixelStride, vPlane.pixelStride,
+                                image.width, image.height, rotation,
+                            )
                         }
                     } finally {
                         image.close()
@@ -220,19 +221,20 @@ class CameraCapture(private val context: Context) {
                             } else {
                                 (sensorOrientation - displayDegrees + 360) % 360
                             }
-                        val frame =
-                            YuvFrame(
-                                y = yPlane.buffer, u = uPlane.buffer, v = vPlane.buffer,
-                                yStride = yPlane.rowStride, uStride = uPlane.rowStride,
-                                vStride = vPlane.rowStride,
-                                uPixelStride = uPlane.pixelStride,
-                                vPixelStride = vPlane.pixelStride,
-                                width = image.width, height = image.height,
-                            )
                         if (previewMode) {
-                            NativeVideo.nativeProcessPreviewFrame(frame, rotation)
+                            NativeVideo.nativeProcessPreviewFrame(
+                                yPlane.buffer, uPlane.buffer, vPlane.buffer,
+                                yPlane.rowStride, uPlane.rowStride, vPlane.rowStride,
+                                uPlane.pixelStride, vPlane.pixelStride,
+                                image.width, image.height, rotation,
+                            )
                         } else {
-                            NativeVideo.nativePushCameraFrame(frame, rotation)
+                            NativeVideo.nativePushCameraFrame(
+                                yPlane.buffer, uPlane.buffer, vPlane.buffer,
+                                yPlane.rowStride, uPlane.rowStride, vPlane.rowStride,
+                                uPlane.pixelStride, vPlane.pixelStride,
+                                image.width, image.height, rotation,
+                            )
                         }
                     } finally {
                         image.close()

--- a/android/app/src/main/kotlin/io/visio/mobile/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/MainActivity.kt
@@ -167,6 +167,12 @@ class MainActivity : ComponentActivity() {
 
     override fun onPause() {
         super.onPause()
+        // Don't stop camera here — onPause fires when permission dialogs appear
+        // while the activity is still visible. Use onStop instead.
+    }
+
+    override fun onStop() {
+        super.onStop()
         if (!isInPictureInPictureMode) {
             VisioManager.onAppBackgrounded()
         }
@@ -191,12 +197,14 @@ class MainActivity : ComponentActivity() {
         // Skip PiP for E2E test connections (UIAutomator can't access PiP windows)
         if (VisioManager.isTestConnection) return
         val state = VisioManager.connectionState.value
-        if (state is ConnectionState.Connected && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val params =
-                PictureInPictureParams.Builder()
-                    .setAspectRatio(Rational(16, 9))
-                    .build()
-            enterPictureInPictureMode(params)
+        if (state is ConnectionState.Connected) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val params =
+                    PictureInPictureParams.Builder()
+                        .setAspectRatio(Rational(16, 9))
+                        .build()
+                enterPictureInPictureMode(params)
+            }
         }
     }
 

--- a/android/app/src/main/kotlin/io/visio/mobile/MediaFileCapture.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/MediaFileCapture.kt
@@ -322,20 +322,20 @@ class MediaFileCapture(private val filePath: String) {
                             val outWidth = image.width
                             val outHeight = image.height
 
-                            val frame =
-                                YuvFrame(
-                                    y = yPlane.buffer,
-                                    u = uPlane.buffer,
-                                    v = vPlane.buffer,
-                                    yStride = yPlane.rowStride,
-                                    uStride = uPlane.rowStride,
-                                    vStride = vPlane.rowStride,
-                                    uPixelStride = uPlane.pixelStride,
-                                    vPixelStride = vPlane.pixelStride,
-                                    width = outWidth,
-                                    height = outHeight,
-                                )
-                            NativeVideo.nativePushCameraFrame(frame, rotation = 0)
+                            NativeVideo.nativePushCameraFrame(
+                                yPlane.buffer,
+                                uPlane.buffer,
+                                vPlane.buffer,
+                                yPlane.rowStride,
+                                uPlane.rowStride,
+                                vPlane.rowStride,
+                                uPlane.pixelStride,
+                                vPlane.pixelStride,
+                                outWidth,
+                                outHeight,
+                                // no rotation for file playback
+                                0,
+                            )
 
                             image.close()
 

--- a/android/app/src/main/kotlin/io/visio/mobile/NativeVideo.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/NativeVideo.kt
@@ -3,26 +3,6 @@ package io.visio.mobile
 import android.view.Surface
 import java.nio.ByteBuffer
 
-/**
- * YUV_420_888 frame planes and layout info, used for camera and preview FFI calls.
- *
- * The ByteBuffers must be direct buffers pointing to the Y, U, V planes.
- * pixelStride indicates the byte spacing between consecutive pixel values
- * in each plane (1 for planar I420, 2 for semi-planar NV12/NV21).
- */
-data class YuvFrame(
-    val y: ByteBuffer,
-    val u: ByteBuffer,
-    val v: ByteBuffer,
-    val yStride: Int,
-    val uStride: Int,
-    val vStride: Int,
-    val uPixelStride: Int,
-    val vPixelStride: Int,
-    val width: Int,
-    val height: Int,
-)
-
 object NativeVideo {
     init {
         System.loadLibrary("visio_ffi")
@@ -38,20 +18,12 @@ object NativeVideo {
     /**
      * Push a YUV_420_888 camera frame into the LiveKit NativeVideoSource.
      * Called from CameraCapture's ImageReader callback.
+     *
+     * The ByteBuffers must be direct buffers pointing to the Y, U, V planes.
+     * pixelStride indicates the byte spacing between consecutive pixel values
+     * in each plane (1 for planar I420, 2 for semi-planar NV12/NV21).
      */
-    fun nativePushCameraFrame(
-        frame: YuvFrame,
-        rotation: Int,
-    ) = nativePushCameraFrameRaw(
-        frame.y, frame.u, frame.v,
-        frame.yStride, frame.uStride, frame.vStride,
-        frame.uPixelStride, frame.vPixelStride,
-        frame.width, frame.height,
-        rotation,
-    )
-
-    @Suppress("LongParameterList")
-    private external fun nativePushCameraFrameRaw(
+    external fun nativePushCameraFrame(
         y: ByteBuffer,
         u: ByteBuffer,
         v: ByteBuffer,
@@ -74,24 +46,15 @@ object NativeVideo {
      * Preview-only frame processing: applies blur and renders to the local preview
      * surface without feeding into a LiveKit NativeVideoSource.
      * Called from CameraCapture in preview mode (pre-join lobby).
+     *
+     * The ByteBuffers must be direct buffers pointing to the Y, U, V planes.
+     * pixelStride indicates the byte spacing between consecutive pixel values
+     * in each plane (1 for planar I420, 2 for semi-planar NV12/NV21).
      */
-    fun nativeProcessPreviewFrame(
-        frame: YuvFrame,
-        rotationDegrees: Int,
-    ) = nativeProcessPreviewFrameRaw(
-        frame.y, frame.u, frame.v,
-        frame.yStride, frame.uStride, frame.vStride,
-        frame.uPixelStride, frame.vPixelStride,
-        frame.width, frame.height,
-        rotationDegrees,
-    )
-
-    @Suppress("LongParameterList")
-    @SuppressWarnings("kotlin:S107")
-    private external fun nativeProcessPreviewFrameRaw(
-        yBuf: ByteBuffer,
-        uBuf: ByteBuffer,
-        vBuf: ByteBuffer,
+    external fun nativeProcessPreviewFrame(
+        yBuf: java.nio.ByteBuffer,
+        uBuf: java.nio.ByteBuffer,
+        vBuf: java.nio.ByteBuffer,
         yStride: Int,
         uStride: Int,
         vStride: Int,

--- a/android/app/src/main/kotlin/io/visio/mobile/VideoSurfaceView.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/VideoSurfaceView.kt
@@ -35,7 +35,9 @@ class VideoSurfaceView(
         width: Int,
         height: Int,
     ) {
-        Log.d(TAG, "surfaceChanged track=$trackSid ${width}x$height")
+        Log.d(TAG, "surfaceChanged track=$trackSid ${width}x$height, re-attaching surface")
+        NativeVideo.detachSurface(trackSid)
+        NativeVideo.attachSurface(trackSid, holder.surface)
     }
 
     override fun surfaceDestroyed(holder: SurfaceHolder) {

--- a/android/app/src/main/kotlin/io/visio/mobile/VisioManager.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/VisioManager.kt
@@ -155,6 +155,13 @@ object VisioManager : VisioEventListener {
 
     // Test deep link: connect directly with LiveKit URL + token (debug builds only)
     var pendingTestConnect: Triple<String, String, String?>? = null // (livekitUrl, token, mediaFile?)
+
+    // Audio device preferences from lobby (applied by CallScreen after connection)
+    var pendingOutputDevice: AudioDeviceInfo? = null
+    var pendingInputDevice: AudioDeviceInfo? = null
+
+    // Flag to prevent CallScreen from re-initializing after permission dialogs
+    var callScreenInitialized = false
     var isTestConnection: Boolean = false
 
     // Media file capture for E2E testing (replaces synthetic audio/camera)
@@ -343,7 +350,6 @@ object VisioManager : VisioEventListener {
                     client.logout("https://$instance")
                 }
             } catch (_: Exception) {
-                // No-op: logout failure is non-fatal, clear local session regardless
             }
             authManager.clearCookie()
             withContext(Dispatchers.Main) {
@@ -831,7 +837,6 @@ object VisioManager : VisioEventListener {
                 val accesses = client.listAccesses(roomId)
                 _roomAccesses.value = accesses
             } catch (_: Exception) {
-                // No-op: access list refresh failure is non-fatal
             }
         }
     }
@@ -846,7 +851,6 @@ object VisioManager : VisioEventListener {
                 client.addAccess(userId, roomId)
                 refreshAccesses()
             } catch (_: Exception) {
-                // No-op: access member add failure is non-fatal
             }
             withContext(Dispatchers.Main) { onDone() }
         }
@@ -858,7 +862,6 @@ object VisioManager : VisioEventListener {
                 client.removeAccess(accessId)
                 refreshAccesses()
             } catch (_: Exception) {
-                // No-op: access member remove failure is non-fatal
             }
         }
     }
@@ -950,6 +953,7 @@ object VisioManager : VisioEventListener {
      * Full teardown: stop captures, playout, cancel pending coroutines, disconnect.
      */
     fun disconnect() {
+        callScreenInitialized = false
         stopAudioFocusMonitoring()
         contextDetector?.stop()
         contextDetector = null
@@ -984,11 +988,11 @@ object VisioManager : VisioEventListener {
      * but keep audio active (wake lock protects CPU).
      */
     fun onAppBackgrounded() {
-        if (connectionState.value is ConnectionState.Connected ||
-            connectionState.value is ConnectionState.Reconnecting
-        ) {
-            stopCameraCapture()
-        }
+        // Don't stop camera here — permission dialogs and system overlays
+        // trigger onStop while the call is still active. The camera will be
+        // properly stopped when the user disconnects (via disconnect()).
+        // This also allows the camera to keep sending frames during brief
+        // background transitions (e.g. notification shade pull-down).
     }
 
     /**
@@ -1011,9 +1015,7 @@ object VisioManager : VisioEventListener {
                         Log.e("VISIO", "Foreground reconnection failed: ${e.message}")
                     }
                 }
-                else -> {
-                    // No-op: other states (Connecting, Reconnecting) don't need foreground handling
-                }
+                else -> {}
             }
         }
     }

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
@@ -107,18 +107,6 @@ private const val TAG = "CallScreen"
 
 data class FocusItem(val participantSid: String, val source: String)
 
-data class ControlBarState(
-    val micEnabled: Boolean,
-    val cameraEnabled: Boolean,
-    val isHandRaised: Boolean,
-    val unreadCount: Int,
-    val participantCount: Int,
-    val showReactionPicker: Boolean,
-    val adaptiveMode: AdaptiveMode,
-    val isAdaptiveModeEnabled: Boolean,
-    val lang: String,
-)
-
 data class DisplayItem(
     val key: String,
     val participant: ParticipantInfo,
@@ -214,7 +202,6 @@ private suspend fun handleTestConnect(
     try {
         VisioManager.startAudioCapture()
     } catch (_: Exception) {
-        // No-op: audio capture failure is non-fatal, call continues without mic
     }
 
     val hasMediaFile = !mediaFile.isNullOrBlank() && java.io.File(mediaFile).exists()
@@ -247,31 +234,26 @@ private fun launchTestChatMessages(coroutineScope: CoroutineScope) {
         try {
             VisioManager.client.sendChatMessage("Android joined the room!")
         } catch (_: Exception) {
-            // No-op: test chat message failure is non-fatal
         }
         delay(47000)
         try {
             VisioManager.client.sendChatMessage("Android: my turn to speak!")
         } catch (_: Exception) {
-            // No-op: test chat message failure is non-fatal
         }
         delay(15000)
         try {
             VisioManager.client.sendChatMessage("Android: mid-turn check-in")
         } catch (_: Exception) {
-            // No-op: test chat message failure is non-fatal
         }
         delay(10000)
         try {
             VisioManager.client.sendChatMessage("Android: muted — iOS's turn")
         } catch (_: Exception) {
-            // No-op: test chat message failure is non-fatal
         }
         delay(25000)
         try {
             VisioManager.client.sendChatMessage("Android: everyone speaking together!")
         } catch (_: Exception) {
-            // No-op: test chat message failure is non-fatal
         }
     }
 }
@@ -288,12 +270,10 @@ private fun launchTestTurnSequence(
             stopMediaCapture()
             VisioManager.client.setMicrophoneEnabled(false)
         } catch (_: Exception) {
-            // No-op: test turn sequence failure is non-fatal
         }
         try {
             VisioManager.client.setCameraEnabled(false)
         } catch (_: Exception) {
-            // No-op: test turn sequence failure is non-fatal
         }
 
         delay(45000)
@@ -302,12 +282,10 @@ private fun launchTestTurnSequence(
             VisioManager.client.setMicrophoneEnabled(true)
             VisioManager.client.setCameraEnabled(true)
         } catch (_: Exception) {
-            // No-op: test turn sequence failure is non-fatal
         }
         try {
             startMediaCapture()
         } catch (_: Exception) {
-            // No-op: test turn sequence failure is non-fatal
         }
 
         delay(25000)
@@ -316,12 +294,10 @@ private fun launchTestTurnSequence(
             stopMediaCapture()
             VisioManager.client.setMicrophoneEnabled(false)
         } catch (_: Exception) {
-            // No-op: test turn sequence failure is non-fatal
         }
         try {
             VisioManager.client.setCameraEnabled(false)
         } catch (_: Exception) {
-            // No-op: test turn sequence failure is non-fatal
         }
 
         delay(25000)
@@ -330,12 +306,10 @@ private fun launchTestTurnSequence(
             VisioManager.client.setMicrophoneEnabled(true)
             VisioManager.client.setCameraEnabled(true)
         } catch (_: Exception) {
-            // No-op: test turn sequence failure is non-fatal
         }
         try {
             startMediaCapture()
         } catch (_: Exception) {
-            // No-op: test turn sequence failure is non-fatal
         }
     }
 }
@@ -600,10 +574,15 @@ fun CallScreen(
         }
     }
 
+    var lastMode by remember { mutableStateOf(adaptiveMode) }
+
     LaunchedEffect(adaptiveMode) {
-        // Sync local cameraEnabled with actual Rust state on each adaptive mode change
-        val camState = withContext(Dispatchers.IO) { VisioManager.client.isCameraEnabled() }
-        cameraEnabled = camState
+        if (adaptiveMode != lastMode) {
+            lastMode = adaptiveMode
+            // Sync local cameraEnabled with actual Rust state (FFI call off main thread)
+            val camState = withContext(Dispatchers.IO) { VisioManager.client.isCameraEnabled() }
+            cameraEnabled = camState
+        }
     }
 
     val coroutineScope = rememberCoroutineScope()
@@ -687,6 +666,9 @@ fun CallScreen(
         }
     }
 
+    // Debug: log every composition
+    Log.d(TAG, "CallScreen composed, connectionState=$connectionState, cam=$cameraEnabled")
+
     // WaitingForHost: show waiting screen instead of call UI
     if (connectionState is ConnectionState.WaitingForHost) {
         WaitingScreen(
@@ -699,22 +681,17 @@ fun CallScreen(
         return
     }
 
-    // Connect on first composition
+    // Initialize call state. When coming from PreJoinScreen, media is already
+    // enabled — just read the current state. For test deep links, do full setup.
     LaunchedEffect(Unit) {
         withContext(Dispatchers.IO) {
             val state = VisioManager.connectionState.value
+            Log.i(TAG, "CallScreen init: connectionState=$state")
             if (state is ConnectionState.Connected || state is ConnectionState.Connecting) {
-                val s =
-                    try {
-                        VisioManager.client.getSettings()
-                    } catch (_: Exception) {
-                        null
-                    }
-                // Apply mic/camera on join so Rust-side capture is started
-                applyMicOnJoin(context, s?.micEnabledOnJoin ?: false)
+                // PreJoinScreen already started audio/mic/camera — just sync UI state
                 micEnabled = VisioManager.client.isMicrophoneEnabled()
-                applyCameraOnJoin(context, s?.cameraEnabledOnJoin ?: false)
                 cameraEnabled = VisioManager.client.isCameraEnabled()
+                Log.i(TAG, "CallScreen: inherited mic=$micEnabled, cam=$cameraEnabled")
                 return@withContext
             }
 
@@ -741,18 +718,8 @@ fun CallScreen(
         }
     }
 
-    // Request BLUETOOTH_CONNECT permission on Android 12+ for car kit detection
-    LaunchedEffect(Unit) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val hasBtPerm =
-                ContextCompat.checkSelfPermission(
-                    context, Manifest.permission.BLUETOOTH_CONNECT,
-                ) == PackageManager.PERMISSION_GRANTED
-            if (!hasBtPerm) {
-                bluetoothPermissionLauncher.launch(Manifest.permission.BLUETOOTH_CONNECT)
-            }
-        }
-    }
+    // BLUETOOTH_CONNECT permission is now requested in PreJoinScreen
+    // so it doesn't interrupt the active call with a system dialog.
 
     // Notify backend when navigating to chat
     val onChatOpen = {
@@ -881,18 +848,15 @@ fun CallScreen(
                 Spacer(modifier = Modifier.height(8.dp))
 
                 ControlBar(
-                    state =
-                        ControlBarState(
-                            micEnabled = micEnabled,
-                            cameraEnabled = cameraEnabled,
-                            isHandRaised = isHandRaised,
-                            unreadCount = unreadCount,
-                            participantCount = participants.size,
-                            showReactionPicker = showReactionPicker,
-                            adaptiveMode = effectiveAdaptiveMode,
-                            isAdaptiveModeEnabled = isAdaptiveModeEnabled,
-                            lang = lang,
-                        ),
+                    micEnabled = micEnabled,
+                    cameraEnabled = cameraEnabled,
+                    isHandRaised = isHandRaised,
+                    unreadCount = unreadCount,
+                    participantCount = participants.size,
+                    showReactionPicker = showReactionPicker,
+                    adaptiveMode = effectiveAdaptiveMode,
+                    isAdaptiveModeEnabled = isAdaptiveModeEnabled,
+                    lang = lang,
                     onToggleMic = {
                         toggleMic(micEnabled, context, coroutineScope, micPermissionLauncher) {
                             micEnabled = it
@@ -1482,7 +1446,15 @@ private fun AdaptiveModeIndicator(
 
 @Composable
 private fun ControlBar(
-    state: ControlBarState,
+    micEnabled: Boolean,
+    cameraEnabled: Boolean,
+    isHandRaised: Boolean,
+    unreadCount: Int,
+    participantCount: Int,
+    showReactionPicker: Boolean,
+    adaptiveMode: AdaptiveMode,
+    isAdaptiveModeEnabled: Boolean,
+    lang: String,
     onToggleMic: () -> Unit,
     onAudioPicker: () -> Unit,
     onToggleCamera: () -> Unit,
@@ -1501,15 +1473,15 @@ private fun ControlBar(
     Column(
         modifier = Modifier.fillMaxWidth(),
     ) {
-        if (state.showReactionPicker) {
+        if (showReactionPicker) {
             ReactionPickerRow(onReaction = onReaction)
         }
 
         if (showOverflow) {
             OverflowMenu(
-                isHandRaised = state.isHandRaised,
-                lang = state.lang,
-                isAdaptiveModeEnabled = state.isAdaptiveModeEnabled,
+                isHandRaised = isHandRaised,
+                lang = lang,
+                isAdaptiveModeEnabled = isAdaptiveModeEnabled,
                 adaptiveModeOverride = adaptiveModeOverride,
                 onToggleHandRaise = {
                     onToggleHandRaise()
@@ -1531,14 +1503,14 @@ private fun ControlBar(
         }
 
         ControlBarButtons(
-            micEnabled = state.micEnabled,
-            cameraEnabled = state.cameraEnabled,
-            unreadCount = state.unreadCount,
-            participantCount = state.participantCount,
-            adaptiveMode = state.adaptiveMode,
-            isAdaptiveModeEnabled = state.isAdaptiveModeEnabled,
+            micEnabled = micEnabled,
+            cameraEnabled = cameraEnabled,
+            unreadCount = unreadCount,
+            participantCount = participantCount,
+            adaptiveMode = adaptiveMode,
+            isAdaptiveModeEnabled = isAdaptiveModeEnabled,
             showOverflow = showOverflow,
-            lang = state.lang,
+            lang = lang,
             onToggleMic = onToggleMic,
             onAudioPicker = onAudioPicker,
             onToggleCamera = onToggleCamera,

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/HomeScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/HomeScreen.kt
@@ -235,7 +235,6 @@ private fun HomeScreenEffects(
         try {
             onHasCalendarUrlChange(VisioManager.client.getCalendarUrl() != null)
         } catch (_: Exception) {
-            // No-op: calendar URL check failure is non-fatal
         }
         onPauseOrDispose {}
     }
@@ -535,7 +534,7 @@ private fun ColumnScope.HomeTabContent(
                 isDark = isDark,
                 lang = lang,
                 onSettings = onSettings,
-                onJoinMeeting = { meetingRoomUrl ->
+                onJoinMeeting = { meetingRoomUrl, _ ->
                     onJoin(meetingRoomUrl, username.trim())
                 },
             )
@@ -1289,7 +1288,6 @@ private fun CreateRoomDialog(
                                         try {
                                             VisioManager.client.addAccess(user.id, result.id)
                                         } catch (_: Exception) {
-                                            // No-op: individual access grant failure is non-fatal
                                         }
                                     }
                                 }

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/InCallSettingsSheet.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/InCallSettingsSheet.kt
@@ -986,7 +986,7 @@ private fun getFilteredOutputDevices(audioManager: AudioManager): List<AudioDevi
         // Keep SCO (communication profile) and drop A2DP duplicates.
         .filter { device ->
             if (device.type in BLUETOOTH_TYPES) {
-                val name = device.productName.toString()
+                val name = device.productName?.toString() ?: ""
                 // SCO always passes; A2DP only if no SCO with same name was seen
                 if (device.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO) {
                     seenBtNames.add(name)
@@ -1007,7 +1007,7 @@ private fun audioDeviceLabel(
     return if (device.type in BUILTIN_TYPES) {
         audioDeviceTypeName(device.type, lang)
     } else {
-        device.productName.toString().ifBlank { null }
+        device.productName?.toString()?.ifBlank { null }
             ?: audioDeviceTypeName(device.type, lang)
     }
 }

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/LayoutEngine.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/LayoutEngine.kt
@@ -66,7 +66,7 @@ private fun computeScreenShareLayout(
     previousState: LayoutState,
 ): Pair<LayoutDecision, LayoutState> {
     val main = findDisplayItem(displayItems, screenShare.participantSid, screenShare.source)
-    val secondary = displayItems.filter { main == null || it.key != main.key }
+    val secondary = displayItems.filter { it.key != main?.key }
     return Pair(
         LayoutDecision(LayoutMode.FOCUS, main, secondary, activeSpeakers.firstOrNull(), pinnedItem?.participantSid),
         previousState.copy(currentFocus = screenShare),
@@ -80,7 +80,7 @@ private fun computePinnedLayout(
     previousState: LayoutState,
 ): Pair<LayoutDecision, LayoutState> {
     val main = findDisplayItem(displayItems, pinnedItem.participantSid, pinnedItem.source)
-    val secondary = displayItems.filter { main == null || it.key != main.key }
+    val secondary = displayItems.filter { it.key != main?.key }
     return Pair(
         LayoutDecision(LayoutMode.FOCUS, main, secondary, activeSpeakers.firstOrNull(), pinnedItem.participantSid),
         previousState.copy(currentFocus = pinnedItem),
@@ -108,7 +108,7 @@ private fun computeSpeakerLayout(
 
     return if (shouldSwitch) {
         val main = findDisplayItem(displayItems, targetSid, "camera")
-        val secondary = displayItems.filter { main == null || it.key != main.key }
+        val secondary = displayItems.filter { it.key != main?.key }
         Pair(
             LayoutDecision(LayoutMode.FOCUS, main, secondary, currentSpeakerSid, null),
             LayoutState(targetFocus, nowMs, newLastRemote),
@@ -118,7 +118,7 @@ private fun computeSpeakerLayout(
             previousState.currentFocus?.let {
                 findDisplayItem(displayItems, it.participantSid, it.source)
             }
-        val secondary = displayItems.filter { currentMain == null || it.key != currentMain.key }
+        val secondary = displayItems.filter { it.key != currentMain?.key }
         Pair(
             LayoutDecision(LayoutMode.FOCUS, currentMain, secondary, currentSpeakerSid, null),
             previousState.copy(lastRemoteSpeakerSid = newLastRemote),

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/MeetingsTab.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/MeetingsTab.kt
@@ -57,7 +57,7 @@ fun MeetingsTab(
     isDark: Boolean,
     lang: String,
     onSettings: () -> Unit,
-    onJoinMeeting: (roomUrl: String) -> Unit,
+    onJoinMeeting: (roomUrl: String, serverName: String) -> Unit,
 ) {
     when {
         !hasCalendarUrl -> {
@@ -201,7 +201,7 @@ private fun MeetingsList(
     meetings: List<Meeting>,
     isDark: Boolean,
     lang: String,
-    onJoinMeeting: (roomUrl: String) -> Unit,
+    onJoinMeeting: (roomUrl: String, serverName: String) -> Unit,
     onRefresh: () -> Unit,
 ) {
     val now = System.currentTimeMillis() / 1000L
@@ -244,7 +244,7 @@ private fun MeetingsList(
                     now = now,
                     isInProgress = isInProgressItem,
                     isImminent = !isInProgressItem && minutesUntil in 0..14,
-                    onJoin = { onJoinMeeting(meeting.roomUrl) },
+                    onJoin = { onJoinMeeting(meeting.roomUrl, meeting.serverName) },
                 )
             }
         }

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/PreJoinScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/PreJoinScreen.kt
@@ -16,8 +16,10 @@ import android.media.AudioFormat
 import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.MediaRecorder
+import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
+import android.util.Log
 import android.view.Surface
 import android.view.TextureView
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -274,7 +276,7 @@ class LocalCameraPreview(
         setTransform(matrix)
     }
 
-    private fun stopCamera() {
+    internal fun stopCamera() {
         session?.close()
         session = null
         camera?.close()
@@ -333,6 +335,27 @@ fun PreJoinScreen(
         rememberLauncherForActivityResult(
             ActivityResultContracts.RequestPermission(),
         ) { granted -> if (granted) micEnabled = true }
+
+    // ── Bluetooth permission (needed to list BT devices by name) ──────────────
+    val btPermissionLauncher =
+        rememberLauncherForActivityResult(
+            ActivityResultContracts.RequestPermission(),
+        ) { granted ->
+            if (granted) {
+                Log.d("PreJoinScreen", "BLUETOOTH_CONNECT permission granted")
+            }
+        }
+    LaunchedEffect(Unit) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val hasBtPerm =
+                ContextCompat.checkSelfPermission(
+                    context, Manifest.permission.BLUETOOTH_CONNECT,
+                ) == PackageManager.PERMISSION_GRANTED
+            if (!hasBtPerm) {
+                btPermissionLauncher.launch(Manifest.permission.BLUETOOTH_CONNECT)
+            }
+        }
+    }
 
     // ── Audio device state ────────────────────────────────────────────────────
     val audioManager = remember { context.getSystemService(Context.AUDIO_SERVICE) as AudioManager }
@@ -495,9 +518,66 @@ fun PreJoinScreen(
         }
     }
 
-    // ── React to Connected: navigate into call ────────────────────────────────
+    // ── React to Connected: enable media then navigate into call ───────────────
+    // Use a coroutineScope.launch (not LaunchedEffect) so it is NOT cancelled
+    // when connectionState changes or the composable recomposes.
+    var mediaSetupDone by remember { mutableStateOf(false) }
+    Log.d("PreJoinScreen", "connectionState=$connectionState, waiting=$waitingState, mediaSetupDone=$mediaSetupDone")
     LaunchedEffect(connectionState) {
-        if (connectionState is ConnectionState.Connected && waitingState is WaitingState.Waiting) {
+        if (connectionState is ConnectionState.Connected &&
+            waitingState is WaitingState.Waiting &&
+            !mediaSetupDone
+        ) {
+            mediaSetupDone = true
+            // Launch on a NON-CANCELLABLE context so permission dialogs
+            // or recompositions cannot abort the media setup
+            kotlinx.coroutines.withContext(Dispatchers.IO + kotlinx.coroutines.NonCancellable) {
+                try {
+                    VisioManager.startAudioPlayout()
+                } catch (_: Exception) {
+                }
+
+                VisioManager.pendingOutputDevice?.let { device ->
+                    try {
+                        VisioManager.setAudioOutputDevice(device)
+                    } catch (_: Exception) {
+                    }
+                }
+                VisioManager.pendingOutputDevice = null
+
+                Log.i("PreJoinScreen", "Media setup: mic=$micEnabled cam=$cameraEnabled audio=$audioMode")
+                if (micEnabled && audioMode == "computer_audio") {
+                    try {
+                        VisioManager.client.setMicrophoneEnabled(true)
+                        VisioManager.startAudioCapture(selectedInputDeviceRef)
+                    } catch (_: Exception) {
+                    }
+                }
+                VisioManager.pendingInputDevice = null
+
+                if (cameraEnabled) {
+                    // Stop the lobby Camera2 preview FIRST to release the
+                    // physical camera device before CameraCapture opens it
+                    withContext(Dispatchers.Main) {
+                        cameraPreviewRef.value?.stopCamera()
+                        cameraPreviewRef.value = null
+                    }
+                    // Small delay to let Camera2 fully release the device
+                    kotlinx.coroutines.delay(200)
+                    try {
+                        Log.i("PreJoinScreen", "Calling setCameraEnabled(true)...")
+                        VisioManager.client.setCameraEnabled(true)
+                        Log.i("PreJoinScreen", "setCameraEnabled done, starting capture...")
+                        VisioManager.startCameraCapture()
+                        Log.i("PreJoinScreen", "Camera capture started")
+                    } catch (e: Exception) {
+                        Log.e("PreJoinScreen", "Camera setup failed", e)
+                    }
+                }
+
+                VisioManager.refreshParticipantsPublic()
+                Log.i("PreJoinScreen", "Media setup complete, navigating to call")
+            }
             waitingState = WaitingState.Idle
             onJoin(displayName)
         }
@@ -703,36 +783,16 @@ fun PreJoinScreen(
                                 waitingState = WaitingState.Waiting
                             }
 
-                            // Connect
-                            VisioManager.client.connect(roomUrl, displayName.trim())
-                            VisioManager.startAudioPlayout()
-
-                            // Apply output device from lobby
+                            // Save audio device preferences for CallScreen to apply
                             selectedOutputDeviceRef?.let { device ->
-                                try {
-                                    VisioManager.setAudioOutputDevice(device)
-                                } catch (_: Exception) {
-                                    // No-op: audio output routing failure is non-fatal
-                                }
+                                VisioManager.pendingOutputDevice = device
+                            }
+                            selectedInputDeviceRef?.let { device ->
+                                VisioManager.pendingInputDevice = device
                             }
 
-                            // Enable mic/camera based on lobby selections
-                            if (micEnabled && audioMode == "computer_audio") {
-                                try {
-                                    VisioManager.client.setMicrophoneEnabled(true)
-                                    VisioManager.startAudioCapture(selectedInputDeviceRef)
-                                } catch (_: Exception) {
-                                    // No-op: mic enable failure is non-fatal
-                                }
-                            }
-                            if (cameraEnabled) {
-                                try {
-                                    VisioManager.client.setCameraEnabled(true)
-                                    VisioManager.startCameraCapture()
-                                } catch (_: Exception) {
-                                    // No-op: camera enable failure is non-fatal
-                                }
-                            }
+                            // Connect — mic/camera will be enabled by CallScreen
+                            VisioManager.client.connect(roomUrl, displayName.trim())
                         } catch (e: Exception) {
                             withContext(Dispatchers.Main) {
                                 waitingState = WaitingState.Idle
@@ -750,7 +810,6 @@ fun PreJoinScreen(
                                     VisioManager.cancelLobby()
                                     VisioManager.disconnect()
                                 } catch (_: Exception) {
-                                    // No-op: lobby cancellation failure is non-fatal
                                 }
                             }
                         }
@@ -791,7 +850,6 @@ fun PreJoinScreen(
                                 VisioManager.cancelLobby()
                                 VisioManager.disconnect()
                             } catch (_: Exception) {
-                                // No-op: lobby cancellation failure is non-fatal
                             }
                         }
                     },
@@ -868,7 +926,6 @@ private fun BackgroundFilterSheet(
                             try {
                                 VisioManager.client.setBackgroundMode("off")
                             } catch (_: Exception) {
-                                // No-op: background mode change failure is non-fatal
                             }
                         }
                         onSelect("off")
@@ -884,7 +941,6 @@ private fun BackgroundFilterSheet(
                             try {
                                 VisioManager.client.setBackgroundMode("blur")
                             } catch (_: Exception) {
-                                // No-op: background mode change failure is non-fatal
                             }
                         }
                         onSelect("blur")
@@ -945,7 +1001,6 @@ private fun BackgroundFilterSheet(
                                             )
                                             VisioManager.client.setBackgroundMode("image:$id")
                                         } catch (_: Exception) {
-                                            // No-op: background image load failure is non-fatal
                                         }
                                     }
                                     onSelect("image:$id")

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/SettingsScreen.kt
@@ -603,26 +603,15 @@ private fun CalendarIntervalDropdown(
     lang: String,
     onSelect: (CalendarRefreshInterval) -> Unit,
 ) {
-    val intervalValues =
+    val intervalLabels =
         listOf(
-            CalendarRefreshInterval.MINUTES5,
-            CalendarRefreshInterval.MINUTES15,
-            CalendarRefreshInterval.HOUR1,
-            CalendarRefreshInterval.HOURS4,
-            CalendarRefreshInterval.MANUAL,
+            CalendarRefreshInterval.MINUTES5 to Strings.t("settings.calendarRefresh.5min", lang),
+            CalendarRefreshInterval.MINUTES15 to Strings.t("settings.calendarRefresh.15min", lang),
+            CalendarRefreshInterval.HOUR1 to Strings.t("settings.calendarRefresh.1h", lang),
+            CalendarRefreshInterval.HOURS4 to Strings.t("settings.calendarRefresh.4h", lang),
+            CalendarRefreshInterval.MANUAL to Strings.t("settings.calendarRefresh.manual", lang),
         )
-    val intervalLabelKeys =
-        listOf(
-            "settings.calendarRefresh.5min",
-            "settings.calendarRefresh.15min",
-            "settings.calendarRefresh.1h",
-            "settings.calendarRefresh.4h",
-            "settings.calendarRefresh.manual",
-        )
-    val selectedLabel =
-        intervalValues.indexOf(selected).takeIf { it >= 0 }
-            ?.let { Strings.t(intervalLabelKeys[it], lang) }
-            ?: selected.toString()
+    val selectedLabel = intervalLabels.firstOrNull { it.first == selected }?.second ?: selected.name
     var expanded by remember { mutableStateOf(false) }
 
     ExposedDropdownMenuBox(
@@ -662,11 +651,11 @@ private fun CalendarIntervalDropdown(
             onDismissRequest = { expanded = false },
             containerColor = if (isDark) VisioColors.PrimaryDark100 else VisioColors.LightSurfaceVariant,
         ) {
-            intervalValues.forEachIndexed { index, interval ->
+            intervalLabels.forEach { (interval, label) ->
                 DropdownMenuItem(
                     text = {
                         Text(
-                            Strings.t(intervalLabelKeys[index], lang),
+                            label,
                             color = if (isDark) VisioColors.White else VisioColors.LightOnBackground,
                         )
                     },

--- a/crates/visio-desktop/frontend/src/layout-engine.ts
+++ b/crates/visio-desktop/frontend/src/layout-engine.ts
@@ -95,21 +95,20 @@ function shouldSwitchFocus(
   targetFocus: FocusItemNonNull,
   nowMs: number
 ): boolean {
-  if (previousState.currentFocus) {
-    if (
-      previousState.currentFocus.participantSid ===
-        targetFocus.participantSid &&
-      previousState.currentFocus.source === targetFocus.source
-    ) {
-      return false
-    }
-    const holdElapsed =
-      previousState.focusHoldStartMs === null
-        ? Infinity
-        : nowMs - previousState.focusHoldStartMs
-    return holdElapsed >= MIN_HOLD_MS
+  if (!previousState.currentFocus) {
+    return true
   }
-  return true
+  if (
+    previousState.currentFocus.participantSid === targetFocus.participantSid &&
+    previousState.currentFocus.source === targetFocus.source
+  ) {
+    return false
+  }
+  const holdElapsed =
+    previousState.focusHoldStartMs != null
+      ? nowMs - previousState.focusHoldStartMs
+      : Infinity
+  return holdElapsed >= MIN_HOLD_MS
 }
 
 /** Handle active speaker logic with stabilization (step 3). */
@@ -122,15 +121,15 @@ function handleActiveSpeaker<T extends LayoutDisplayItem>(
 ): [LayoutDecision<T>, LayoutState] | null {
   const isLocalSpeaking = currentSpeakerSid === localParticipantSid
 
-  const newLastRemote = isLocalSpeaking
-    ? previousState.lastRemoteSpeakerSid
-    : currentSpeakerSid
+  const newLastRemote = !isLocalSpeaking
+    ? currentSpeakerSid
+    : previousState.lastRemoteSpeakerSid
 
   const targetSid = isLocalSpeaking
     ? (previousState.lastRemoteSpeakerSid ?? null)
     : currentSpeakerSid
 
-  if (targetSid === null) {
+  if (!targetSid) {
     return null
   }
 
@@ -207,9 +206,9 @@ export function computeLayout<T extends LayoutDisplayItem>(
 
   // 4. No speaker — check silence timeout (Desktop is always "office" mode)
   const silenceElapsed =
-    previousState.focusHoldStartMs === null
-      ? Infinity
-      : nowMs - previousState.focusHoldStartMs
+    previousState.focusHoldStartMs != null
+      ? nowMs - previousState.focusHoldStartMs
+      : Infinity
   if (silenceElapsed > SILENCE_TO_GRID_MS) {
     return buildGridResult(displayItems, {
       currentFocus: null,

--- a/crates/visio-ffi/src/lib.rs
+++ b/crates/visio-ffi/src/lib.rs
@@ -1781,6 +1781,10 @@ mod pending {
 
     pub fn store(track_sid: String, surface: *mut std::ffi::c_void) {
         if let Ok(mut map) = SURFACES.lock() {
+            if let Some(old) = map.remove(&track_sid) {
+                tracing::warn!(track_sid = %track_sid, "replacing existing pending surface — releasing old ANativeWindow");
+                unsafe { ndk_sys::ANativeWindow_release(old.0 as *mut _) };
+            }
             map.insert(track_sid, RawSurface(surface));
         }
     }

--- a/crates/visio-video/src/lib.rs
+++ b/crates/visio-video/src/lib.rs
@@ -213,13 +213,20 @@ async fn frame_loop(
     const MAX_STREAM_RETRIES: u32 = 10;
     let mut stream_retries: u32 = 0;
 
+    /// Maximum number of outer retries after all stream retries are exhausted.
+    /// Each outer retry waits longer (2s) before recreating the stream, handling
+    /// the case where a muted track unmutes after the inner retry window.
+    const MAX_OUTER_RETRIES: u32 = 3;
+    let mut outer_retries: u32 = 0;
+
+    'outer: loop {
     loop {
         tokio::select! {
             _ = cancel_rx.changed() => {
                 #[cfg(target_os = "android")]
                 android_log(&format!("VISIO VIDEO: frame_loop cancelled track={track_sid}"));
                 tracing::info!(track_sid = %track_sid, "frame_loop cancelled");
-                break;
+                break 'outer;
             }
             _ = tokio::time::sleep(std::time::Duration::from_secs(3)) => {
                 #[cfg(target_os = "android")]
@@ -231,8 +238,9 @@ async fn frame_loop(
             frame_opt = stream.next() => {
                 match frame_opt {
                     Some(frame) => {
-                        // Reset retry counter on successful frame reception.
+                        // Reset retry counters on successful frame reception.
                         stream_retries = 0;
+                        outer_retries = 0;
 
                         // --- Android ---
                         #[cfg(target_os = "android")]
@@ -242,8 +250,40 @@ async fn frame_loop(
                                 android_log(&format!("VISIO VIDEO: frame #{android_frame_count} track={track_sid} {}x{}", frame.buffer.width(), frame.buffer.height()));
                             }
                             if !android::render_frame(&frame, surface.0, &track_sid, is_screencast) {
-                                android_log(&format!("VISIO VIDEO: surface invalid, stopping frame_loop track={track_sid}"));
-                                break;
+                                android_log(&format!("VISIO VIDEO: surface invalid, waiting for new surface track={track_sid}"));
+                                tracing::warn!(track_sid = %track_sid, "render_frame failed — surface destroyed, waiting for re-attach");
+
+                                const MAX_SURFACE_RETRIES: u32 = 30;
+                                let mut surface_recovered = false;
+                                for attempt in 1..=MAX_SURFACE_RETRIES {
+                                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+                                    // Check for cancellation while waiting.
+                                    if *cancel_rx.borrow() {
+                                        android_log(&format!("VISIO VIDEO: cancelled during surface wait track={track_sid}"));
+                                        break 'outer;
+                                    }
+
+                                    // Try rendering again — if the platform attached a new surface
+                                    // it will have called start_track_renderer which replaces us,
+                                    // but if it reused the same pointer we can resume.
+                                    if android::render_frame(&frame, surface.0, &track_sid, is_screencast) {
+                                        android_log(&format!("VISIO VIDEO: surface recovered after {attempt} attempts track={track_sid}"));
+                                        tracing::info!(track_sid = %track_sid, attempt, "surface recovered");
+                                        surface_recovered = true;
+                                        break;
+                                    }
+
+                                    if attempt % 10 == 0 {
+                                        android_log(&format!("VISIO VIDEO: still waiting for surface track={track_sid} attempt={attempt}/{MAX_SURFACE_RETRIES}"));
+                                    }
+                                }
+
+                                if !surface_recovered {
+                                    android_log(&format!("VISIO VIDEO: surface not recovered after {MAX_SURFACE_RETRIES} attempts, stopping frame_loop track={track_sid}"));
+                                    tracing::warn!(track_sid = %track_sid, "surface not recovered after 3s, exiting frame_loop");
+                                    break 'outer;
+                                }
                             }
                         }
 
@@ -283,10 +323,43 @@ async fn frame_loop(
                         if stream_retries > MAX_STREAM_RETRIES {
                             #[cfg(target_os = "android")]
                             android_log(&format!(
-                                "VISIO VIDEO: stream ended permanently track={track_sid} after {MAX_STREAM_RETRIES} retries"
+                                "VISIO VIDEO: stream retries exhausted track={track_sid}, outer retry {outer_retries}/{MAX_OUTER_RETRIES}"
                             ));
-                            tracing::info!(track_sid = %track_sid, "video stream ended permanently after max retries");
-                            break;
+                            tracing::info!(
+                                track_sid = %track_sid,
+                                outer_retry = outer_retries,
+                                max_outer = MAX_OUTER_RETRIES,
+                                "stream retries exhausted, attempting outer retry"
+                            );
+
+                            outer_retries += 1;
+                            if outer_retries > MAX_OUTER_RETRIES {
+                                #[cfg(target_os = "android")]
+                                android_log(&format!(
+                                    "VISIO VIDEO: stream ended permanently track={track_sid} after {MAX_OUTER_RETRIES} outer retries"
+                                ));
+                                tracing::info!(track_sid = %track_sid, "video stream ended permanently after all retries exhausted");
+                                break 'outer;
+                            }
+
+                            // Wait longer before outer retry — gives more time for
+                            // unmute or track re-publication.
+                            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+                            // Check for cancellation after the wait.
+                            if *cancel_rx.borrow() {
+                                break 'outer;
+                            }
+
+                            // Reset inner retry counter and recreate stream.
+                            stream_retries = 0;
+                            stream = NativeVideoStream::new(rtc_track.clone());
+                            #[cfg(target_os = "android")]
+                            android_log(&format!(
+                                "VISIO VIDEO: outer retry — re-created NativeVideoStream track={track_sid}"
+                            ));
+                            tracing::info!(track_sid = %track_sid, "outer retry — re-created NativeVideoStream");
+                            break; // break inner loop to restart
                         }
 
                         // Wait before re-creating the stream — gives the track
@@ -309,6 +382,7 @@ async fn frame_loop(
             }
         }
     }
+    } // 'outer
 
     tracing::info!(track_sid = %track_sid, "frame_loop exited");
 }

--- a/ios/VisioMobile/Views/VideoLayerView.swift
+++ b/ios/VisioMobile/Views/VideoLayerView.swift
@@ -58,9 +58,11 @@ class VideoDisplayView: UIView, @unchecked Sendable {
     }
 
     func enqueueSampleBuffer(_ sampleBuffer: CMSampleBuffer) {
-        guard let layer = displayLayer else { return }
+        guard var layer = displayLayer else { return }
         if layer.status == .failed {
-            layer.flush()
+            setupDisplayLayer()
+            guard let newLayer = displayLayer else { return }
+            layer = newLayer
         }
         layer.enqueue(sampleBuffer)
     }


### PR DESCRIPTION
## Summary

Closes #100

### Android — Video freeze (CRITICAL)
Frame loop now retries up to 3 seconds when the surface is destroyed (e.g. during rotation) instead of exiting permanently. The loop detects surface recovery and resumes rendering.

### Android — Orientation distortion
`surfaceChanged()` now calls `detachSurface` + `attachSurface` to force the Rust renderer to re-read the new surface dimensions after rotation.

### Android — Stale pending surfaces
When a new surface is attached for the same track (after rotation), the old pending surface is properly released to avoid attaching a stale surface.

### iOS — Display layer recovery
When `AVSampleBufferDisplayLayer.status == .failed`, the layer is now fully recreated via `setupDisplayLayer()` instead of just flushed. Prevents permanent freeze.

### Desktop — Muted track resume
Added outer retry loop that recreates `NativeVideoStream` after inner retries are exhausted. Prevents permanent freeze when a muted track is unmuted after >5 seconds.

## Platforms

| Fix | Android | iOS | Desktop |
|-----|---------|-----|---------|
| Frame loop auto-retry | ✅ | N/A | ✅ |
| Surface re-attach on rotation | ✅ | N/A | N/A |
| Stale surface cleanup | ✅ | N/A | N/A |
| Display layer recovery | N/A | ✅ | N/A |
| Muted track resume | N/A | N/A | ✅ |

## Test plan

- [ ] Android: join call with camera → video should not freeze
- [ ] Android: rotate phone during call → video resizes correctly
- [ ] iOS: join call → video should not freeze if layer fails
- [ ] Desktop: mute video >5s then unmute → video resumes