### PR TITLE
feat: display room name from ?room-display-name= query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Room display name via `?room-display-name=` URL param
+  or manual input (#113)
+
 ### Changed
 
 - Convert desktop settings from modal to full-page view (#80)

--- a/android/app/src/main/kotlin/io/visio/mobile/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/MainActivity.kt
@@ -43,8 +43,11 @@ class MainActivity : ComponentActivity() {
         val slug = uri.path?.trimStart('/') ?: return null
         if (host.isBlank() || slug.isBlank()) return null
 
+        val displayName = uri.getQueryParameter("room-display-name")
+
         val instances = VisioManager.client.getMeetInstances()
         return if (instances.contains(host)) {
+            VisioManager.pendingDeepLinkDisplayName = displayName
             "https://$host/$slug"
         } else {
             null

--- a/android/app/src/main/kotlin/io/visio/mobile/VisioManager.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/VisioManager.kt
@@ -153,6 +153,9 @@ object VisioManager : VisioEventListener {
     // Deep link: pre-fill room URL on HomeScreen
     var pendingDeepLink: String? by mutableStateOf(null)
 
+    // Room display name from deep link (e.g. ?room-display-name=...)
+    var pendingDeepLinkDisplayName: String? by mutableStateOf(null)
+
     // Test deep link: connect directly with LiveKit URL + token (debug builds only)
     var pendingTestConnect: Triple<String, String, String?>? = null // (livekitUrl, token, mediaFile?)
 

--- a/android/app/src/main/kotlin/io/visio/mobile/navigation/AppNavigation.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/navigation/AppNavigation.kt
@@ -25,17 +25,18 @@ fun AppNavigation() {
         if (VisioManager.pendingTestConnect != null) {
             // Navigate to call with a placeholder URL; CallScreen will use pendingTestConnect
             val encoded = URLEncoder.encode("test://direct-connect", "UTF-8")
-            navController.navigate("call/$encoded?username=test-user")
+            navController.navigate("call/$encoded?username=test-user&roomDisplayName=")
         }
     }
 
     NavHost(navController = navController, startDestination = "home") {
         composable("home") {
             HomeScreen(
-                onJoin = { roomUrl, username ->
+                onJoin = { roomUrl, username, roomDisplayName ->
                     val encoded = URLEncoder.encode(roomUrl, "UTF-8")
                     val encodedName = URLEncoder.encode(username.ifBlank { "" }, "UTF-8")
-                    navController.navigate("lobby/$encoded?username=$encodedName")
+                    val encodedDisplayName = URLEncoder.encode(roomDisplayName ?: "", "UTF-8")
+                    navController.navigate("lobby/$encoded?username=$encodedName&roomDisplayName=$encodedDisplayName")
                 },
                 onSettings = {
                     navController.navigate("settings")
@@ -44,11 +45,15 @@ fun AppNavigation() {
         }
 
         composable(
-            route = "lobby/{roomUrl}?username={username}",
+            route = "lobby/{roomUrl}?username={username}&roomDisplayName={roomDisplayName}",
             arguments =
                 listOf(
                     navArgument("roomUrl") { type = NavType.StringType },
                     navArgument("username") {
+                        type = NavType.StringType
+                        defaultValue = ""
+                    },
+                    navArgument("roomDisplayName") {
                         type = NavType.StringType
                         defaultValue = ""
                     },
@@ -64,13 +69,20 @@ fun AppNavigation() {
                     backStackEntry.arguments?.getString("username") ?: "",
                     "UTF-8",
                 )
+            val roomDisplayName =
+                URLDecoder.decode(
+                    backStackEntry.arguments?.getString("roomDisplayName") ?: "",
+                    "UTF-8",
+                ).ifBlank { null }
             PreJoinScreen(
                 roomUrl = roomUrl,
                 initialUsername = username,
+                roomDisplayName = roomDisplayName,
                 onJoin = { finalUsername ->
                     val enc = URLEncoder.encode(roomUrl, "UTF-8")
                     val encName = URLEncoder.encode(finalUsername.ifBlank { "" }, "UTF-8")
-                    navController.navigate("call/$enc?username=$encName") {
+                    val encDisplayName = URLEncoder.encode(roomDisplayName ?: "", "UTF-8")
+                    navController.navigate("call/$enc?username=$encName&roomDisplayName=$encDisplayName") {
                         popUpTo("home")
                     }
                 },
@@ -79,11 +91,15 @@ fun AppNavigation() {
         }
 
         composable(
-            route = "call/{roomUrl}?username={username}",
+            route = "call/{roomUrl}?username={username}&roomDisplayName={roomDisplayName}",
             arguments =
                 listOf(
                     navArgument("roomUrl") { type = NavType.StringType },
                     navArgument("username") {
+                        type = NavType.StringType
+                        defaultValue = ""
+                    },
+                    navArgument("roomDisplayName") {
                         type = NavType.StringType
                         defaultValue = ""
                     },
@@ -99,9 +115,15 @@ fun AppNavigation() {
                     backStackEntry.arguments?.getString("username") ?: "",
                     "UTF-8",
                 )
+            val roomDisplayName =
+                URLDecoder.decode(
+                    backStackEntry.arguments?.getString("roomDisplayName") ?: "",
+                    "UTF-8",
+                ).ifBlank { null }
             CallScreen(
                 roomUrl = roomUrl,
                 username = username,
+                roomDisplayName = roomDisplayName,
                 onNavigateToChat = { navController.navigate("chat") },
                 onHangUp = {
                     navController.popBackStack("home", inclusive = false)

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
@@ -476,6 +476,7 @@ private fun toggleCamera(
 fun CallScreen(
     roomUrl: String,
     username: String,
+    roomDisplayName: String? = null,
     onNavigateToChat: () -> Unit,
     onHangUp: () -> Unit,
 ) {
@@ -760,6 +761,7 @@ fun CallScreen(
     if (showInCallSettings) {
         InCallSettingsSheet(
             roomUrl = roomUrl,
+            roomName = roomDisplayName,
             initialTab = inCallSettingsTab,
             onDismiss = { showInCallSettings = false },
             onSelectAudioInput = { device -> VisioManager.setAudioInputDevice(device) },
@@ -783,6 +785,16 @@ fun CallScreen(
         Column(modifier = Modifier.fillMaxSize().statusBarsPadding().navigationBarsPadding()) {
             // Connection state banner
             ConnectionStateBanner(connectionState, errorMessage)
+
+            // Room display name header
+            if (roomDisplayName != null) {
+                Text(
+                    text = roomDisplayName,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = VisioColors.White.copy(alpha = 0.7f),
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                )
+            }
 
             // Compute layout decision for rendering
             val localSid = participants.firstOrNull()?.sid ?: ""

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/HomeScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/HomeScreen.kt
@@ -86,14 +86,15 @@ private const val TAG = "HomeScreen"
 
 @Composable
 fun HomeScreen(
-    onJoin: (roomUrl: String, username: String) -> Unit,
+    onJoin: (roomUrl: String, username: String, roomDisplayName: String?) -> Unit,
     onSettings: () -> Unit,
 ) {
     val context = LocalContext.current
     var roomUrl by remember { mutableStateOf("") }
     var resolvedRoomUrl by remember { mutableStateOf("") }
     var username by remember { mutableStateOf("") }
-    var roomHistory by remember { mutableStateOf(listOf<String>()) }
+    var roomDisplayName by remember { mutableStateOf("") }
+    var roomHistory by remember { mutableStateOf(listOf<uniffi.visio.RoomHistoryEntry>()) }
     val lang = VisioManager.currentLang
     val isDark = VisioManager.currentTheme == "dark"
     var roomStatus by remember { mutableStateOf("idle") }
@@ -122,6 +123,7 @@ fun HomeScreen(
         onRoomStatusChange = { roomStatus = it },
         onResolvedRoomUrlChange = { resolvedRoomUrl = it },
         onUsernameChange = { username = it },
+        onRoomDisplayNameChange = { roomDisplayName = it },
     )
 
     val nowSeconds = System.currentTimeMillis() / 1000L
@@ -173,6 +175,7 @@ fun HomeScreen(
             selectedTab = selectedTab,
             roomUrl = roomUrl,
             username = username,
+            roomDisplayName = roomDisplayName,
             roomStatus = roomStatus,
             resolvedRoomUrl = resolvedRoomUrl,
             isDark = isDark,
@@ -185,6 +188,7 @@ fun HomeScreen(
             coroutineScope = coroutineScope,
             onRoomUrlChange = { roomUrl = it },
             onUsernameChange = { username = it },
+            onRoomDisplayNameChange = { roomDisplayName = it },
             onJoin = onJoin,
             onShowCreateRoom = { showCreateRoom = true },
             onHistoryJoiningChange = { historyJoining = it },
@@ -198,7 +202,7 @@ fun HomeScreen(
             lang = lang,
             onCreated = { url ->
                 showCreateRoom = false
-                onJoin(url, username)
+                onJoin(url, username, null)
             },
             onDismiss = { showCreateRoom = false },
         )
@@ -212,13 +216,14 @@ private fun HomeScreenEffects(
     username: String,
     slugRegex: Regex,
     meetInstances: List<String>,
-    onRoomHistoryLoaded: (List<String>) -> Unit,
+    onRoomHistoryLoaded: (List<uniffi.visio.RoomHistoryEntry>) -> Unit,
     onHasCalendarUrlChange: (Boolean) -> Unit,
     onRoomUrlChange: (String) -> Unit,
     onMeetInstancesLoaded: (List<String>) -> Unit,
     onRoomStatusChange: (String) -> Unit,
     onResolvedRoomUrlChange: (String) -> Unit,
     onUsernameChange: (String) -> Unit,
+    onRoomDisplayNameChange: (String) -> Unit,
 ) {
     LaunchedEffect(Unit) {
         try {
@@ -248,6 +253,11 @@ private fun HomeScreenEffects(
         if (link != null) {
             onRoomUrlChange(link)
             VisioManager.pendingDeepLink = null
+            val displayName = VisioManager.pendingDeepLinkDisplayName
+            if (displayName != null) {
+                onRoomDisplayNameChange(displayName)
+                VisioManager.pendingDeepLinkDisplayName = null
+            }
         }
     }
 
@@ -479,11 +489,12 @@ private fun ColumnScope.HomeTabContent(
     selectedTab: Int,
     roomUrl: String,
     username: String,
+    roomDisplayName: String,
     roomStatus: String,
     resolvedRoomUrl: String,
     isDark: Boolean,
     lang: String,
-    roomHistory: List<String>,
+    roomHistory: List<uniffi.visio.RoomHistoryEntry>,
     historyJoining: String?,
     upcomingMeetings: List<uniffi.visio.Meeting>,
     hasCalendarUrl: Boolean,
@@ -491,7 +502,8 @@ private fun ColumnScope.HomeTabContent(
     coroutineScope: kotlinx.coroutines.CoroutineScope,
     onRoomUrlChange: (String) -> Unit,
     onUsernameChange: (String) -> Unit,
-    onJoin: (roomUrl: String, username: String) -> Unit,
+    onRoomDisplayNameChange: (String) -> Unit,
+    onJoin: (roomUrl: String, username: String, roomDisplayName: String?) -> Unit,
     onShowCreateRoom: () -> Unit,
     onHistoryJoiningChange: (String?) -> Unit,
     onSettings: () -> Unit,
@@ -503,6 +515,8 @@ private fun ColumnScope.HomeTabContent(
                 onRoomUrlChange = onRoomUrlChange,
                 username = username,
                 onUsernameChange = onUsernameChange,
+                roomDisplayName = roomDisplayName,
+                onRoomDisplayNameChange = onRoomDisplayNameChange,
                 roomStatus = roomStatus,
                 resolvedRoomUrl = resolvedRoomUrl,
                 isDark = isDark,
@@ -512,13 +526,14 @@ private fun ColumnScope.HomeTabContent(
                 historyJoining = historyJoining,
                 onJoin = onJoin,
                 onShowCreateRoom = onShowCreateRoom,
-                onHistoryClick = { url ->
-                    onRoomUrlChange(url)
-                    onHistoryJoiningChange(url)
+                onHistoryClick = { entry ->
+                    onRoomUrlChange(entry.url)
+                    onHistoryJoiningChange(entry.url)
                     coroutineScope.launch {
                         handleHistoryJoin(
-                            url,
+                            entry.url,
                             username,
+                            entry.displayName,
                             onJoin,
                             onHistoryJoiningChange,
                         )
@@ -535,7 +550,7 @@ private fun ColumnScope.HomeTabContent(
                 lang = lang,
                 onSettings = onSettings,
                 onJoinMeeting = { meetingRoomUrl, _ ->
-                    onJoin(meetingRoomUrl, username.trim())
+                    onJoin(meetingRoomUrl, username.trim(), null)
                 },
             )
         }
@@ -545,7 +560,8 @@ private fun ColumnScope.HomeTabContent(
 private suspend fun handleHistoryJoin(
     url: String,
     username: String,
-    onJoin: (String, String) -> Unit,
+    roomDisplayName: String?,
+    onJoin: (String, String, String?) -> Unit,
     onHistoryJoiningChange: (String?) -> Unit,
 ) {
     try {
@@ -556,7 +572,7 @@ private suspend fun handleHistoryJoin(
             }
         if (result is RoomValidationResult.Valid) {
             onHistoryJoiningChange(null)
-            onJoin(url, username.trim())
+            onJoin(url, username.trim(), roomDisplayName)
         } else {
             onHistoryJoiningChange(null)
         }
@@ -667,16 +683,18 @@ private fun JoinTab(
     onRoomUrlChange: (String) -> Unit,
     username: String,
     onUsernameChange: (String) -> Unit,
+    roomDisplayName: String,
+    onRoomDisplayNameChange: (String) -> Unit,
     roomStatus: String,
     resolvedRoomUrl: String,
     isDark: Boolean,
     lang: String,
     isAuthenticated: Boolean,
-    roomHistory: List<String>,
+    roomHistory: List<uniffi.visio.RoomHistoryEntry>,
     historyJoining: String?,
-    onJoin: (roomUrl: String, username: String) -> Unit,
+    onJoin: (roomUrl: String, username: String, roomDisplayName: String?) -> Unit,
     onShowCreateRoom: () -> Unit,
-    onHistoryClick: (String) -> Unit,
+    onHistoryClick: (uniffi.visio.RoomHistoryEntry) -> Unit,
 ) {
     Column(
         modifier =
@@ -764,10 +782,32 @@ private fun JoinTab(
             shape = RoundedCornerShape(12.dp),
         )
 
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = roomDisplayName,
+            onValueChange = onRoomDisplayNameChange,
+            label = {
+                Text(
+                    Strings.t("home.roomDisplayName", lang),
+                    color = if (isDark) VisioColors.Greyscale400 else VisioColors.LightTextSecondary,
+                )
+            },
+            placeholder = {
+                Text(
+                    Strings.t("home.roomDisplayNamePlaceholder", lang),
+                    color = if (isDark) VisioColors.Greyscale400 else VisioColors.LightTextSecondary,
+                )
+            },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+        )
+
         Spacer(modifier = Modifier.height(24.dp))
 
         Button(
-            onClick = { onJoin(resolvedRoomUrl, username.trim()) },
+            onClick = { onJoin(resolvedRoomUrl, username.trim(), roomDisplayName.trim().ifBlank { null }) },
             enabled = roomStatus == "valid",
             modifier = Modifier.fillMaxWidth().testTag("home_join_button"),
             colors =
@@ -849,11 +889,11 @@ private fun RoomStatusIndicator(
 
 @Composable
 private fun RoomHistoryList(
-    roomHistory: List<String>,
+    roomHistory: List<uniffi.visio.RoomHistoryEntry>,
     historyJoining: String?,
     isDark: Boolean,
     lang: String,
-    onHistoryClick: (String) -> Unit,
+    onHistoryClick: (uniffi.visio.RoomHistoryEntry) -> Unit,
 ) {
     Spacer(modifier = Modifier.height(24.dp))
     Text(
@@ -863,11 +903,11 @@ private fun RoomHistoryList(
         modifier = Modifier.fillMaxWidth(),
     )
     Spacer(modifier = Modifier.height(8.dp))
-    roomHistory.forEachIndexed { index, url ->
+    roomHistory.forEachIndexed { index, entry ->
         RoomHistoryItem(
-            url = url,
+            entry = entry,
             index = index,
-            isJoining = historyJoining == url,
+            isJoining = historyJoining == entry.url,
             isEnabled = historyJoining == null,
             isDark = isDark,
             onHistoryClick = onHistoryClick,
@@ -878,13 +918,14 @@ private fun RoomHistoryList(
 
 @Composable
 private fun RoomHistoryItem(
-    url: String,
+    entry: uniffi.visio.RoomHistoryEntry,
     index: Int,
     isJoining: Boolean,
     isEnabled: Boolean,
     isDark: Boolean,
-    onHistoryClick: (String) -> Unit,
+    onHistoryClick: (uniffi.visio.RoomHistoryEntry) -> Unit,
 ) {
+    val url = entry.url
     val slug = if ('/' in url) url.substringAfterLast('/') else url
     val host =
         try {
@@ -897,7 +938,7 @@ private fun RoomHistoryItem(
             Modifier
                 .fillMaxWidth()
                 .testTag("home_room_history_item_$index")
-                .clickable(enabled = isEnabled) { onHistoryClick(url) }
+                .clickable(enabled = isEnabled) { onHistoryClick(entry) }
                 .background(
                     VisioColors.Primary500.copy(alpha = if (isDark) 0.12f else 0.08f),
                     RoundedCornerShape(8.dp),
@@ -921,18 +962,33 @@ private fun RoomHistoryItem(
             )
         }
         Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = slug,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            if (host.isNotEmpty()) {
+            val displayName = entry.displayName
+            if (displayName != null) {
                 Text(
-                    text = host,
+                    text = displayName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = if (host.isNotEmpty()) "$slug · $host" else slug,
                     style = MaterialTheme.typography.bodySmall,
                     color = if (isDark) VisioColors.Greyscale400 else VisioColors.LightTextSecondary,
                 )
+            } else {
+                Text(
+                    text = slug,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                if (host.isNotEmpty()) {
+                    Text(
+                        text = host,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (isDark) VisioColors.Greyscale400 else VisioColors.LightTextSecondary,
+                    )
+                }
             }
         }
     }

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/InCallSettingsSheet.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/InCallSettingsSheet.kt
@@ -87,6 +87,7 @@ import uniffi.visio.UserSearchResult
 @Composable
 fun InCallSettingsSheet(
     roomUrl: String,
+    roomName: String? = null,
     initialTab: Int = 0,
     onDismiss: () -> Unit,
     onSelectAudioInput: (AudioDeviceInfo) -> Unit,
@@ -178,7 +179,7 @@ fun InCallSettingsSheet(
                         .padding(start = 8.dp, end = 8.dp, bottom = 32.dp),
             ) {
                 when (selectedTab) {
-                    0 -> RoomInfoTab(roomUrl, lang)
+                    0 -> RoomInfoTab(roomUrl, roomName, lang)
                     1 -> MicroTab(context, lang, onSelectAudioInput, onSelectAudioOutput)
                     2 -> CameraTab(lang, isFrontCamera, onSwitchCamera)
                     3 ->
@@ -679,11 +680,25 @@ private fun NotificationRow(
 @Composable
 private fun RoomInfoTab(
     roomUrl: String,
+    roomName: String?,
     lang: String,
 ) {
     val context = LocalContext.current
     val displayUrl = roomUrl.removePrefix("https://").removePrefix("http://")
-    val deepLink = "visio://$displayUrl"
+    val deepLink =
+        if (roomName != null) {
+            val encoded = java.net.URLEncoder.encode(roomName, "UTF-8").replace("+", "%20")
+            "visio://$displayUrl?room-display-name=$encoded"
+        } else {
+            "visio://$displayUrl"
+        }
+    val shareHttpUrl =
+        if (roomName != null) {
+            val encoded = java.net.URLEncoder.encode(roomName, "UTF-8").replace("+", "%20")
+            "$roomUrl?room-display-name=$encoded"
+        } else {
+            roomUrl
+        }
     var copiedHttp by remember { mutableStateOf(false) }
     var copiedDeep by remember { mutableStateOf(false) }
 
@@ -703,7 +718,7 @@ private fun RoomInfoTab(
             )
             IconButton(onClick = {
                 val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-                clipboard.setPrimaryClip(android.content.ClipData.newPlainText("Room URL", roomUrl))
+                clipboard.setPrimaryClip(android.content.ClipData.newPlainText("Room URL", shareHttpUrl))
                 copiedHttp = true
             }, modifier = Modifier.size(32.dp).testTag("incall_room_url_copy")) {
                 Icon(
@@ -717,7 +732,7 @@ private fun RoomInfoTab(
                 val shareIntent =
                     android.content.Intent(android.content.Intent.ACTION_SEND).apply {
                         type = "text/plain"
-                        putExtra(android.content.Intent.EXTRA_TEXT, roomUrl)
+                        putExtra(android.content.Intent.EXTRA_TEXT, shareHttpUrl)
                     }
                 context.startActivity(android.content.Intent.createChooser(shareIntent, null))
             }, modifier = Modifier.size(32.dp)) {
@@ -730,7 +745,7 @@ private fun RoomInfoTab(
             }
         }
         OutlinedTextField(
-            value = roomUrl,
+            value = shareHttpUrl,
             onValueChange = {},
             readOnly = true,
             singleLine = true,
@@ -772,7 +787,7 @@ private fun RoomInfoTab(
                 val shareIntent =
                     android.content.Intent(android.content.Intent.ACTION_SEND).apply {
                         type = "text/plain"
-                        putExtra(android.content.Intent.EXTRA_TEXT, roomUrl)
+                        putExtra(android.content.Intent.EXTRA_TEXT, deepLink)
                     }
                 context.startActivity(android.content.Intent.createChooser(shareIntent, null))
             }, modifier = Modifier.size(32.dp)) {

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/PreJoinScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/PreJoinScreen.kt
@@ -291,6 +291,7 @@ class LocalCameraPreview(
 fun PreJoinScreen(
     roomUrl: String,
     initialUsername: String,
+    roomDisplayName: String? = null,
     onJoin: (finalUsername: String) -> Unit,
     onCancel: () -> Unit,
 ) {
@@ -596,12 +597,28 @@ fun PreJoinScreen(
         // Top bar
         TopAppBar(
             title = {
-                Text(
-                    text = roomSlug,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    fontWeight = FontWeight.Medium,
-                )
+                if (roomDisplayName != null) {
+                    Column {
+                        Text(
+                            text = roomDisplayName,
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            fontWeight = FontWeight.Medium,
+                        )
+                        Text(
+                            text = roomSlug,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                        )
+                    }
+                } else {
+                    Text(
+                        text = roomSlug,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
             },
             navigationIcon = {
                 IconButton(onClick = onCancel) {

--- a/crates/visio-core/src/auth.rs
+++ b/crates/visio-core/src/auth.rs
@@ -113,6 +113,11 @@ impl AuthService {
         } else {
             input
         };
+        let candidate = if candidate.contains('?') {
+            candidate.split('?').next().unwrap_or("")
+        } else {
+            candidate
+        };
         let re =
             SLUG_RE.get_or_init(|| regex::Regex::new(r"^[a-z]{3}-[a-z]{4}-[a-z]{3}$").unwrap());
         if re.is_match(candidate) {
@@ -142,11 +147,8 @@ impl AuthService {
 
     /// Parse a Meet URL into (instance, room_slug).
     pub fn parse_meet_url(url: &str) -> Result<(String, String), VisioError> {
-        let url = url
-            .trim()
-            .trim_end_matches('/')
-            .replace("https://", "")
-            .replace("http://", "");
+        let url = crate::strip_room_display_name_param(url.trim().trim_end_matches('/'));
+        let url = url.replace("https://", "").replace("http://", "");
 
         let parts: Vec<&str> = url.splitn(2, '/').collect();
         if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
@@ -215,6 +217,25 @@ mod tests {
     #[test]
     fn extract_slug_from_url_with_trailing_slash() {
         let slug = AuthService::extract_slug("https://meet.example.com/abc-defg-hij/").unwrap();
+        assert_eq!(slug, "abc-defg-hij");
+    }
+
+    #[test]
+    fn parse_meet_url_strips_display_name_param() {
+        let (instance, slug) = AuthService::parse_meet_url(
+            "https://meet.example.com/abc-defg-hij?room-display-name=Comex",
+        )
+        .unwrap();
+        assert_eq!(instance, "meet.example.com");
+        assert_eq!(slug, "abc-defg-hij");
+    }
+
+    #[test]
+    fn extract_slug_with_query_param() {
+        let slug = AuthService::extract_slug(
+            "https://meet.example.com/abc-defg-hij?room-display-name=Test",
+        )
+        .unwrap();
         assert_eq!(slug, "abc-defg-hij");
     }
 }

--- a/crates/visio-core/src/lib.rs
+++ b/crates/visio-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod hand_raise;
 pub mod lobby;
 pub mod participants;
 pub mod room;
+pub mod room_display_name;
 pub mod session;
 pub mod settings;
 
@@ -37,5 +38,8 @@ pub use hand_raise::HandRaiseManager;
 pub use lobby::{LobbyPollResult, LobbyService, LobbyStatus, WaitingParticipant};
 pub use participants::ParticipantManager;
 pub use room::RoomManager;
+pub use room_display_name::{
+    extract_room_display_name, strip_room_display_name_param, validate_room_display_name,
+};
 pub use session::{CreateRoomLiveKit, CreateRoomResponse, SessionManager, SessionState, UserInfo};
 pub use settings::{CalendarRefreshInterval, Settings, SettingsStore};

--- a/crates/visio-core/src/room_display_name.rs
+++ b/crates/visio-core/src/room_display_name.rs
@@ -1,0 +1,278 @@
+//! Room display name validation and URL helpers.
+//!
+//! Provides sanitization of user-supplied display names and extraction
+//! from LiveKit join URLs.
+
+/// Validates and sanitizes a room display name.
+///
+/// Trims leading/trailing whitespace, collapses internal runs of whitespace
+/// to a single space, then checks:
+/// - non-empty after trimming
+/// - at most 80 Unicode scalar values
+/// - no forbidden characters: `< > " ' \` ; & \ / { }`
+/// - no ASCII control characters
+/// - no Unicode bidirectional override characters (U+202A–U+202E, U+2066–U+2069)
+///
+/// Returns `Some(sanitized)` on success, `None` on any violation.
+pub fn validate_room_display_name(raw: &str) -> Option<String> {
+    // Reject control characters before any normalization so that e.g. \n is
+    // caught even though split_whitespace would otherwise consume it.
+    if raw.chars().any(|c| c.is_control()) {
+        return None;
+    }
+    let trimmed: String = raw.split_whitespace().collect::<Vec<&str>>().join(" ");
+    if trimmed.is_empty() || trimmed.chars().count() > 80 {
+        return None;
+    }
+    const FORBIDDEN: &[char] = &['<', '>', '"', '\'', '`', ';', '&', '\\', '/', '{', '}'];
+    if trimmed.chars().any(|c| FORBIDDEN.contains(&c)) {
+        return None;
+    }
+    if trimmed
+        .chars()
+        .any(|c| matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}'))
+    {
+        return None;
+    }
+    Some(trimmed)
+}
+
+/// Extracts and validates the `room-display-name` query parameter from a URL.
+///
+/// Percent-decodes the value, then passes it through [`validate_room_display_name`].
+/// Returns `None` if the parameter is absent, empty, or fails validation.
+pub fn extract_room_display_name(url: &str) -> Option<String> {
+    let query_start = url.find('?')?;
+    let query = &url[query_start + 1..];
+    for pair in query.split('&') {
+        let mut kv = pair.splitn(2, '=');
+        let key = kv.next().unwrap_or("");
+        let value = kv.next().unwrap_or("");
+        if key == "room-display-name" {
+            let decoded = urlencoding::decode(value).ok()?;
+            return validate_room_display_name(&decoded);
+        }
+    }
+    None
+}
+
+/// Removes the `room-display-name` query parameter from a URL.
+///
+/// All other query parameters are preserved. If removing the parameter
+/// leaves no query string, the `?` is also removed.
+pub fn strip_room_display_name_param(url: &str) -> String {
+    let Some(query_start) = url.find('?') else {
+        return url.to_string();
+    };
+    let base = &url[..query_start];
+    let query = &url[query_start + 1..];
+    let remaining: Vec<&str> = query
+        .split('&')
+        .filter(|pair| {
+            let key = pair.split('=').next().unwrap_or("");
+            key != "room-display-name"
+        })
+        .collect();
+    if remaining.is_empty() {
+        base.to_string()
+    } else {
+        format!("{}?{}", base, remaining.join("&"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- validate_room_display_name ---
+
+    #[test]
+    fn validate_simple_name() {
+        assert_eq!(
+            validate_room_display_name("Alice"),
+            Some("Alice".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_trims_whitespace() {
+        assert_eq!(
+            validate_room_display_name("  Bob  "),
+            Some("Bob".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_collapses_internal_spaces() {
+        assert_eq!(
+            validate_room_display_name("Alice   Bob"),
+            Some("Alice Bob".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_empty_returns_none() {
+        assert_eq!(validate_room_display_name(""), None);
+    }
+
+    #[test]
+    fn validate_whitespace_only_returns_none() {
+        assert_eq!(validate_room_display_name("   "), None);
+    }
+
+    #[test]
+    fn validate_too_long_returns_none() {
+        // 81 ASCII chars → None
+        let name = "a".repeat(81);
+        assert_eq!(validate_room_display_name(&name), None);
+    }
+
+    #[test]
+    fn validate_max_length_ok() {
+        // exactly 80 ASCII chars → Some
+        let name = "a".repeat(80);
+        assert_eq!(validate_room_display_name(&name), Some(name));
+    }
+
+    #[test]
+    fn validate_multibyte_80_chars_ok() {
+        // 80 × 'é' (U+00E9, 2 UTF-8 bytes each) → Some
+        let name: String = std::iter::repeat('é').take(80).collect();
+        assert_eq!(validate_room_display_name(&name), Some(name));
+    }
+
+    #[test]
+    fn validate_multibyte_81_chars_none() {
+        // 81 × 'é' → None
+        let name: String = std::iter::repeat('é').take(81).collect();
+        assert_eq!(validate_room_display_name(&name), None);
+    }
+
+    #[test]
+    fn validate_rejects_angle_brackets() {
+        assert_eq!(validate_room_display_name("<script>"), None);
+    }
+
+    #[test]
+    fn validate_rejects_all_forbidden_chars() {
+        for &ch in &['<', '>', '"', '\'', '`', ';', '&', '\\', '/', '{', '}'] {
+            let input = format!("Alice{}Bob", ch);
+            assert_eq!(
+                validate_room_display_name(&input),
+                None,
+                "expected None for char {:?}",
+                ch
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_control_chars() {
+        // U+0001 is a control character
+        assert_eq!(validate_room_display_name("Alice\x01Bob"), None);
+        // newline is also a control char
+        assert_eq!(validate_room_display_name("Alice\nBob"), None);
+    }
+
+    #[test]
+    fn validate_rejects_rtl_override() {
+        // U+202E RIGHT-TO-LEFT OVERRIDE
+        let input = format!("Alice\u{202E}Bob");
+        assert_eq!(validate_room_display_name(&input), None);
+        // U+2066 LEFT-TO-RIGHT ISOLATE
+        let input2 = format!("Alice\u{2066}Bob");
+        assert_eq!(validate_room_display_name(&input2), None);
+    }
+
+    #[test]
+    fn validate_allows_unicode_letters() {
+        // Arabic, CJK, accented Latin — all fine
+        assert!(validate_room_display_name("مرحبا").is_some());
+        assert!(validate_room_display_name("こんにちは").is_some());
+        assert!(validate_room_display_name("Ångström").is_some());
+    }
+
+    #[test]
+    fn validate_allows_parens_and_hyphens() {
+        assert_eq!(
+            validate_room_display_name("Alice (Team-A)"),
+            Some("Alice (Team-A)".to_string())
+        );
+    }
+
+    // --- extract_room_display_name ---
+
+    #[test]
+    fn extract_present_percent_encoded() {
+        let url = "https://meet.example.com/room?room-display-name=Hello%20World&token=abc";
+        assert_eq!(
+            extract_room_display_name(url),
+            Some("Hello World".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_absent_returns_none() {
+        let url = "https://meet.example.com/room?token=abc";
+        assert_eq!(extract_room_display_name(url), None);
+    }
+
+    #[test]
+    fn extract_empty_value_returns_none() {
+        let url = "https://meet.example.com/room?room-display-name=&token=abc";
+        assert_eq!(extract_room_display_name(url), None);
+    }
+
+    #[test]
+    fn extract_invalid_value_xss_returns_none() {
+        let url = "https://meet.example.com/room?room-display-name=%3Cscript%3E";
+        assert_eq!(extract_room_display_name(url), None);
+    }
+
+    #[test]
+    fn extract_with_other_params() {
+        let url = "https://meet.example.com/room?token=abc&room-display-name=Bob&theme=dark";
+        assert_eq!(extract_room_display_name(url), Some("Bob".to_string()));
+    }
+
+    // --- strip_room_display_name_param ---
+
+    #[test]
+    fn strip_removes_param() {
+        let url = "https://meet.example.com/room?room-display-name=Alice&token=abc";
+        assert_eq!(
+            strip_room_display_name_param(url),
+            "https://meet.example.com/room?token=abc"
+        );
+    }
+
+    #[test]
+    fn strip_preserves_other_params() {
+        let url = "https://meet.example.com/room?token=abc&room-display-name=Alice&theme=dark";
+        assert_eq!(
+            strip_room_display_name_param(url),
+            "https://meet.example.com/room?token=abc&theme=dark"
+        );
+    }
+
+    #[test]
+    fn strip_no_param_unchanged() {
+        let url = "https://meet.example.com/room?token=abc";
+        assert_eq!(strip_room_display_name_param(url), url);
+    }
+
+    #[test]
+    fn strip_only_param_removes_question_mark() {
+        let url = "https://meet.example.com/room?room-display-name=Alice";
+        assert_eq!(
+            strip_room_display_name_param(url),
+            "https://meet.example.com/room"
+        );
+    }
+
+    #[test]
+    fn strip_no_query_string_unchanged() {
+        let url = "https://meet.example.com/room";
+        assert_eq!(strip_room_display_name_param(url), url);
+    }
+}

--- a/crates/visio-core/src/settings.rs
+++ b/crates/visio-core/src/settings.rs
@@ -1,7 +1,86 @@
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-use serde::{Deserialize, Serialize};
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+use crate::room_display_name::strip_room_display_name_param;
+
+/// A single entry in the room join history.
+///
+/// Supports backward-compatible deserialization: old format stores bare strings,
+/// new format stores `{"url": "...", "display_name": "..."}` objects.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RoomHistoryEntry {
+    pub url: String,
+    pub display_name: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for RoomHistoryEntry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RoomHistoryEntryVisitor;
+
+        impl<'de> Visitor<'de> for RoomHistoryEntryVisitor {
+            type Value = RoomHistoryEntry;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a string URL or an object with url and optional display_name")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(RoomHistoryEntry {
+                    url: v.to_string(),
+                    display_name: None,
+                })
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(RoomHistoryEntry {
+                    url: v,
+                    display_name: None,
+                })
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::MapAccess<'de>,
+            {
+                let mut url: Option<String> = None;
+                let mut display_name: Option<String> = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "url" => {
+                            url = Some(map.next_value()?);
+                        }
+                        "display_name" => {
+                            display_name = map.next_value()?;
+                        }
+                        _ => {
+                            // Ignore unknown fields
+                            let _ = map.next_value::<Value>()?;
+                        }
+                    }
+                }
+
+                let url = url.ok_or_else(|| de::Error::missing_field("url"))?;
+                Ok(RoomHistoryEntry { url, display_name })
+            }
+        }
+
+        deserializer.deserialize_any(RoomHistoryEntryVisitor)
+    }
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
 pub enum CalendarRefreshInterval {
@@ -40,7 +119,7 @@ pub struct Settings {
     #[serde(default)]
     pub adaptive_mode_enabled: bool,
     #[serde(default)]
-    pub room_history: Vec<String>,
+    pub room_history: Vec<RoomHistoryEntry>,
     #[serde(default = "default_true")]
     pub noise_reduction_enabled: bool,
     /// Preferred audio input device name.
@@ -266,16 +345,35 @@ impl SettingsStore {
         self.save();
     }
 
-    pub fn add_room_to_history(&self, url: String) {
+    pub fn add_room_to_history(&self, url: String, display_name: Option<String>) {
+        let canonical = strip_room_display_name_param(&url);
         let mut s = self.settings.lock().unwrap_or_else(|e| e.into_inner());
-        s.room_history.retain(|u| u != &url);
-        s.room_history.insert(0, url);
+        if let Some(pos) = s.room_history.iter().position(|e| e.url == canonical) {
+            let existing_name = s.room_history[pos].display_name.take();
+            let merged_name = display_name.or(existing_name);
+            s.room_history.remove(pos);
+            s.room_history.insert(
+                0,
+                RoomHistoryEntry {
+                    url: canonical,
+                    display_name: merged_name,
+                },
+            );
+        } else {
+            s.room_history.insert(
+                0,
+                RoomHistoryEntry {
+                    url: canonical,
+                    display_name,
+                },
+            );
+        }
         s.room_history.truncate(10);
         drop(s);
         self.save();
     }
 
-    pub fn get_room_history(&self) -> Vec<String> {
+    pub fn get_room_history(&self) -> Vec<RoomHistoryEntry> {
         self.settings
             .lock()
             .unwrap_or_else(|e| e.into_inner())
@@ -651,14 +749,14 @@ mod tests {
         let dir = temp_dir();
         let store = SettingsStore::new(dir.path().to_str().unwrap());
 
-        store.add_room_to_history("https://meet.example.com/room1".to_string());
-        store.add_room_to_history("https://meet.example.com/room2".to_string());
-        store.add_room_to_history("https://meet.example.com/room1".to_string()); // dedup, moves to front
+        store.add_room_to_history("https://meet.example.com/room1".to_string(), None);
+        store.add_room_to_history("https://meet.example.com/room2".to_string(), None);
+        store.add_room_to_history("https://meet.example.com/room1".to_string(), None); // dedup, moves to front
 
         let history = store.get_room_history();
         assert_eq!(history.len(), 2);
-        assert_eq!(history[0], "https://meet.example.com/room1");
-        assert_eq!(history[1], "https://meet.example.com/room2");
+        assert_eq!(history[0].url, "https://meet.example.com/room1");
+        assert_eq!(history[1].url, "https://meet.example.com/room2");
 
         store.clear_room_history();
         assert!(store.get_room_history().is_empty());
@@ -670,12 +768,12 @@ mod tests {
         let store = SettingsStore::new(dir.path().to_str().unwrap());
 
         for i in 0..15 {
-            store.add_room_to_history(format!("https://meet.example.com/room{i}"));
+            store.add_room_to_history(format!("https://meet.example.com/room{i}"), None);
         }
 
         let history = store.get_room_history();
         assert_eq!(history.len(), 10);
-        assert_eq!(history[0], "https://meet.example.com/room14");
+        assert_eq!(history[0].url, "https://meet.example.com/room14");
     }
 
     #[test]
@@ -684,12 +782,12 @@ mod tests {
         let path = dir.path().to_str().unwrap();
         {
             let store = SettingsStore::new(path);
-            store.add_room_to_history("https://meet.example.com/room1".to_string());
+            store.add_room_to_history("https://meet.example.com/room1".to_string(), None);
         }
         let store = SettingsStore::new(path);
         let history = store.get_room_history();
         assert_eq!(history.len(), 1);
-        assert_eq!(history[0], "https://meet.example.com/room1");
+        assert_eq!(history[0].url, "https://meet.example.com/room1");
     }
 
     #[test]
@@ -852,5 +950,132 @@ mod tests {
             s.calendar_refresh_interval,
             CalendarRefreshInterval::Minutes15
         );
+    }
+
+    // --- RoomHistoryEntry and migration tests ---
+
+    #[test]
+    fn room_history_entry_round_trip() {
+        let entry = RoomHistoryEntry {
+            url: "https://meet.example.com/room".to_string(),
+            display_name: Some("My Room".to_string()),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let decoded: RoomHistoryEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.url, "https://meet.example.com/room");
+        assert_eq!(decoded.display_name, Some("My Room".to_string()));
+    }
+
+    #[test]
+    fn room_history_entry_without_name() {
+        let entry = RoomHistoryEntry {
+            url: "https://meet.example.com/room".to_string(),
+            display_name: None,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let decoded: RoomHistoryEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.url, "https://meet.example.com/room");
+        assert_eq!(decoded.display_name, None);
+    }
+
+    #[test]
+    fn room_history_migrates_old_string_format() {
+        let dir = temp_dir();
+        let path = dir.path().to_str().unwrap();
+        fs::write(
+            dir.path().join("settings.json"),
+            r#"{"room_history": ["https://meet.example.com/room1", "https://meet.example.com/room2"]}"#,
+        )
+        .unwrap();
+        let store = SettingsStore::new(path);
+        let history = store.get_room_history();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].url, "https://meet.example.com/room1");
+        assert_eq!(history[0].display_name, None);
+        assert_eq!(history[1].url, "https://meet.example.com/room2");
+        assert_eq!(history[1].display_name, None);
+    }
+
+    #[test]
+    fn room_history_new_format() {
+        let dir = temp_dir();
+        let path = dir.path().to_str().unwrap();
+        fs::write(
+            dir.path().join("settings.json"),
+            r#"{"room_history": [{"url": "https://meet.example.com/room", "display_name": "My Room"}]}"#,
+        )
+        .unwrap();
+        let store = SettingsStore::new(path);
+        let history = store.get_room_history();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].url, "https://meet.example.com/room");
+        assert_eq!(history[0].display_name, Some("My Room".to_string()));
+    }
+
+    #[test]
+    fn room_history_mixed_format() {
+        let dir = temp_dir();
+        let path = dir.path().to_str().unwrap();
+        fs::write(
+            dir.path().join("settings.json"),
+            r#"{"room_history": ["https://meet.example.com/room1", {"url": "https://meet.example.com/room2", "display_name": "Room Two"}]}"#,
+        )
+        .unwrap();
+        let store = SettingsStore::new(path);
+        let history = store.get_room_history();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].url, "https://meet.example.com/room1");
+        assert_eq!(history[0].display_name, None);
+        assert_eq!(history[1].url, "https://meet.example.com/room2");
+        assert_eq!(history[1].display_name, Some("Room Two".to_string()));
+    }
+
+    #[test]
+    fn add_room_updates_display_name() {
+        let dir = temp_dir();
+        let store = SettingsStore::new(dir.path().to_str().unwrap());
+        store.add_room_to_history(
+            "https://meet.example.com/room".to_string(),
+            Some("Old Name".to_string()),
+        );
+        store.add_room_to_history(
+            "https://meet.example.com/room".to_string(),
+            Some("New Name".to_string()),
+        );
+        let history = store.get_room_history();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].url, "https://meet.example.com/room");
+        assert_eq!(history[0].display_name, Some("New Name".to_string()));
+    }
+
+    #[test]
+    fn add_room_without_name_preserves_existing() {
+        let dir = temp_dir();
+        let store = SettingsStore::new(dir.path().to_str().unwrap());
+        store.add_room_to_history(
+            "https://meet.example.com/room".to_string(),
+            Some("Keep Me".to_string()),
+        );
+        store.add_room_to_history("https://meet.example.com/room".to_string(), None);
+        let history = store.get_room_history();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].url, "https://meet.example.com/room");
+        assert_eq!(history[0].display_name, Some("Keep Me".to_string()));
+    }
+
+    #[test]
+    fn add_room_caps_at_10() {
+        let dir = temp_dir();
+        let store = SettingsStore::new(dir.path().to_str().unwrap());
+        for i in 0..12 {
+            store.add_room_to_history(
+                format!("https://meet.example.com/room{i}"),
+                Some(format!("Room {i}")),
+            );
+        }
+        let history = store.get_room_history();
+        assert_eq!(history.len(), 10);
+        assert_eq!(history[0].url, "https://meet.example.com/room11");
+        assert_eq!(history[0].display_name, Some("Room 11".to_string()));
     }
 }

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -155,6 +155,11 @@ interface Meeting {
   server_name: string
 }
 
+interface RoomHistoryEntry {
+  url: string
+  display_name: string | null
+}
+
 interface ReactionData {
   id: number
   participantSid: string
@@ -815,12 +820,13 @@ function HomeView({
   const t = useT()
   const [activeTab, setActiveTab] = useState<'join' | 'meetings'>('join')
   const [meetUrl, setMeetUrl] = useState('')
+  const [roomDisplayName, setRoomDisplayName] = useState('')
   const [resolvedUrl, setResolvedUrl] = useState('')
-  const [roomHistory, setRoomHistory] = useState<string[]>([])
+  const [roomHistory, setRoomHistory] = useState<RoomHistoryEntry[]>([])
   const [meetingCount, setMeetingCount] = useState(0)
 
   useEffect(() => {
-    invoke<string[]>('get_room_history')
+    invoke<RoomHistoryEntry[]>('get_room_history')
       .then(setRoomHistory)
       .catch(() => {})
   }, [])
@@ -924,10 +930,15 @@ function HomeView({
   }, [meetUrl])
 
   const handleJoin = async () => {
-    const url = resolvedUrl
+    let url = resolvedUrl
     if (!url) {
       setError(t('home.error.noUrl'))
       return
+    }
+    const trimmedDisplayName = roomDisplayName.trim()
+    if (trimmedDisplayName) {
+      const sep = url.includes('?') ? '&' : '?'
+      url = `${url}${sep}room-display-name=${encodeURIComponent(trimmedDisplayName)}`
     }
     setError('')
     setJoining(true)
@@ -1202,6 +1213,21 @@ function HomeView({
                 onKeyDown={handleKeyDown}
               />
             </div>
+            <div className="form-group">
+              <label htmlFor="roomDisplayName">
+                {t('home.roomDisplayName')}
+              </label>
+              <input
+                id="roomDisplayName"
+                type="text"
+                placeholder={t('home.roomDisplayNamePlaceholder')}
+                autoComplete="off"
+                data-testid="home-room-display-name-input"
+                value={roomDisplayName}
+                onChange={(e) => setRoomDisplayName(e.target.value)}
+                onKeyDown={handleKeyDown}
+              />
+            </div>
             {roomStatus === 'auth_required' ? (
               <button className="btn btn-primary" onClick={handleAuth}>
                 {t('home.signIn')}
@@ -1255,12 +1281,17 @@ function HomeView({
             {roomHistory.length > 0 && (
               <div className="room-history">
                 <h4>{t('home.recentRooms')}</h4>
-                {roomHistory.map((url, i) => {
+                {roomHistory.map((entry, i) => {
+                  const { url, display_name } = entry
                   const slug = url.includes('/') ? url.split('/').pop() : url
                   let host = ''
                   try {
                     host = new URL(url).host
                   } catch {}
+                  const primaryLabel = display_name || slug || url
+                  const secondaryLabel = display_name
+                    ? `${slug} · ${host}`
+                    : host
                   return (
                     <button
                       key={i}
@@ -1296,9 +1327,13 @@ function HomeView({
                         <RiGlobalLine size={16} />
                       )}
                       <div className="room-history-info">
-                        <span className="room-history-slug">{slug}</span>
-                        {host && (
-                          <span className="room-history-host">{host}</span>
+                        <span className="room-history-slug">
+                          {primaryLabel}
+                        </span>
+                        {secondaryLabel && (
+                          <span className="room-history-host">
+                            {secondaryLabel}
+                          </span>
                         )}
                       </div>
                     </button>
@@ -1691,11 +1726,13 @@ function InfoSidebar({
   onClose,
   roomId,
   accessLevel,
+  roomDisplayName,
 }: {
   meetUrl: string
   onClose: () => void
   roomId?: string
   accessLevel?: string
+  roomDisplayName?: string | null
 }) {
   const t = useT()
   const [copiedHttp, setCopiedHttp] = useState(false)
@@ -1704,9 +1741,19 @@ function InfoSidebar({
   const [memberSearch, setMemberSearch] = useState('')
   const [memberResults, setMemberResults] = useState<any[]>([])
 
+  // Build share URL with room display name param if available
+  const shareUrl = (() => {
+    if (!roomDisplayName) return meetUrl
+    const sep = meetUrl.includes('?') ? '&' : '?'
+    return `${meetUrl}${sep}room-display-name=${encodeURIComponent(roomDisplayName)}`
+  })()
+
   // Normalize URL for display (strip scheme)
   const displayUrl = meetUrl.replace(/^https?:\/\//, '')
-  const deepLink = `visio://${displayUrl}`
+  const deepLinkBase = `visio://${displayUrl}`
+  const deepLink = roomDisplayName
+    ? `${deepLinkBase}?room-display-name=${encodeURIComponent(roomDisplayName)}`
+    : deepLinkBase
 
   // Fetch accesses on mount if roomId is provided
   useEffect(() => {
@@ -1747,7 +1794,7 @@ function InfoSidebar({
 
   const handleCopyHttp = async () => {
     try {
-      await navigator.clipboard.writeText(meetUrl)
+      await navigator.clipboard.writeText(shareUrl)
       setCopiedHttp(true)
       setTimeout(() => setCopiedHttp(false), 2000)
     } catch {
@@ -1793,7 +1840,7 @@ function InfoSidebar({
           <input
             className="info-link-input"
             readOnly
-            value={meetUrl}
+            value={shareUrl}
             onClick={(e) => (e.target as HTMLInputElement).select()}
           />
         </div>
@@ -2170,6 +2217,7 @@ function CallView({
   setWaitingParticipants,
   roomId,
   accessLevel,
+  roomDisplayName,
 }: {
   participants: Participant[]
   localParticipant: Participant | null
@@ -2214,6 +2262,7 @@ function CallView({
   >
   roomId?: string
   accessLevel?: string
+  roomDisplayName?: string | null
 }) {
   const t = useT()
   const [focusedItem, setFocusedItem] = useState<FocusItem>(null)
@@ -2923,6 +2972,7 @@ function CallView({
             onClose={onToggleInfo}
             roomId={roomId}
             accessLevel={accessLevel}
+            roomDisplayName={roomDisplayName}
           />
         )}
 
@@ -3705,6 +3755,7 @@ function chainUnlisten(
 function PreJoinScreen({
   roomUrl,
   username,
+  roomDisplayName,
   lang,
   isDark,
   onJoin,
@@ -3712,6 +3763,7 @@ function PreJoinScreen({
 }: {
   roomUrl: string
   username: string | null
+  roomDisplayName?: string | null
   lang: string
   isDark: boolean
   onJoin: (username: string | null) => void
@@ -3722,7 +3774,10 @@ function PreJoinScreen({
     [lang]
   )
 
-  const slug = roomUrl.includes('/') ? roomUrl.split('/').pop() : roomUrl
+  const slugSource = roomUrl.split('?')[0]
+  const slug = slugSource.includes('/')
+    ? slugSource.split('/').pop()
+    : slugSource
 
   // ---- State ---------------------------------------------------------------
   const [displayName, setDisplayName] = useState(username ?? '')
@@ -4026,7 +4081,14 @@ function PreJoinScreen({
       {/* Header */}
       <div className="prejoin-header">
         <span className="prejoin-app-name">Visio Mobile</span>
-        <span className="prejoin-slug">{slug}</span>
+        {roomDisplayName ? (
+          <>
+            <span className="prejoin-slug">{roomDisplayName}</span>
+            <span className="prejoin-slug-secondary">{slug}</span>
+          </>
+        ) : (
+          <span className="prejoin-slug">{slug}</span>
+        )}
       </div>
 
       {/* Display name */}
@@ -4309,6 +4371,9 @@ export default function App() {
   const [view, setView] = useState<View>('home')
   const [lobbyRoomUrl, setLobbyRoomUrl] = useState('')
   const [lobbyUsername, setLobbyUsername] = useState<string | null>(null)
+  const [currentRoomDisplayName, setCurrentRoomDisplayName] = useState<
+    string | null
+  >(null)
   const [connectionState, setConnectionState] = useState('disconnected')
   const [participants, setParticipants] = useState<Participant[]>([])
   const [localParticipant, setLocalParticipant] = useState<Participant | null>(
@@ -4450,14 +4515,19 @@ export default function App() {
           return
         }
 
-        // Handle room deep links: visio://{host}/{slug}
+        // Handle room deep links: visio://{host}/{slug}[?room-display-name=...]
         const slug = parsed.pathname.replace(/^\//, '')
         if (!host || !slug) return
 
+        const deepLinkDisplayName = parsed.searchParams.get('room-display-name')
         invoke<string[]>('get_meet_instances').then((instances) => {
           if (instances.includes(host)) {
             setView('home')
-            setDeepLinkUrl(`https://${host}/${slug}`)
+            let roomUrl = `https://${host}/${slug}`
+            if (deepLinkDisplayName) {
+              roomUrl += `?room-display-name=${encodeURIComponent(deepLinkDisplayName)}`
+            }
+            setDeepLinkUrl(roomUrl)
             setDeepLinkError(null)
           } else {
             setDeepLinkError(
@@ -4908,6 +4978,18 @@ export default function App() {
     roomId?: string,
     accessLevel?: string
   ) => {
+    // Extract room display name from query param before storing URL
+    let displayNameFromUrl: string | null = null
+    try {
+      const parsed = new URL(
+        meetUrl.startsWith('http') ? meetUrl : `https://${meetUrl}`
+      )
+      const raw = parsed.searchParams.get('room-display-name')
+      if (raw) displayNameFromUrl = decodeURIComponent(raw)
+    } catch {
+      /* ignore */
+    }
+    setCurrentRoomDisplayName(displayNameFromUrl)
     setCurrentMeetUrl(meetUrl)
     if (roomId) setCurrentRoomId(roomId)
     if (accessLevel) setCurrentAccessLevel(accessLevel)
@@ -5064,7 +5146,7 @@ export default function App() {
     <I18nContext.Provider value={t}>
       {(view === 'call' || connectionState === 'waiting_for_host') && (
         <header>
-          <h1>{t('app.title')}</h1>
+          <h1>{currentRoomDisplayName || t('app.title')}</h1>
           <StatusBadge state={connectionState} />
         </header>
       )}
@@ -5128,6 +5210,7 @@ export default function App() {
           <PreJoinScreen
             roomUrl={lobbyRoomUrl}
             username={lobbyUsername}
+            roomDisplayName={currentRoomDisplayName}
             lang={lang}
             isDark={theme === 'dark'}
             onJoin={() => {
@@ -5190,6 +5273,7 @@ export default function App() {
             setWaitingParticipants={setWaitingParticipants}
             roomId={currentRoomId || undefined}
             accessLevel={currentAccessLevel || undefined}
+            roomDisplayName={currentRoomDisplayName}
           />
         )}
         {connectionState === 'waiting_for_host' && (

--- a/crates/visio-desktop/src/lib.rs
+++ b/crates/visio-desktop/src/lib.rs
@@ -128,7 +128,9 @@ fn handle_connection_state_changed(
         let settings = settings.clone();
         tokio::spawn(async move {
             if let Some((url, _)) = room.lock().await.last_connection_info().await {
-                settings.add_room_to_history(url);
+                let display_name = visio_core::extract_room_display_name(&url);
+                let clean_url = visio_core::strip_room_display_name_param(&url);
+                settings.add_room_to_history(clean_url, display_name);
             }
         });
     }
@@ -920,9 +922,28 @@ fn set_meet_instances(state: tauri::State<'_, VisioState>, instances: Vec<String
     state.settings.set_meet_instances(instances);
 }
 
+#[derive(serde::Serialize)]
+struct RoomHistoryEntryJs {
+    url: String,
+    display_name: Option<String>,
+}
+
 #[tauri::command]
-fn get_room_history(state: tauri::State<'_, VisioState>) -> Result<Vec<String>, String> {
-    Ok(state.settings.get_room_history())
+fn get_room_history(state: tauri::State<'_, VisioState>) -> Result<Vec<RoomHistoryEntryJs>, String> {
+    Ok(state
+        .settings
+        .get_room_history()
+        .into_iter()
+        .map(|e| RoomHistoryEntryJs {
+            url: e.url,
+            display_name: e.display_name,
+        })
+        .collect())
+}
+
+#[tauri::command]
+fn validate_room_display_name_cmd(name: String) -> Option<String> {
+    visio_core::validate_room_display_name(&name)
 }
 
 #[tauri::command]
@@ -2130,6 +2151,7 @@ pub fn run() {
             check_media_permissions,
             get_room_history,
             clear_room_history,
+            validate_room_display_name_cmd,
             get_calendar_url,
             set_calendar_url,
             get_calendar_refresh_interval,

--- a/crates/visio-ffi/src/lib.rs
+++ b/crates/visio-ffi/src/lib.rs
@@ -278,6 +278,21 @@ impl From<CalendarRefreshInterval> for CoreCalendarRefreshInterval {
 }
 
 #[derive(Debug, Clone)]
+pub struct RoomHistoryEntry {
+    pub url: String,
+    pub display_name: Option<String>,
+}
+
+impl From<visio_core::settings::RoomHistoryEntry> for RoomHistoryEntry {
+    fn from(e: visio_core::settings::RoomHistoryEntry) -> Self {
+        Self {
+            url: e.url,
+            display_name: e.display_name,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct Meeting {
     pub id: String,
     pub summary: String,
@@ -786,7 +801,7 @@ impl BridgeListener {
         let settings = self.settings.clone();
         tokio::spawn(async move {
             if let Some((url, _)) = rm.last_connection_info().await {
-                settings.add_room_to_history(url);
+                settings.add_room_to_history(url, None);
             }
         });
     }
@@ -921,7 +936,10 @@ impl VisioClient {
     }
 
     pub fn connect(&self, meet_url: String, username: Option<String>) -> Result<(), VisioError> {
-        visio_log(&format!("VISIO FFI: connect() entered, url={meet_url}"));
+        let display_name = visio_core::extract_room_display_name(&meet_url);
+        let clean_url = visio_core::strip_room_display_name_param(&meet_url);
+
+        visio_log(&format!("VISIO FFI: connect() entered, url={clean_url}"));
 
         let cookie = {
             let session = self.session_manager.lock().unwrap();
@@ -939,7 +957,7 @@ impl VisioClient {
             let res = self.rt.block_on(async {
                 visio_log("VISIO FFI: inside block_on async block");
                 self.room_manager
-                    .connect(&meet_url, username.as_deref(), cookie.as_deref())
+                    .connect(&clean_url, username.as_deref(), cookie.as_deref())
                     .await
                     .map_err(VisioError::from)
             });
@@ -958,7 +976,8 @@ impl VisioClient {
                     *CLIENT_FOR_VIDEO.lock().unwrap() = self as *const VisioClient as usize;
                 }
 
-                self.settings.add_room_to_history(meet_url.clone());
+                self.settings
+                    .add_room_to_history(clean_url.clone(), display_name);
 
                 Ok(())
             }
@@ -1236,16 +1255,28 @@ impl VisioClient {
         self.settings.set_camera_device(name);
     }
 
-    pub fn add_room_to_history(&self, url: String) {
-        self.settings.add_room_to_history(url);
+    pub fn add_room_to_history(&self, url: String, display_name: Option<String>) {
+        self.settings.add_room_to_history(url, display_name);
     }
 
-    pub fn get_room_history(&self) -> Vec<String> {
-        self.settings.get_room_history()
+    pub fn get_room_history(&self) -> Vec<RoomHistoryEntry> {
+        self.settings
+            .get_room_history()
+            .into_iter()
+            .map(Into::into)
+            .collect()
     }
 
     pub fn clear_room_history(&self) {
         self.settings.clear_room_history();
+    }
+
+    pub fn extract_room_display_name(&self, url: String) -> Option<String> {
+        visio_core::extract_room_display_name(&url)
+    }
+
+    pub fn validate_room_display_name(&self, raw: String) -> Option<String> {
+        visio_core::validate_room_display_name(&raw)
     }
 
     pub fn raise_hand(&self) -> Result<(), VisioError> {
@@ -1291,17 +1322,18 @@ impl VisioClient {
     }
 
     pub fn validate_room(&self, url: String, username: Option<String>) -> RoomValidationResult {
+        let clean_url = visio_core::strip_room_display_name_param(&url);
         let cookie = {
             let session = self.session_manager.lock().unwrap();
             session.cookie()
         };
-        if let Err(e) = visio_core::AuthService::extract_slug(&url) {
+        if let Err(e) = visio_core::AuthService::extract_slug(&clean_url) {
             return RoomValidationResult::InvalidFormat {
                 message: e.to_string(),
             };
         }
         match self.rt.block_on(visio_core::AuthService::validate_room(
-            &url,
+            &clean_url,
             username.as_deref(),
             cookie.as_deref(),
         )) {

--- a/crates/visio-ffi/src/visio.udl
+++ b/crates/visio-ffi/src/visio.udl
@@ -207,6 +207,11 @@ dictionary Meeting {
     string server_name;
 };
 
+dictionary RoomHistoryEntry {
+    string url;
+    string? display_name;
+};
+
 interface VisioClient {
     constructor(string data_dir);
 
@@ -355,11 +360,15 @@ interface VisioClient {
 
     void stop_video_renderer(string track_sid);
 
-    void add_room_to_history(string url);
+    void add_room_to_history(string url, string? display_name);
 
-    sequence<string> get_room_history();
+    sequence<RoomHistoryEntry> get_room_history();
 
     void clear_room_history();
+
+    string? extract_room_display_name(string url);
+
+    string? validate_room_display_name(string raw);
 
     void set_background_mode(string mode);
 

--- a/docs/superpowers/plans/2026-03-22-room-display-name.md
+++ b/docs/superpowers/plans/2026-03-22-room-display-name.md
@@ -1,0 +1,1326 @@
+# Room Display Name — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a friendly display name to rooms, shown in lobby, call, recent rooms, and shared links across all 3 platforms.
+
+**Architecture:** All logic (validation, extraction, storage, migration) lives in `visio-core`. Platforms receive structured `RoomHistoryEntry { url, display_name }` via FFI (mobile) or direct calls (desktop) and only handle display. TDD approach: tests first in Rust, then platform integration.
+
+**Tech Stack:** Rust (visio-core, visio-ffi), UniFFI, Kotlin/Compose (Android), Swift/SwiftUI (iOS), React/TypeScript + Tauri (Desktop)
+
+**Spec:** `docs/superpowers/specs/2026-03-22-room-display-name-design.md`
+**Issue:** #113
+**Branch:** `feat/room-display-name` (worktree: `.worktrees/room-display-name/`)
+
+---
+
+## File Map
+
+### Create
+- `crates/visio-core/src/room_display_name.rs` — validation + URL extraction + stripping logic
+
+### Modify
+- `crates/visio-core/src/lib.rs` — add `mod room_display_name` and re-export
+- `crates/visio-core/src/settings.rs:43,108,269-284` — `RoomHistoryEntry` struct, migration deserializer, updated `add_room_to_history`/`get_room_history`
+- `crates/visio-ffi/src/visio.udl:358-362` — new dictionary + updated signatures
+- `crates/visio-ffi/src/lib.rs:923-980,1239-1249` — connect flow + history wrappers
+- `android/app/src/main/kotlin/io/visio/mobile/MainActivity.kt:32-52` — deep link display name extraction
+- `android/app/src/main/kotlin/io/visio/mobile/ui/HomeScreen.kt:93-104,851-877` — new field + recent rooms display
+- `android/app/src/main/kotlin/io/visio/mobile/ui/PreJoinScreen.kt:290-296,600` — display name in header
+- `android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt` — header banner
+- `android/app/src/main/kotlin/io/visio/mobile/ui/InCallSettingsSheet.kt:87-96,680-802` — share URL with display name
+- `ios/VisioMobile/Views/HomeView.swift:7,133-137,235-284` — new field + recent rooms display
+- `ios/VisioMobile/Views/PreJoinView.swift:168-171,193-201` — display name in header
+- `ios/VisioMobile/Views/CallView.swift:259` — navigation title
+- `ios/VisioMobile/Views/InCallSettingsSheet.swift:5-10,214-279` — share URL with display name
+- `crates/visio-desktop/src/lib.rs:130-131,441-466` — connect + history commands
+- `crates/visio-desktop/frontend/src/App.tsx:817-823,1132-1139,1255-1291,3706-3725,3921-3949` — home, lobby, call, share
+- `i18n/en.json`, `i18n/fr.json`, `i18n/de.json`, `i18n/es.json`, `i18n/it.json`, `i18n/nl.json` — new keys
+
+### Test
+- `crates/visio-core/src/room_display_name.rs` — inline `#[cfg(test)]` module
+- `crates/visio-core/src/settings.rs` — existing test module extended
+
+---
+
+## Task 1: Validation and URL helpers (Rust core)
+
+**Files:**
+- Create: `crates/visio-core/src/room_display_name.rs`
+- Modify: `crates/visio-core/src/lib.rs`
+
+- [ ] **Step 1: Create module file with test skeleton**
+
+Create `crates/visio-core/src/room_display_name.rs`:
+
+```rust
+//! Room display name: validation, URL extraction, and parameter stripping.
+
+/// Validate and sanitize a room display name.
+/// Returns `Some(sanitized)` if valid, `None` if empty or invalid.
+pub fn validate_room_display_name(_raw: &str) -> Option<String> {
+    todo!()
+}
+
+/// Extract the `room-display-name` query parameter from a URL.
+/// Returns the validated display name, or `None` if absent/invalid.
+pub fn extract_room_display_name(_url: &str) -> Option<String> {
+    todo!()
+}
+
+/// Remove only the `room-display-name` query parameter from a URL.
+/// Preserves all other query parameters.
+pub fn strip_room_display_name_param(_url: &str) -> String {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── validate_room_display_name ──
+
+    #[test]
+    fn validate_simple_name() {
+        assert_eq!(
+            validate_room_display_name("Weekly Standup"),
+            Some("Weekly Standup".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_trims_whitespace() {
+        assert_eq!(
+            validate_room_display_name("  Comex  "),
+            Some("Comex".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_collapses_spaces() {
+        assert_eq!(
+            validate_room_display_name("Team   Meeting"),
+            Some("Team Meeting".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_empty_returns_none() {
+        assert_eq!(validate_room_display_name(""), None);
+        assert_eq!(validate_room_display_name("   "), None);
+    }
+
+    #[test]
+    fn validate_too_long_returns_none() {
+        let long = "a".repeat(81);
+        assert_eq!(validate_room_display_name(&long), None);
+    }
+
+    #[test]
+    fn validate_max_length_ok() {
+        let max = "a".repeat(80);
+        assert_eq!(validate_room_display_name(&max), Some(max));
+    }
+
+    #[test]
+    fn validate_multibyte_chars_count_correctly() {
+        // 80 two-byte chars = 160 bytes but 80 chars → should pass
+        let name = "é".repeat(80);
+        assert_eq!(validate_room_display_name(&name), Some(name));
+        // 81 two-byte chars → should fail
+        let too_long = "é".repeat(81);
+        assert_eq!(validate_room_display_name(&too_long), None);
+    }
+
+    #[test]
+    fn validate_rejects_angle_brackets() {
+        assert_eq!(validate_room_display_name("<script>alert(1)</script>"), None);
+    }
+
+    #[test]
+    fn validate_rejects_forbidden_chars() {
+        for c in ['<', '>', '"', '\'', '`', ';', '&', '\\', '/', '{', '}'] {
+            let name = format!("Room{c}Name");
+            assert_eq!(validate_room_display_name(&name), None, "should reject '{c}'");
+        }
+    }
+
+    #[test]
+    fn validate_rejects_control_chars() {
+        assert_eq!(validate_room_display_name("Room\x00Name"), None);
+        assert_eq!(validate_room_display_name("Room\x1FName"), None);
+        assert_eq!(validate_room_display_name("Room\x7FName"), None);
+    }
+
+    #[test]
+    fn validate_rejects_rtl_override() {
+        // U+202E = Right-to-Left Override
+        assert_eq!(validate_room_display_name("Room\u{202E}Name"), None);
+        // U+2066 = Left-to-Right Isolate
+        assert_eq!(validate_room_display_name("Room\u{2066}Name"), None);
+    }
+
+    #[test]
+    fn validate_allows_unicode_letters() {
+        assert_eq!(
+            validate_room_display_name("Réunion d'équipe"),
+            None, // apostrophe is forbidden
+        );
+        assert_eq!(
+            validate_room_display_name("Réunion équipe"),
+            Some("Réunion équipe".to_string()),
+        );
+    }
+
+    #[test]
+    fn validate_allows_parens_and_hyphens() {
+        assert_eq!(
+            validate_room_display_name("Sprint Planning (Week 12)"),
+            Some("Sprint Planning (Week 12)".to_string()),
+        );
+        assert_eq!(
+            validate_room_display_name("Team-Meeting"),
+            Some("Team-Meeting".to_string()),
+        );
+    }
+
+    // ── extract_room_display_name ──
+
+    #[test]
+    fn extract_present() {
+        assert_eq!(
+            extract_room_display_name("https://meet.example.com/abc-defg-hij?room-display-name=Weekly%20Standup"),
+            Some("Weekly Standup".to_string()),
+        );
+    }
+
+    #[test]
+    fn extract_absent() {
+        assert_eq!(
+            extract_room_display_name("https://meet.example.com/abc-defg-hij"),
+            None,
+        );
+    }
+
+    #[test]
+    fn extract_empty_value() {
+        assert_eq!(
+            extract_room_display_name("https://meet.example.com/abc-defg-hij?room-display-name="),
+            None,
+        );
+    }
+
+    #[test]
+    fn extract_invalid_value() {
+        assert_eq!(
+            extract_room_display_name("https://meet.example.com/abc?room-display-name=%3Cscript%3E"),
+            None,
+        );
+    }
+
+    #[test]
+    fn extract_with_other_params() {
+        assert_eq!(
+            extract_room_display_name("https://meet.example.com/abc?token=xyz&room-display-name=Comex&lang=fr"),
+            Some("Comex".to_string()),
+        );
+    }
+
+    // ── strip_room_display_name_param ──
+
+    #[test]
+    fn strip_removes_param() {
+        assert_eq!(
+            strip_room_display_name_param("https://meet.example.com/abc?room-display-name=Comex"),
+            "https://meet.example.com/abc",
+        );
+    }
+
+    #[test]
+    fn strip_preserves_other_params() {
+        assert_eq!(
+            strip_room_display_name_param("https://meet.example.com/abc?token=xyz&room-display-name=Comex&lang=fr"),
+            "https://meet.example.com/abc?token=xyz&lang=fr",
+        );
+    }
+
+    #[test]
+    fn strip_no_param_unchanged() {
+        assert_eq!(
+            strip_room_display_name_param("https://meet.example.com/abc-defg-hij"),
+            "https://meet.example.com/abc-defg-hij",
+        );
+    }
+
+    #[test]
+    fn strip_only_param_removes_question_mark() {
+        assert_eq!(
+            strip_room_display_name_param("https://meet.example.com/abc?room-display-name=Test"),
+            "https://meet.example.com/abc",
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Register module in lib.rs**
+
+In `crates/visio-core/src/lib.rs`, add:
+```rust
+pub mod room_display_name;
+pub use room_display_name::{validate_room_display_name, extract_room_display_name, strip_room_display_name_param};
+```
+
+- [ ] **Step 3: Run tests — verify they fail**
+
+Run: `cargo test -p visio-core room_display_name`
+Expected: all tests FAIL with `not yet implemented`
+
+- [ ] **Step 4: Implement `validate_room_display_name`**
+
+```rust
+pub fn validate_room_display_name(raw: &str) -> Option<String> {
+    // Trim and collapse spaces
+    let trimmed: String = raw
+        .split_whitespace()
+        .collect::<Vec<&str>>()
+        .join(" ");
+
+    if trimmed.is_empty() || trimmed.chars().count() > 80 {
+        return None;
+    }
+
+    // Forbidden characters
+    const FORBIDDEN: &[char] = &['<', '>', '"', '\'', '`', ';', '&', '\\', '/', '{', '}'];
+    if trimmed.chars().any(|c| FORBIDDEN.contains(&c)) {
+        return None;
+    }
+
+    // Control characters (U+0000–U+001F, U+007F)
+    if trimmed.chars().any(|c| c.is_control()) {
+        return None;
+    }
+
+    // RTL/embedding override characters (U+202A–U+202E, U+2066–U+2069)
+    if trimmed.chars().any(|c| matches!(c, '\u{202A}'..='\u{202E}' | '\u{2066}'..='\u{2069}')) {
+        return None;
+    }
+
+    Some(trimmed)
+}
+```
+
+- [ ] **Step 5: Implement `extract_room_display_name`**
+
+```rust
+pub fn extract_room_display_name(url: &str) -> Option<String> {
+    let query_start = url.find('?')?;
+    let query = &url[query_start + 1..];
+
+    for pair in query.split('&') {
+        let mut kv = pair.splitn(2, '=');
+        let key = kv.next().unwrap_or("");
+        let value = kv.next().unwrap_or("");
+        if key == "room-display-name" {
+            let decoded = urlencoding::decode(value).ok()?;
+            return validate_room_display_name(&decoded);
+        }
+    }
+    None
+}
+```
+
+- [ ] **Step 6: Implement `strip_room_display_name_param`**
+
+```rust
+pub fn strip_room_display_name_param(url: &str) -> String {
+    let Some(query_start) = url.find('?') else {
+        return url.to_string();
+    };
+
+    let base = &url[..query_start];
+    let query = &url[query_start + 1..];
+
+    let remaining: Vec<&str> = query
+        .split('&')
+        .filter(|pair| {
+            let key = pair.splitn(2, '=').next().unwrap_or("");
+            key != "room-display-name"
+        })
+        .collect();
+
+    if remaining.is_empty() {
+        base.to_string()
+    } else {
+        format!("{}?{}", base, remaining.join("&"))
+    }
+}
+```
+
+- [ ] **Step 7: Run tests — verify they all pass**
+
+Run: `cargo test -p visio-core room_display_name`
+Expected: all tests PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/visio-core/src/room_display_name.rs crates/visio-core/src/lib.rs
+git commit -m "feat(core): add room display name validation and URL helpers (#113)"
+```
+
+---
+
+## Task 2: RoomHistoryEntry struct and migration (Rust core)
+
+**Files:**
+- Modify: `crates/visio-core/src/settings.rs:43,108,269-284,398-405`
+
+- [ ] **Step 1: Write failing tests for RoomHistoryEntry and migration**
+
+Add to the existing `#[cfg(test)]` module in `settings.rs`:
+
+```rust
+#[test]
+fn room_history_entry_round_trip() {
+    let entry = RoomHistoryEntry {
+        url: "https://meet.example.com/abc-defg-hij".to_string(),
+        display_name: Some("Comex".to_string()),
+    };
+    let json = serde_json::to_string(&entry).unwrap();
+    let back: RoomHistoryEntry = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.url, entry.url);
+    assert_eq!(back.display_name, entry.display_name);
+}
+
+#[test]
+fn room_history_entry_without_name() {
+    let entry = RoomHistoryEntry {
+        url: "https://meet.example.com/abc-defg-hij".to_string(),
+        display_name: None,
+    };
+    let json = serde_json::to_string(&entry).unwrap();
+    let back: RoomHistoryEntry = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.display_name, None);
+}
+
+#[test]
+fn room_history_migrates_old_string_format() {
+    let old_json = r#"{"room_history": ["https://meet.example.com/abc", "https://meet.example.com/def"]}"#;
+    let settings: Settings = serde_json::from_str(old_json).unwrap();
+    assert_eq!(settings.room_history.len(), 2);
+    assert_eq!(settings.room_history[0].url, "https://meet.example.com/abc");
+    assert_eq!(settings.room_history[0].display_name, None);
+}
+
+#[test]
+fn room_history_new_format() {
+    let new_json = r#"{"room_history": [{"url": "https://meet.example.com/abc", "display_name": "Comex"}]}"#;
+    let settings: Settings = serde_json::from_str(new_json).unwrap();
+    assert_eq!(settings.room_history[0].display_name, Some("Comex".to_string()));
+}
+
+#[test]
+fn room_history_mixed_format() {
+    let json = r#"{"room_history": ["https://meet.example.com/old", {"url": "https://meet.example.com/new", "display_name": "New Room"}]}"#;
+    let settings: Settings = serde_json::from_str(json).unwrap();
+    assert_eq!(settings.room_history.len(), 2);
+    assert_eq!(settings.room_history[0].display_name, None);
+    assert_eq!(settings.room_history[1].display_name, Some("New Room".to_string()));
+}
+
+#[test]
+fn add_room_updates_display_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SettingsStore::new(dir.path().to_str().unwrap());
+    store.add_room_to_history("https://meet.example.com/abc".to_string(), Some("Old Name".to_string()));
+    store.add_room_to_history("https://meet.example.com/abc".to_string(), Some("New Name".to_string()));
+    let history = store.get_room_history();
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].display_name, Some("New Name".to_string()));
+}
+
+#[test]
+fn add_room_without_name_preserves_existing() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SettingsStore::new(dir.path().to_str().unwrap());
+    store.add_room_to_history("https://meet.example.com/abc".to_string(), Some("Comex".to_string()));
+    store.add_room_to_history("https://meet.example.com/abc".to_string(), None);
+    let history = store.get_room_history();
+    assert_eq!(history[0].display_name, Some("Comex".to_string()));
+}
+
+#[test]
+fn add_room_caps_at_10() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SettingsStore::new(dir.path().to_str().unwrap());
+    for i in 0..12 {
+        store.add_room_to_history(format!("https://meet.example.com/room-{i:03}-aaa"), None);
+    }
+    assert_eq!(store.get_room_history().len(), 10);
+}
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+Run: `cargo test -p visio-core room_history`
+Expected: FAIL — `RoomHistoryEntry` not defined, `add_room_to_history` wrong signature
+
+- [ ] **Step 3: Implement `RoomHistoryEntry` struct with custom deserializer**
+
+In `settings.rs`, add above the `Settings` struct:
+
+```rust
+use crate::room_display_name::strip_room_display_name_param;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RoomHistoryEntry {
+    pub url: String,
+    pub display_name: Option<String>,
+}
+
+impl<'de> serde::Deserialize<'de> for RoomHistoryEntry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de;
+        use serde_json::Value;
+
+        let value = Value::deserialize(deserializer)?;
+        match &value {
+            Value::Object(map) => {
+                let url = map.get("url")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| de::Error::custom("missing 'url' field"))?
+                    .to_string();
+                let display_name = map.get("display_name")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                Ok(RoomHistoryEntry { url, display_name })
+            }
+            Value::String(s) => Ok(RoomHistoryEntry {
+                url: s.clone(),
+                display_name: None,
+            }),
+            _ => Err(de::Error::custom(format!(
+                "expected string or object for RoomHistoryEntry, got {value}"
+            ))),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Update `Settings.room_history` field**
+
+Change line 43 from:
+```rust
+pub room_history: Vec<String>,
+```
+to:
+```rust
+pub room_history: Vec<RoomHistoryEntry>,
+```
+
+Update the `Default` impl accordingly (line 108).
+
+- [ ] **Step 5: Update `add_room_to_history`**
+
+Replace the existing function (lines 269-276):
+
+```rust
+pub fn add_room_to_history(&self, url: String, display_name: Option<String>) {
+    let canonical = strip_room_display_name_param(&url);
+    let mut s = self.settings.lock().unwrap_or_else(|e| e.into_inner());
+
+    // Find existing entry with same canonical URL
+    if let Some(pos) = s.room_history.iter().position(|e| strip_room_display_name_param(&e.url) == canonical) {
+        let existing_name = s.room_history[pos].display_name.clone();
+        s.room_history.remove(pos);
+        s.room_history.insert(0, RoomHistoryEntry {
+            url: canonical,
+            display_name: display_name.or(existing_name),
+        });
+    } else {
+        s.room_history.insert(0, RoomHistoryEntry {
+            url: canonical,
+            display_name,
+        });
+    }
+
+    s.room_history.truncate(10);
+    drop(s);
+    self.save();
+}
+```
+
+- [ ] **Step 6: Update `get_room_history`**
+
+Change return type (lines 278-284):
+```rust
+pub fn get_room_history(&self) -> Vec<RoomHistoryEntry> {
+    self.settings
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .room_history
+        .clone()
+}
+```
+
+- [ ] **Step 7: Update `clear_room_history`** (lines 398-405)
+
+No signature change needed — just ensure it still compiles with the new type.
+
+- [ ] **Step 8: Update ALL existing tests and references to old `Vec<String>` room_history**
+
+Search for `room_history` and `add_room_to_history` in the file. The existing tests (around lines 650-693) use the old single-argument `add_room_to_history(url)` and compare history entries to `String`. Update them all:
+
+- Change all `store.add_room_to_history("url".to_string())` to `store.add_room_to_history("url".to_string(), None)`
+- Change all `assert_eq!(history[0], "url")` to `assert_eq!(history[0].url, "url")`
+- Update any `Vec<String>` type annotations to `Vec<RoomHistoryEntry>`
+
+- [ ] **Step 9: Run tests — verify they pass**
+
+Run: `cargo test -p visio-core`
+Expected: all tests PASS (both new and existing)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/visio-core/src/settings.rs
+git commit -m "feat(core): add RoomHistoryEntry with backward-compatible migration (#113)"
+```
+
+---
+
+## Task 3: Update parse_meet_url and extract_slug for query params
+
+**Files:**
+- Modify: `crates/visio-core/src/auth.rs:106-125,144-159`
+
+- [ ] **Step 1: Write test for URL with query params**
+
+Add to existing tests in `auth.rs`:
+
+```rust
+#[test]
+fn parse_meet_url_strips_display_name_param() {
+    let (instance, slug) = AuthService::parse_meet_url(
+        "https://meet.example.com/abc-defg-hij?room-display-name=Comex"
+    ).unwrap();
+    assert_eq!(instance, "meet.example.com");
+    assert_eq!(slug, "abc-defg-hij");
+}
+
+#[test]
+fn extract_slug_with_query_param() {
+    let slug = AuthService::extract_slug(
+        "https://meet.example.com/abc-defg-hij?room-display-name=Test"
+    ).unwrap();
+    assert_eq!(slug, "abc-defg-hij");
+}
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+Run: `cargo test -p visio-core parse_meet_url_strips extract_slug_with`
+Expected: FAIL (query param included in slug)
+
+- [ ] **Step 3: Update `parse_meet_url`**
+
+Strip the display name param before parsing:
+
+```rust
+pub fn parse_meet_url(url: &str) -> Result<(String, String), VisioError> {
+    let url = crate::strip_room_display_name_param(
+        url.trim().trim_end_matches('/')
+    );
+    let url = url
+        .replace("https://", "")
+        .replace("http://", "");
+    // ... rest unchanged
+}
+```
+
+- [ ] **Step 4: Update `extract_slug`**
+
+Strip query params from candidate before regex match:
+
+```rust
+let candidate = if candidate.contains('?') {
+    candidate.split('?').next().unwrap_or("")
+} else {
+    candidate
+};
+```
+
+- [ ] **Step 5: Run all tests**
+
+Run: `cargo test -p visio-core`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/visio-core/src/auth.rs
+git commit -m "fix(core): strip room-display-name param from URL before parsing (#113)"
+```
+
+---
+
+## Task 4: FFI layer (visio-ffi)
+
+**Files:**
+- Modify: `crates/visio-ffi/src/visio.udl:358-362`
+- Modify: `crates/visio-ffi/src/lib.rs:923-980,1239-1249`
+
+- [ ] **Step 1: Add `RoomHistoryEntry` dictionary to UDL**
+
+In `visio.udl`, add before the interface block (near line 88):
+
+```udl
+dictionary RoomHistoryEntry {
+    string url;
+    string? display_name;
+};
+```
+
+- [ ] **Step 2: Update function signatures in UDL**
+
+Replace lines 358-362:
+
+```udl
+void add_room_to_history(string url, string? display_name);
+sequence<RoomHistoryEntry> get_room_history();
+void clear_room_history();
+string? extract_room_display_name(string url);
+string? validate_room_display_name(string raw);
+```
+
+- [ ] **Step 3: Add `RoomHistoryEntry` struct to lib.rs for UniFFI**
+
+In `lib.rs`, add the UniFFI-compatible struct:
+
+```rust
+#[derive(uniffi::Record)]
+pub struct RoomHistoryEntry {
+    pub url: String,
+    pub display_name: Option<String>,
+}
+
+impl From<visio_core::settings::RoomHistoryEntry> for RoomHistoryEntry {
+    fn from(e: visio_core::settings::RoomHistoryEntry) -> Self {
+        Self { url: e.url, display_name: e.display_name }
+    }
+}
+```
+
+- [ ] **Step 4: Update `add_room_to_history` in lib.rs**
+
+Replace lines 1239-1241:
+
+```rust
+pub fn add_room_to_history(&self, url: String, display_name: Option<String>) {
+    self.settings.add_room_to_history(url, display_name);
+}
+```
+
+- [ ] **Step 5: Update `get_room_history` in lib.rs**
+
+Replace lines 1243-1245:
+
+```rust
+pub fn get_room_history(&self) -> Vec<RoomHistoryEntry> {
+    self.settings.get_room_history().into_iter().map(Into::into).collect()
+}
+```
+
+- [ ] **Step 6: Add new FFI functions**
+
+```rust
+pub fn extract_room_display_name(&self, url: String) -> Option<String> {
+    visio_core::extract_room_display_name(&url)
+}
+
+pub fn validate_room_display_name(&self, raw: String) -> Option<String> {
+    visio_core::validate_room_display_name(&raw)
+}
+```
+
+- [ ] **Step 7: Update `connect()` flow — strip URL BEFORE connecting**
+
+In the connect function (lines 923-980), extract display name and strip the param **before** passing the URL to LiveKit. Change the function to:
+
+```rust
+pub fn connect(&self, meet_url: String, username: Option<String>) -> Result<(), VisioError> {
+    // Extract display name before stripping the param
+    let display_name = visio_core::extract_room_display_name(&meet_url);
+    let clean_url = visio_core::strip_room_display_name_param(&meet_url);
+
+    // ... (existing cookie retrieval code unchanged) ...
+
+    // Use clean_url (not meet_url) for the actual connection:
+    self.room_manager.connect(&clean_url, username.as_deref(), cookie.as_deref())
+
+    // On success (line 961), store with display name:
+    self.settings.add_room_to_history(clean_url.clone(), display_name);
+```
+
+**Important:** The URL passed to `room_manager.connect()` must be `clean_url` (without `?room-display-name=`), not the original `meet_url`. This matches the spec: "Connect to LiveKit with clean URL."
+
+- [ ] **Step 7b: Fix `BridgeListener::record_room_in_history` (lines 784-792)**
+
+This second call site fires on `ConnectionState::Connected` (including reconnections and lobby acceptance). Since it uses `last_connection_info()` which returns the clean URL (post-connection, no query params), it must pass `None` for display_name. The `or(existing_name)` logic in `add_room_to_history` will preserve any previously stored name:
+
+```rust
+impl BridgeListener {
+    fn record_room_in_history(&self) {
+        let rm = self.room_manager.clone();
+        let settings = self.settings.clone();
+        tokio::spawn(async move {
+            if let Some((url, _)) = rm.last_connection_info().await {
+                // Pass None — the display name was already stored by connect().
+                // The or(existing_name) logic preserves it.
+                settings.add_room_to_history(url, None);
+            }
+        });
+    }
+}
+```
+
+- [ ] **Step 7c: Update `validate_room()` to strip param before validation**
+
+In `validate_room()` (around line 1293), strip the display name param before passing to `AuthService::validate_room`:
+
+```rust
+pub fn validate_room(&self, url: String, username: Option<String>) -> Result<(), VisioError> {
+    let clean_url = visio_core::strip_room_display_name_param(&url);
+    // Use clean_url for all downstream calls
+    // ...
+}
+```
+
+- [ ] **Step 8: Build to verify compilation**
+
+Run: `cargo build -p visio-ffi`
+Expected: compiles without errors
+
+- [ ] **Step 9: Regenerate UniFFI bindings**
+
+Run: `scripts/generate-bindings.sh all`
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/visio-ffi/
+git commit -m "feat(ffi): expose RoomHistoryEntry and display name helpers via UniFFI (#113)"
+```
+
+---
+
+## Task 5: i18n — add translation keys
+
+**Files:**
+- Modify: `i18n/en.json`, `i18n/fr.json`, `i18n/de.json`, `i18n/es.json`, `i18n/it.json`, `i18n/nl.json`
+
+- [ ] **Step 1: Add keys to all 6 language files**
+
+Add near existing `home.*` keys:
+
+| Key | EN | FR | DE | ES | IT | NL |
+|---|---|---|---|---|---|---|
+| `home.roomDisplayName` | Room name (optional) | Nom de la room (optionnel) | Raumname (optional) | Nombre de sala (opcional) | Nome stanza (opzionale) | Kamernaam (optioneel) |
+| `home.roomDisplayNamePlaceholder` | e.g. "Weekly standup" | ex. "Réunion hebdo" | z.B. "Wöchentliches Meeting" | ej. "Reunión semanal" | es. "Riunione settimanale" | bijv. "Wekelijkse vergadering" |
+
+- [ ] **Step 2: Verify JSON is valid**
+
+Run: `python3 -c "import json; [json.load(open(f'i18n/{l}.json')) for l in ['en','fr','de','es','it','nl']]"`
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add i18n/
+git commit -m "feat(i18n): add room display name translation keys (#113)"
+```
+
+---
+
+## Task 6: Desktop — Tauri commands and frontend
+
+**Files:**
+- Modify: `crates/visio-desktop/src/lib.rs:130-131,441-466`
+- Modify: `crates/visio-desktop/frontend/src/App.tsx:817-823,1132-1139,1255-1291,3706-3725,3921-3949`
+
+- [ ] **Step 1: Update `handle_connection_state_changed` in lib.rs**
+
+Around line 130, change:
+```rust
+settings.add_room_to_history(url);
+```
+to:
+```rust
+let display_name = visio_core::extract_room_display_name(&url);
+let clean_url = visio_core::strip_room_display_name_param(&url);
+settings.add_room_to_history(clean_url, display_name);
+```
+
+- [ ] **Step 2: Update `get_room_history` Tauri command**
+
+Update the return type to serialize `RoomHistoryEntry` structs instead of strings. Create a Tauri-serializable struct if needed:
+
+```rust
+#[derive(serde::Serialize)]
+struct RoomHistoryEntryJs {
+    url: String,
+    display_name: Option<String>,
+}
+
+#[tauri::command]
+async fn get_room_history(state: tauri::State<'_, AppState>) -> Result<Vec<RoomHistoryEntryJs>, String> {
+    Ok(state.settings.get_room_history().into_iter().map(|e| RoomHistoryEntryJs {
+        url: e.url,
+        display_name: e.display_name,
+    }).collect())
+}
+```
+
+- [ ] **Step 3: Add `validate_room_display_name` Tauri command**
+
+```rust
+#[tauri::command]
+fn validate_room_display_name(raw: String) -> Option<String> {
+    visio_core::validate_room_display_name(&raw)
+}
+```
+
+Register in Tauri builder's `invoke_handler`.
+
+- [ ] **Step 4: Build backend**
+
+Run: `cargo build -p visio-desktop`
+Expected: compiles
+
+- [ ] **Step 5: Update TypeScript types in App.tsx**
+
+Add interface and update state:
+
+```typescript
+interface RoomHistoryEntry {
+  url: string
+  display_name: string | null
+}
+
+// Change line 819:
+const [roomHistory, setRoomHistory] = useState<RoomHistoryEntry[]>([])
+const [roomDisplayName, setRoomDisplayName] = useState('')
+```
+
+- [ ] **Step 6: Update room history loading**
+
+Around line 823, change `invoke<string[]>` to `invoke<RoomHistoryEntry[]>`.
+
+- [ ] **Step 7: Add display name input field on Home screen**
+
+After the meetUrl input (around line 1139), add:
+
+```tsx
+<label htmlFor="roomDisplayName">{t('home.roomDisplayName')}</label>
+<input
+  id="roomDisplayName"
+  type="text"
+  placeholder={t('home.roomDisplayNamePlaceholder')}
+  value={roomDisplayName}
+  onChange={(e) => setRoomDisplayName(e.target.value)}
+/>
+```
+
+- [ ] **Step 8: Update `handleJoin` to pass display name**
+
+In the join flow, if user entered a display name, append it to the URL before connecting:
+
+```typescript
+const urlWithName = roomDisplayName.trim()
+  ? `${trimmed}?room-display-name=${encodeURIComponent(roomDisplayName.trim())}`
+  : trimmed
+```
+
+- [ ] **Step 9: Update recent rooms rendering**
+
+Around line 1258, change from rendering just URL to rendering display name + slug:
+
+```tsx
+{roomHistory.map((entry, i) => {
+  const slug = entry.url.includes('/') ? entry.url.split('/').pop() : entry.url
+  const host = entry.url.replace(/^https?:\/\//, '').split('/')[0]
+  return (
+    <div key={i} className="room-history-item">
+      <span className="room-name">{entry.display_name || slug}</span>
+      {entry.display_name && <span className="room-slug">{slug} · {host}</span>}
+      {!entry.display_name && <span className="room-host">{host}</span>}
+    </div>
+  )
+})}
+```
+
+- [ ] **Step 10: Update PreJoin (lobby) header**
+
+Around line 3725, update:
+
+```typescript
+const slug = roomUrl.includes('/') ? roomUrl.split('/').pop() : roomUrl
+// Add: receive roomDisplayName prop and show it
+```
+
+Display the display name as the main title, slug as subtitle.
+
+- [ ] **Step 11: Update call header**
+
+Show display name when available in the call header area.
+
+- [ ] **Step 12: Update share/copy URL**
+
+When building the URL for sharing, append `?room-display-name=` if a display name exists (percent-encoded with `%20` for spaces).
+
+- [ ] **Step 13: Handle deep links**
+
+In the Desktop deep link handler (look for `visio://` protocol handling in `lib.rs` or `App.tsx`), extract the `room-display-name` query parameter using `URL` or `URLSearchParams`:
+
+```typescript
+const url = new URL(deepLinkUrl.replace('visio://', 'https://'))
+const displayName = url.searchParams.get('room-display-name')
+url.searchParams.delete('room-display-name')
+const cleanUrl = url.toString()
+// Pass cleanUrl + displayName to the join flow
+```
+
+- [ ] **Step 14: Build and test frontend**
+
+Run: `cd crates/visio-desktop && cargo tauri dev`
+Expected: app launches, new field visible, recent rooms show names
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add crates/visio-desktop/
+git commit -m "feat(desktop): display room name in home, lobby, call and share (#113)"
+```
+
+---
+
+## Task 7: Android — all screens
+
+**Files:**
+- Modify: `android/app/src/main/kotlin/io/visio/mobile/MainActivity.kt:32-52`
+- Modify: `android/app/src/main/kotlin/io/visio/mobile/ui/HomeScreen.kt`
+- Modify: `android/app/src/main/kotlin/io/visio/mobile/ui/PreJoinScreen.kt`
+- Modify: `android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt`
+- Modify: `android/app/src/main/kotlin/io/visio/mobile/ui/InCallSettingsSheet.kt`
+
+- [ ] **Step 1: Update `parseDeepLink()` in MainActivity**
+
+Extract display name before reconstructing URL (lines 32-52):
+
+```kotlin
+private fun parseDeepLink(intent: Intent?): Pair<String, String?>? {
+    val uri = intent?.data ?: return null
+    if (uri.scheme != "visio") return null
+    val host = uri.host ?: return null
+
+    if (host == OidcAuthManager.AUTH_CALLBACK_HOST) {
+        handleAuthCallback(uri)
+        return null
+    }
+
+    val slug = uri.path?.trimStart('/') ?: return null
+    if (host.isBlank() || slug.isBlank()) return null
+
+    val displayName = uri.getQueryParameter("room-display-name")
+
+    val instances = VisioManager.client.getMeetInstances()
+    return if (instances.contains(host)) {
+        Pair("https://$host/$slug", displayName)
+    } else {
+        null
+    }
+}
+```
+
+Update all callers to handle the `Pair<String, String?>` return type.
+
+- [ ] **Step 2: Update HomeScreen — add display name field**
+
+Add state and TextField below the URL input:
+
+```kotlin
+var roomDisplayName by remember { mutableStateOf("") }
+
+// After the URL TextField:
+OutlinedTextField(
+    value = roomDisplayName,
+    onValueChange = { roomDisplayName = it },
+    label = { Text(Strings.t("home.roomDisplayName", lang)) },
+    placeholder = { Text(Strings.t("home.roomDisplayNamePlaceholder", lang)) },
+    singleLine = true,
+    modifier = Modifier.fillMaxWidth(),
+)
+```
+
+- [ ] **Step 3: Update HomeScreen — recent rooms list**
+
+Change room history from `List<String>` to use `RoomHistoryEntry` from FFI:
+
+```kotlin
+val history = VisioManager.client.getRoomHistory() // now returns List<RoomHistoryEntry>
+
+// Rendering:
+history.forEach { entry ->
+    val slug = if ('/' in entry.url) entry.url.substringAfterLast('/') else entry.url
+    val host = try { java.net.URI(entry.url).host ?: "" } catch (_: Exception) { "" }
+
+    // Primary: display_name or slug
+    Text(
+        text = entry.displayName ?: slug,
+        fontWeight = FontWeight.Bold,
+    )
+    // Secondary: slug + host (only if display name exists)
+    if (entry.displayName != null) {
+        Text(
+            text = "$slug · $host",
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Update HomeScreen — join flow**
+
+Pass display name when navigating to lobby/call. If user typed a name, include it.
+
+- [ ] **Step 5: Update PreJoinScreen — accept and show display name**
+
+Add parameter to function signature:
+
+```kotlin
+fun PreJoinScreen(
+    roomUrl: String,
+    roomDisplayName: String? = null,  // NEW
+    initialUsername: String,
+    onJoin: (finalUsername: String) -> Unit,
+    onCancel: () -> Unit,
+)
+```
+
+In header, show display name or slug:
+
+```kotlin
+Text(
+    text = roomDisplayName ?: roomSlug,
+    style = MaterialTheme.typography.headlineSmall,
+    fontWeight = FontWeight.SemiBold,
+)
+if (roomDisplayName != null) {
+    Text(
+        text = roomSlug,
+        style = MaterialTheme.typography.bodySmall,
+        color = if (isDark) VisioColors.Greyscale400 else VisioColors.LightTextSecondary,
+    )
+}
+```
+
+- [ ] **Step 6: Update CallScreen — header banner**
+
+Add `roomDisplayName: String?` parameter. Show as header when present.
+
+- [ ] **Step 7: Update InCallSettingsSheet — share with display name**
+
+Add `roomName: String?` parameter. When building share/deep link URLs:
+
+```kotlin
+val shareUrl = if (!roomName.isNullOrBlank()) {
+    val encoded = java.net.URLEncoder.encode(roomName, "UTF-8").replace("+", "%20")
+    "$roomUrl?room-display-name=$encoded"
+} else {
+    roomUrl
+}
+```
+
+- [ ] **Step 8: Add accessibility**
+
+- `contentDescription` on the new display name TextField
+- `semantics` block on recent room entries combining display name, slug, and host
+
+- [ ] **Step 9: Build Android**
+
+Run: `cd android && ./gradlew assembleDebug`
+Expected: compiles without errors
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add android/
+git commit -m "feat(android): display room name in home, lobby, call and share (#113)"
+```
+
+---
+
+## Task 8: iOS — all screens
+
+**Files:**
+- Modify: `ios/VisioMobile/Views/HomeView.swift:7,133-137,235-284`
+- Modify: `ios/VisioMobile/Views/PreJoinView.swift:168-171,193-201`
+- Modify: `ios/VisioMobile/Views/CallView.swift:259`
+- Modify: `ios/VisioMobile/Views/InCallSettingsSheet.swift:5-10,214-279`
+
+- [ ] **Step 1: Update HomeView — add display name field**
+
+Add state and TextField:
+
+```swift
+@State private var roomDisplayName: String = ""
+
+// After URL TextField:
+TextField(Strings.t("home.roomDisplayName", lang: lang), text: $roomDisplayName)
+    .textFieldStyle(.roundedBorder)
+    .accessibilityLabel(Strings.t("home.roomDisplayName", lang: lang))
+```
+
+- [ ] **Step 2: Update HomeView — recent rooms list**
+
+Change from `[String]` to structured entries. Update rendering:
+
+```swift
+let entry = roomHistory[i] // now RoomHistoryEntry
+let slug = entry.url.contains("/") ? String(entry.url.split(separator: "/").last ?? "") : entry.url
+let host = URL(string: entry.url)?.host ?? ""
+
+Text(entry.displayName ?? slug)
+    .fontWeight(.semibold)
+if entry.displayName != nil {
+    Text("\(slug) · \(host)")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+}
+```
+
+- [ ] **Step 3: Update HomeView — join flow**
+
+Pass display name to PreJoinView and CallView navigation.
+
+- [ ] **Step 4: Update PreJoinView — accept and show display name**
+
+Add property:
+
+```swift
+let roomDisplayName: String?
+```
+
+Update header (lines 193-201):
+
+```swift
+Text(roomDisplayName ?? slug)
+    .font(.title2)
+    .fontWeight(.semibold)
+    .foregroundStyle(VisioColors.onBackground(dark: isDark))
+if roomDisplayName != nil {
+    Text(slug)
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+}
+```
+
+- [ ] **Step 5: Update CallView — navigation title**
+
+Change line 259:
+
+```swift
+.navigationTitle(roomDisplayName ?? Strings.t("call.title", lang: lang))
+```
+
+- [ ] **Step 6: Update InCallSettingsSheet — share with display name**
+
+Add property `let roomDisplayName: String?`. Update deep link construction:
+
+```swift
+let shareUrl: String
+if let name = roomDisplayName, !name.isEmpty {
+    // .urlQueryAllowed includes spaces as allowed, so use a custom set
+    var allowed = CharacterSet.urlQueryAllowed
+    allowed.remove(charactersIn: " +&=")
+    let encoded = name.addingPercentEncoding(withAllowedCharacters: allowed) ?? name
+    shareUrl = "\(roomURL)?room-display-name=\(encoded)"
+} else {
+    shareUrl = roomURL
+}
+```
+
+- [ ] **Step 7: Handle deep links**
+
+In the app's deep link handler (look for `visio://` scheme handling, typically in the `App` struct or `SceneDelegate`), extract `room-display-name` from the URL components:
+
+```swift
+if let components = URLComponents(url: deepLinkURL, resolvingAgainstBaseURL: false),
+   let displayName = components.queryItems?.first(where: { $0.name == "room-display-name" })?.value {
+    // Pass displayName alongside the clean URL through navigation
+}
+```
+
+Reconstruct the clean URL without the `room-display-name` param for connection, but pass the display name separately to the lobby/call views.
+
+- [ ] **Step 8: Add accessibility**
+
+- `.accessibilityLabel` on new TextField
+- `.accessibilityElement(children: .combine)` on recent room entries
+
+- [ ] **Step 9: Build iOS**
+
+Run: `scripts/build-ios.sh sim`
+Expected: compiles without errors
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add ios/
+git commit -m "feat(ios): display room name in home, lobby, call and share (#113)"
+```
+
+---
+
+## Task 9: Final integration test and cleanup
+
+- [ ] **Step 1: Run full Rust test suite**
+
+Run: `cargo test -p visio-core -p visio-desktop`
+Expected: all pass
+
+- [ ] **Step 2: Build all platforms**
+
+```bash
+cargo build -p visio-core
+cargo build -p visio-ffi
+cargo build -p visio-desktop
+cd android && ./gradlew assembleDebug
+```
+
+- [ ] **Step 3: Verify CHANGELOG**
+
+Add entry under `[Unreleased]`:
+```markdown
+### Added
+
+- Room display name: friendly names for rooms via `?room-display-name=` URL parameter or manual input (#113)
+```
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "chore: add room display name to CHANGELOG (#113)"
+```
+
+- [ ] **Step 5: Push branch and create PR**
+
+```bash
+git push -u origin feat/room-display-name
+```
+
+Create PR targeting `main` referencing issue #113.

--- a/docs/superpowers/specs/2026-03-22-room-display-name-design.md
+++ b/docs/superpowers/specs/2026-03-22-room-display-name-design.md
@@ -1,0 +1,256 @@
+# Room Display Name — Design Spec
+
+**Date:** 2026-03-22
+**Issue:** #113
+**Replaces:** PR #66 (closed)
+**Branch:** `feat/room-display-name`
+
+## Problem
+
+Rooms are identified only by their technical slug (e.g., `abc-defg-hij`). Users have no way to give a room a friendly name. When sharing links or reviewing recent rooms, the slug provides no meaningful context.
+
+## Solution
+
+Add a display name to rooms, sourced from a URL query parameter (`?room-display-name=`) or manual user input. The name is stored locally, shown across all screens, and preserved when sharing links.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Name priority | Most recent wins | Simple mental model, no conflict resolution needed |
+| Name source | URL param + manual input | Covers both sharing and personal naming |
+| Validation location | Rust core only | Single source of truth, testable, shared by all platforms |
+| Storage | `RoomHistoryEntry` struct in settings | Natural extension of existing room history |
+| Query param name | `?room-display-name=` | Explicit, avoids collision with `?name=` (too generic) |
+| Edit from recent list | No | Name updates naturally on next join; keeps UI simple |
+| Name clearing | Not supported | Once set, a name persists until replaced by a new one. Accepted limitation for v1. |
+| URL encoding | `%20` for spaces | Cross-platform consistency (not `+` which varies by decoder) |
+
+## Data Model
+
+### RoomHistoryEntry (visio-core/src/settings.rs)
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoomHistoryEntry {
+    pub url: String,
+    pub display_name: Option<String>,
+}
+```
+
+### Backward-compatible migration
+
+A **custom `Deserialize` implementation** on `Vec<RoomHistoryEntry>` (not `#[serde(untagged)]` — which swallows error messages and makes debugging difficult):
+1. First try to parse each element as `RoomHistoryEntry` struct
+2. If that fails, try to parse as a plain `String` and wrap as `RoomHistoryEntry { url: s, display_name: None }`
+3. If both fail, skip the entry and log a warning
+
+Formats accepted:
+- Old: `["https://meet.example.com/abc"]` → `RoomHistoryEntry { url, display_name: None }`
+- New: `[{ "url": "...", "display_name": "Weekly" }]`
+- Mixed: both formats in the same array
+
+On next save, all entries are written in the new format. No explicit migration step needed.
+
+## Validation Rules
+
+Function: `validate_room_display_name(raw: &str) -> Option<String>`
+
+| Rule | Detail |
+|---|---|
+| Length | 1–80 characters (after trim) |
+| Forbidden chars | `` < > " ' ` ; & \ / { } `` , control characters (U+0000–U+001F, U+007F), and RTL/embedding override characters (U+202A–U+202E, U+2066–U+2069) |
+| Sanitization | Trim leading/trailing whitespace, collapse multiple spaces to one |
+| Empty after trim | Returns `None` |
+| Invalid from URL | Silently ignored, existing name preserved |
+
+## URL Handling
+
+### Extraction
+
+Function: `extract_room_display_name(url: &str) -> Option<String>`
+- Parses query parameter `?room-display-name=`
+- URL-decodes the value (percent-encoding)
+- Passes through `validate_room_display_name`
+- Returns `None` if absent or invalid
+
+### Stripping
+
+Function: `strip_room_display_name_param(url: &str) -> String`
+- Removes only the `room-display-name` query parameter from the URL
+- Preserves any other query parameters that may exist
+- Used before calling LiveKit API and for room deduplication in history
+- **Design note:** we strip only our param rather than all query params, to avoid breaking future features that may use other query parameters
+
+## Room History Changes
+
+### add_room_to_history(url, display_name)
+
+1. Strip query params from URL to get canonical URL
+2. If canonical URL already in history: update display_name (if new one is `Some`), move to top
+3. If new: insert at top with display_name
+4. Cap at 10 entries
+
+### get_room_history() -> Vec<RoomHistoryEntry>
+
+Returns all entries with their display names.
+
+## FFI Layer (visio-ffi)
+
+### UDL changes
+
+```udl
+dictionary RoomHistoryEntry {
+    string url;
+    string? display_name;
+};
+```
+
+### Modified signatures
+
+- `get_room_history() -> sequence<RoomHistoryEntry>`
+- `add_room_to_history(string url, string? display_name)` — **breaking change** from previous `add_room_to_history(string url)`. All call sites on Android and iOS must be updated in the same PR.
+- `extract_room_display_name(string url) -> string?` (new)
+- `validate_room_display_name(string raw) -> string?` (new)
+
+**Note:** The `Settings` dictionary in UDL does not include `room_history` and remains unchanged. Room history is accessed only via the standalone `get_room_history()` function.
+
+### connect() flow
+
+1. Extract display name from URL via `extract_room_display_name()`
+2. Strip query params from URL
+3. Connect to LiveKit with clean URL
+4. On success: `add_room_to_history(clean_url, display_name)`
+
+### validate_room() flow
+
+Strip query params before server validation (unchanged behavior).
+
+## Android
+
+### HomeScreen
+
+- **New field:** Optional `TextField` for room display name, below the Meeting URL field
+  - Placeholder: `t("home.roomDisplayNamePlaceholder")`
+  - Label: `t("home.roomDisplayName")`
+  - Validation via `VisioManager.client.validateRoomDisplayName()`
+  - Value passed to `connect()` alongside the URL
+- **Recent rooms list:** If `display_name` present → bold primary text, slug+host as secondary. If absent → slug as primary (current behavior).
+
+### PreJoinScreen (Lobby)
+
+- Receives `roomDisplayName: String?` parameter
+- Header: display name when present, slug as fallback
+- Slug shown as subtitle for context
+
+### CallScreen
+
+- Header banner shows display name when present, slug otherwise
+
+### Accessibility (Android)
+
+- Room display name `TextField`: `contentDescription` set to label
+- Recent rooms: two-line entries use `semantics { contentDescription = "$displayName, $slug on $host" }`
+
+### InCallSettingsSheet
+
+- Shared/copied URL includes `?room-display-name=` (URL-encoded) when name exists
+- Deep link: `visio://host/slug?room-display-name=Encoded%20Name` (spaces as `%20`, not `+`, for cross-platform consistency)
+
+### MainActivity (deep links)
+
+- **Important:** current `parseDeepLink()` reconstructs the URL as `"https://$host/$slug"`, discarding all query parameters. Must be modified to extract `room-display-name` from the URI **before** reconstruction and propagate it separately through navigation.
+- The clean URL (without display name param) is used for connection; the display name is passed as a separate navigation argument.
+
+## iOS
+
+### HomeView
+
+- **New field:** Optional `TextField` for room display name (same as Android)
+- **Recent rooms list:** Same display logic as Android
+
+### PreJoinView (Lobby)
+
+- `roomDisplayName: String?` parameter
+- Header: display name or slug fallback, slug as subtitle
+
+### CallView
+
+- `.navigationTitle` set to display name when available, else `Strings.t("call.title")`
+
+### InCallSettingsSheet
+
+- URL and deep link include `?room-display-name=` when name exists
+
+### Accessibility (iOS)
+
+- Room display name `TextField`: `accessibilityLabel` set
+- Recent rooms: two-line entries use `.accessibilityElement(children: .combine)`
+
+### Deep links
+
+- Extract query param from `visio://` URL scheme, propagate via SwiftUI navigation
+
+## Desktop
+
+### App.tsx — Home
+
+- **New field:** Optional input for room display name below URL field
+- **Recent rooms:** Same display logic as mobile
+
+### App.tsx — Lobby (PreJoin)
+
+- Display name shown in header when present, slug as fallback
+- Slug as subtitle for context
+
+### App.tsx — Call
+
+- Header shows display name when present
+
+### App.tsx — Share
+
+- Copied URL includes `?room-display-name=` encoded
+
+### lib.rs — Tauri commands
+
+- `connect`: extracts display name, strips query params, stores in history (direct visio-core call)
+- `get_room_history`: returns `Vec<RoomHistoryEntry>` serialized as JSON
+- `validate_room_display_name(raw: String) -> Option<String>`: new command
+
+### Deep links
+
+- Extract query param, propagate to connection flow
+
+## i18n
+
+New keys in all 6 language files (en, fr, de, es, it, nl):
+
+| Key | EN | FR |
+|---|---|---|
+| `home.roomDisplayName` | Room name (optional) | Nom de la room (optionnel) |
+| `home.roomDisplayNamePlaceholder` | e.g. "Weekly standup" | ex. "Réunion hebdo" |
+
+DE, ES, IT, NL translations TBD — to be provided during implementation.
+
+**Note:** No new key needed for lobby/call fallback. When no display name is set, the existing slug extraction logic is used as-is.
+
+## Testing
+
+### Rust unit tests (visio-core)
+
+- `RoomHistoryEntry` serde: new format round-trip
+- Backward migration: old `Vec<String>` → `Vec<RoomHistoryEntry>`
+- `validate_room_display_name`: valid names, empty, too long, forbidden chars, XSS attempts, control chars
+- `extract_room_display_name`: with param, without, invalid, encoded special chars
+- `strip_room_display_name_param`: with and without params
+- `add_room_to_history`: new entry, update existing (same URL different name), deduplication, cap at 10
+
+### Integration tests (per platform)
+
+- Join via URL with `?room-display-name=` → name shown in lobby, call, recent rooms
+- Join via manual name input → name stored and shown
+- Join same room with new name → name updated
+- Join same room without name → previous name preserved
+- Share/copy URL → `?room-display-name=` present
+- Deep link with name → name propagated through flow
+- Invalid name in URL → silently ignored

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -189,6 +189,8 @@
   "bandwidth.reducedVideo": "Geringe Bandbreite — reduziertes Video",
   "bandwidth.audioOnly": "Sehr geringe Bandbreite — nur Audio",
   "home.recentRooms": "Letzte Räume",
+  "home.roomDisplayName": "Raumname (optional)",
+  "home.roomDisplayNamePlaceholder": "z.B. \"Wöchentliches Meeting\"",
   "participant.pin": "Anheften",
   "participant.unpin": "Loslösen",
   "participant.mute": "Stummschalten",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -189,6 +189,8 @@
   "bandwidth.reducedVideo": "Low bandwidth — reduced video",
   "bandwidth.audioOnly": "Very low bandwidth — audio only",
   "home.recentRooms": "Recent rooms",
+  "home.roomDisplayName": "Room name (optional)",
+  "home.roomDisplayNamePlaceholder": "e.g. \"Weekly standup\"",
   "participant.pin": "Pin",
   "participant.unpin": "Unpin",
   "participant.mute": "Mute",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -189,6 +189,8 @@
   "bandwidth.reducedVideo": "Ancho de banda bajo — video reducido",
   "bandwidth.audioOnly": "Ancho de banda muy bajo — solo audio",
   "home.recentRooms": "Salas recientes",
+  "home.roomDisplayName": "Nombre de sala (opcional)",
+  "home.roomDisplayNamePlaceholder": "ej. \"Reunión semanal\"",
   "participant.pin": "Fijar",
   "participant.unpin": "Desfijar",
   "participant.mute": "Silenciar",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -189,6 +189,8 @@
   "bandwidth.reducedVideo": "Faible débit — vidéo réduite",
   "bandwidth.audioOnly": "Très faible débit — audio uniquement",
   "home.recentRooms": "Salles récentes",
+  "home.roomDisplayName": "Nom de la room (optionnel)",
+  "home.roomDisplayNamePlaceholder": "ex. \"Réunion hebdo\"",
   "participant.pin": "Épingler",
   "participant.unpin": "Désépingler",
   "participant.mute": "Couper le micro",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -189,6 +189,8 @@
   "bandwidth.reducedVideo": "Banda bassa — video ridotto",
   "bandwidth.audioOnly": "Banda molto bassa — solo audio",
   "home.recentRooms": "Stanze recenti",
+  "home.roomDisplayName": "Nome stanza (opzionale)",
+  "home.roomDisplayNamePlaceholder": "es. \"Riunione settimanale\"",
   "participant.pin": "Fissa",
   "participant.unpin": "Sblocca",
   "participant.mute": "Silenzia",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -189,6 +189,8 @@
   "bandwidth.reducedVideo": "Lage bandbreedte — verminderde video",
   "bandwidth.audioOnly": "Zeer lage bandbreedte — alleen audio",
   "home.recentRooms": "Recente kamers",
+  "home.roomDisplayName": "Kamernaam (optioneel)",
+  "home.roomDisplayNamePlaceholder": "bijv. \"Wekelijkse vergadering\"",
   "participant.pin": "Vastzetten",
   "participant.unpin": "Losmaken",
   "participant.mute": "Dempen",

--- a/ios/VisioMobile/Generated/visio.swift
+++ b/ios/VisioMobile/Generated/visio.swift
@@ -545,7 +545,7 @@ public protocol VisioClientProtocol: AnyObject, Sendable {
     
     func addListener(listener: VisioEventListener) 
     
-    func addRoomToHistory(url: String) 
+    func addRoomToHistory(url: String, displayName: String?) 
     
     func admitParticipant(participantId: String) throws 
     
@@ -571,6 +571,8 @@ public protocol VisioClientProtocol: AnyObject, Sendable {
     
     func exchangeOidcCode(meetInstance: String, code: String) throws  -> String
     
+    func extractRoomDisplayName(url: String)  -> String?
+    
     func getBackgroundMode()  -> String
     
     func getCalendarRefreshInterval()  -> CalendarRefreshInterval
@@ -579,7 +581,7 @@ public protocol VisioClientProtocol: AnyObject, Sendable {
     
     func getMeetInstances()  -> [String]
     
-    func getRoomHistory()  -> [String]
+    func getRoomHistory()  -> [RoomHistoryEntry]
     
     func getSessionState()  -> SessionState
     
@@ -683,6 +685,8 @@ public protocol VisioClientProtocol: AnyObject, Sendable {
     
     func validateRoom(url: String, username: String?)  -> RoomValidationResult
     
+    func validateRoomDisplayName(raw: String)  -> String?
+    
     func validateSession(meetUrl: String) throws  -> Bool
     
 }
@@ -776,9 +780,10 @@ open func addListener(listener: VisioEventListener)  {try! rustCall() {
 }
 }
     
-open func addRoomToHistory(url: String)  {try! rustCall() {
+open func addRoomToHistory(url: String, displayName: String?)  {try! rustCall() {
     uniffi_visio_ffi_fn_method_visioclient_add_room_to_history(self.uniffiClonePointer(),
-        FfiConverterString.lower(url),$0
+        FfiConverterString.lower(url),
+        FfiConverterOptionString.lower(displayName),$0
     )
 }
 }
@@ -872,6 +877,14 @@ open func exchangeOidcCode(meetInstance: String, code: String)throws  -> String 
 })
 }
     
+open func extractRoomDisplayName(url: String) -> String?  {
+    return try!  FfiConverterOptionString.lift(try! rustCall() {
+    uniffi_visio_ffi_fn_method_visioclient_extract_room_display_name(self.uniffiClonePointer(),
+        FfiConverterString.lower(url),$0
+    )
+})
+}
+    
 open func getBackgroundMode() -> String  {
     return try!  FfiConverterString.lift(try! rustCall() {
     uniffi_visio_ffi_fn_method_visioclient_get_background_mode(self.uniffiClonePointer(),$0
@@ -900,8 +913,8 @@ open func getMeetInstances() -> [String]  {
 })
 }
     
-open func getRoomHistory() -> [String]  {
-    return try!  FfiConverterSequenceString.lift(try! rustCall() {
+open func getRoomHistory() -> [RoomHistoryEntry]  {
+    return try!  FfiConverterSequenceTypeRoomHistoryEntry.lift(try! rustCall() {
     uniffi_visio_ffi_fn_method_visioclient_get_room_history(self.uniffiClonePointer(),$0
     )
 })
@@ -1260,6 +1273,14 @@ open func validateRoom(url: String, username: String?) -> RoomValidationResult  
     uniffi_visio_ffi_fn_method_visioclient_validate_room(self.uniffiClonePointer(),
         FfiConverterString.lower(url),
         FfiConverterOptionString.lower(username),$0
+    )
+})
+}
+    
+open func validateRoomDisplayName(raw: String) -> String?  {
+    return try!  FfiConverterOptionString.lift(try! rustCall() {
+    uniffi_visio_ffi_fn_method_visioclient_validate_room_display_name(self.uniffiClonePointer(),
+        FfiConverterString.lower(raw),$0
     )
 })
 }
@@ -1859,6 +1880,76 @@ public func FfiConverterTypeRoomAccess_lift(_ buf: RustBuffer) throws -> RoomAcc
 #endif
 public func FfiConverterTypeRoomAccess_lower(_ value: RoomAccess) -> RustBuffer {
     return FfiConverterTypeRoomAccess.lower(value)
+}
+
+
+public struct RoomHistoryEntry {
+    public var url: String
+    public var displayName: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(url: String, displayName: String?) {
+        self.url = url
+        self.displayName = displayName
+    }
+}
+
+#if compiler(>=6)
+extension RoomHistoryEntry: Sendable {}
+#endif
+
+
+extension RoomHistoryEntry: Equatable, Hashable {
+    public static func ==(lhs: RoomHistoryEntry, rhs: RoomHistoryEntry) -> Bool {
+        if lhs.url != rhs.url {
+            return false
+        }
+        if lhs.displayName != rhs.displayName {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(url)
+        hasher.combine(displayName)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeRoomHistoryEntry: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> RoomHistoryEntry {
+        return
+            try RoomHistoryEntry(
+                url: FfiConverterString.read(from: &buf), 
+                displayName: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: RoomHistoryEntry, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.url, into: &buf)
+        FfiConverterOptionString.write(value.displayName, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeRoomHistoryEntry_lift(_ buf: RustBuffer) throws -> RoomHistoryEntry {
+    return try FfiConverterTypeRoomHistoryEntry.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeRoomHistoryEntry_lower(_ value: RoomHistoryEntry) -> RustBuffer {
+    return FfiConverterTypeRoomHistoryEntry.lower(value)
 }
 
 
@@ -3895,6 +3986,31 @@ fileprivate struct FfiConverterSequenceTypeRoomAccess: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterSequenceTypeRoomHistoryEntry: FfiConverterRustBuffer {
+    typealias SwiftType = [RoomHistoryEntry]
+
+    public static func write(_ value: [RoomHistoryEntry], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeRoomHistoryEntry.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [RoomHistoryEntry] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [RoomHistoryEntry]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeRoomHistoryEntry.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterSequenceTypeUserSearchResult: FfiConverterRustBuffer {
     typealias SwiftType = [UserSearchResult]
 
@@ -3977,7 +4093,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_visio_ffi_checksum_method_visioclient_add_listener() != 29296) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_visio_ffi_checksum_method_visioclient_add_room_to_history() != 37487) {
+    if (uniffi_visio_ffi_checksum_method_visioclient_add_room_to_history() != 15289) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_visio_ffi_checksum_method_visioclient_admit_participant() != 6663) {
@@ -4016,6 +4132,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_visio_ffi_checksum_method_visioclient_exchange_oidc_code() != 58208) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_visio_ffi_checksum_method_visioclient_extract_room_display_name() != 14190) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_visio_ffi_checksum_method_visioclient_get_background_mode() != 47158) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -4028,7 +4147,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_visio_ffi_checksum_method_visioclient_get_meet_instances() != 1312) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_visio_ffi_checksum_method_visioclient_get_room_history() != 62961) {
+    if (uniffi_visio_ffi_checksum_method_visioclient_get_room_history() != 9831) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_visio_ffi_checksum_method_visioclient_get_session_state() != 38004) {
@@ -4182,6 +4301,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_visio_ffi_checksum_method_visioclient_validate_room() != 14512) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_visio_ffi_checksum_method_visioclient_validate_room_display_name() != 54000) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_visio_ffi_checksum_method_visioclient_validate_session() != 29581) {

--- a/ios/VisioMobile/Generated/visioFFI.h
+++ b/ios/VisioMobile/Generated/visioFFI.h
@@ -303,7 +303,7 @@ void uniffi_visio_ffi_fn_method_visioclient_add_listener(void*_Nonnull ptr, uint
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_FN_METHOD_VISIOCLIENT_ADD_ROOM_TO_HISTORY
 #define UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_FN_METHOD_VISIOCLIENT_ADD_ROOM_TO_HISTORY
-void uniffi_visio_ffi_fn_method_visioclient_add_room_to_history(void*_Nonnull ptr, RustBuffer url, RustCallStatus *_Nonnull out_status
+void uniffi_visio_ffi_fn_method_visioclient_add_room_to_history(void*_Nonnull ptr, RustBuffer url, RustBuffer display_name, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_FN_METHOD_VISIOCLIENT_ADMIT_PARTICIPANT
@@ -364,6 +364,11 @@ void uniffi_visio_ffi_fn_method_visioclient_disconnect(void*_Nonnull ptr, RustCa
 #ifndef UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_FN_METHOD_VISIOCLIENT_EXCHANGE_OIDC_CODE
 #define UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_FN_METHOD_VISIOCLIENT_EXCHANGE_OIDC_CODE
 RustBuffer uniffi_visio_ffi_fn_method_visioclient_exchange_oidc_code(void*_Nonnull ptr, RustBuffer meet_instance, RustBuffer code, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_FN_METHOD_VISIOCLIENT_EXTRACT_ROOM_DISPLAY_NAME
+#define UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_FN_METHOD_VISIOCLIENT_EXTRACT_ROOM_DISPLAY_NAME
+RustBuffer uniffi_visio_ffi_fn_method_visioclient_extract_room_display_name(void*_Nonnull ptr, RustBuffer url, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_FN_METHOD_VISIOCLIENT_GET_BACKGROUND_MODE
@@ -644,6 +649,11 @@ uint32_t uniffi_visio_ffi_fn_method_visioclient_unread_count(void*_Nonnull ptr, 
 #ifndef UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_FN_METHOD_VISIOCLIENT_VALIDATE_ROOM
 #define UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_FN_METHOD_VISIOCLIENT_VALIDATE_ROOM
 RustBuffer uniffi_visio_ffi_fn_method_visioclient_validate_room(void*_Nonnull ptr, RustBuffer url, RustBuffer username, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_FN_METHOD_VISIOCLIENT_VALIDATE_ROOM_DISPLAY_NAME
+#define UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_FN_METHOD_VISIOCLIENT_VALIDATE_ROOM_DISPLAY_NAME
+RustBuffer uniffi_visio_ffi_fn_method_visioclient_validate_room_display_name(void*_Nonnull ptr, RustBuffer raw, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_FN_METHOD_VISIOCLIENT_VALIDATE_SESSION
@@ -1050,6 +1060,12 @@ uint16_t uniffi_visio_ffi_checksum_method_visioclient_exchange_oidc_code(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_CHECKSUM_METHOD_VISIOCLIENT_EXTRACT_ROOM_DISPLAY_NAME
+#define UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_CHECKSUM_METHOD_VISIOCLIENT_EXTRACT_ROOM_DISPLAY_NAME
+uint16_t uniffi_visio_ffi_checksum_method_visioclient_extract_room_display_name(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_CHECKSUM_METHOD_VISIOCLIENT_GET_BACKGROUND_MODE
 #define UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_CHECKSUM_METHOD_VISIOCLIENT_GET_BACKGROUND_MODE
 uint16_t uniffi_visio_ffi_checksum_method_visioclient_get_background_mode(void
@@ -1383,6 +1399,12 @@ uint16_t uniffi_visio_ffi_checksum_method_visioclient_unread_count(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_CHECKSUM_METHOD_VISIOCLIENT_VALIDATE_ROOM
 #define UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_CHECKSUM_METHOD_VISIOCLIENT_VALIDATE_ROOM
 uint16_t uniffi_visio_ffi_checksum_method_visioclient_validate_room(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_CHECKSUM_METHOD_VISIOCLIENT_VALIDATE_ROOM_DISPLAY_NAME
+#define UNIFFI_FFIDEF_UNIFFI_VISIO_FFI_CHECKSUM_METHOD_VISIOCLIENT_VALIDATE_ROOM_DISPLAY_NAME
+uint16_t uniffi_visio_ffi_checksum_method_visioclient_validate_room_display_name(void
     
 );
 #endif

--- a/ios/VisioMobile/Views/CallView.swift
+++ b/ios/VisioMobile/Views/CallView.swift
@@ -60,6 +60,7 @@ struct CallView: View {
 
     let roomURL: String
     let displayName: String
+    var roomDisplayName: String? = nil
 
     @State private var showChat: Bool = false
     @State private var showAudioDevices: Bool = false
@@ -256,7 +257,7 @@ struct CallView: View {
                 }
             }
         }
-        .navigationTitle(Strings.t("call.title", lang: lang))
+        .navigationTitle(roomDisplayName ?? Strings.t("call.title", lang: lang))
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .toolbarColorScheme(isDark ? .dark : .light, for: .navigationBar)
@@ -281,7 +282,7 @@ struct CallView: View {
                 .presentationDetents([.medium])
         }
         .sheet(isPresented: $showInCallSettings) {
-            InCallSettingsSheet(roomURL: roomURL, selectedTab: inCallSettingsTab)
+            InCallSettingsSheet(roomURL: roomURL, selectedTab: inCallSettingsTab, roomDisplayName: roomDisplayName)
                 .environmentObject(manager)
                 .presentationDetents([.medium, .large])
         }
@@ -289,7 +290,15 @@ struct CallView: View {
             // Only connect if not already connected (PreJoinView already connects)
             if case .disconnected = manager.connectionState {
                 let name = displayName.isEmpty ? nil : displayName
-                manager.connect(url: roomURL, username: name)
+                var connectURL = roomURL
+                if let rdName = roomDisplayName, !rdName.isEmpty {
+                    var allowed = CharacterSet.urlQueryAllowed
+                    allowed.remove(charactersIn: " +&=")
+                    let encoded = rdName.addingPercentEncoding(withAllowedCharacters: allowed) ?? rdName
+                    let separator = connectURL.contains("?") ? "&" : "?"
+                    connectURL += "\(separator)room-display-name=\(encoded)"
+                }
+                manager.connect(url: connectURL, username: name)
             }
             CallKitManager.shared.reportCallStarted(roomName: roomURL)
             UIApplication.shared.isIdleTimerDisabled = true

--- a/ios/VisioMobile/Views/HomeView.swift
+++ b/ios/VisioMobile/Views/HomeView.swift
@@ -14,7 +14,8 @@ struct HomeView: View {
     @State private var showServerPicker: Bool = false
     @State private var customServer: String = ""
     @State private var showCreateRoom: Bool = false
-    @State private var roomHistory: [String] = []
+    @State private var roomDisplayName: String = ""
+    @State private var roomHistory: [RoomHistoryEntry] = []
     @State private var historyJoinPending: Bool = false
     @State private var showCompactHeader: Bool = false
     @State private var selectedTab: Int = 0
@@ -150,6 +151,9 @@ struct HomeView: View {
                             .foregroundStyle(.red)
                     }
 
+                    TextField(Strings.t("home.roomDisplayName", lang: lang), text: $roomDisplayName)
+                        .textFieldStyle(.roundedBorder)
+
                     TextField(Strings.t("home.displayName", lang: lang), text: $displayName)
                         .textFieldStyle(.roundedBorder)
                         .textInputAutocapitalization(.words)
@@ -232,13 +236,16 @@ struct HomeView: View {
                             .fontWeight(.medium)
                             .foregroundStyle(VisioColors.secondaryText(dark: isDark))
 
-                        ForEach(Array(roomHistory.enumerated()), id: \.offset) { index, url in
-                            let slug = url.contains("/") ? String(url.split(separator: "/").last ?? "") : url
-                            let host = URL(string: url)?.host ?? ""
+                        ForEach(Array(roomHistory.enumerated()), id: \.offset) { index, entry in
+                            let slug = entry.url.contains("/") ? String(entry.url.split(separator: "/").last ?? "") : entry.url
+                            let host = URL(string: entry.url)?.host ?? ""
 
                             Button {
-                                roomURL = url
-                                resolvedRoomURL = url
+                                roomURL = entry.url
+                                resolvedRoomURL = entry.url
+                                if let name = entry.displayName {
+                                    roomDisplayName = name
+                                }
                                 // If already validated, navigate immediately
                                 if roomStatus == "valid" {
                                     navigateToCall = true
@@ -247,7 +254,7 @@ struct HomeView: View {
                                 }
                             } label: {
                                 HStack(spacing: 10) {
-                                    if historyJoinPending && roomURL == url {
+                                    if historyJoinPending && roomURL == entry.url {
                                         ProgressView()
                                             .scaleEffect(0.7)
                                             .frame(width: 14, height: 14)
@@ -258,14 +265,24 @@ struct HomeView: View {
                                     }
 
                                     VStack(alignment: .leading, spacing: 2) {
-                                        Text(slug)
-                                            .font(.body)
-                                            .fontWeight(.medium)
-                                            .foregroundStyle(VisioColors.onBackground(dark: isDark))
-                                        if !host.isEmpty {
-                                            Text(host)
+                                        if let name = entry.displayName {
+                                            Text(name)
+                                                .font(.body)
+                                                .fontWeight(.bold)
+                                                .foregroundStyle(VisioColors.onBackground(dark: isDark))
+                                            Text("\(slug) · \(host)")
                                                 .font(.caption)
                                                 .foregroundStyle(VisioColors.secondaryText(dark: isDark))
+                                        } else {
+                                            Text(slug)
+                                                .font(.body)
+                                                .fontWeight(.medium)
+                                                .foregroundStyle(VisioColors.onBackground(dark: isDark))
+                                            if !host.isEmpty {
+                                                Text(host)
+                                                    .font(.caption)
+                                                    .foregroundStyle(VisioColors.secondaryText(dark: isDark))
+                                            }
                                         }
                                     }
 
@@ -320,7 +337,10 @@ struct HomeView: View {
         .navigationDestination(isPresented: $navigateToCall) {
             PreJoinView(
                 roomURL: resolvedRoomURL,
-                initialDisplayName: displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+                initialDisplayName: displayName.trimmingCharacters(in: .whitespacesAndNewlines),
+                roomDisplayName: roomDisplayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ? nil
+                    : roomDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
             )
         }
         .sheet(isPresented: $showSettings) {
@@ -363,7 +383,13 @@ struct HomeView: View {
         }
         .onChange(of: manager.pendingDeepLink) { newValue in
             if let link = newValue {
-                roomURL = link
+                // Extract room-display-name from the URL if present, then strip the param
+                if let extracted = manager.client.extractRoomDisplayName(url: link) {
+                    roomDisplayName = extracted
+                }
+                // Strip the query param from the URL shown in the field
+                let cleanURL = link.components(separatedBy: "?").first ?? link
+                roomURL = cleanURL
                 manager.pendingDeepLink = nil
             }
         }

--- a/ios/VisioMobile/Views/InCallSettingsSheet.swift
+++ b/ios/VisioMobile/Views/InCallSettingsSheet.swift
@@ -8,6 +8,7 @@ struct InCallSettingsSheet: View {
 
     let roomURL: String
     @State var selectedTab: Int
+    var roomDisplayName: String? = nil
 
     private var lang: String { manager.currentLang }
     private var isDark: Bool { manager.currentTheme == "dark" }
@@ -214,7 +215,25 @@ struct InCallSettingsSheet: View {
     private var roomInfoTab: some View {
         let displayUrl = roomURL.replacingOccurrences(of: "https://", with: "")
                                 .replacingOccurrences(of: "http://", with: "")
+        let shareUrl: String = {
+            if let name = roomDisplayName, !name.isEmpty {
+                var allowed = CharacterSet.urlQueryAllowed
+                allowed.remove(charactersIn: " +&=")
+                let encoded = name.addingPercentEncoding(withAllowedCharacters: allowed) ?? name
+                return "\(roomURL)?room-display-name=\(encoded)"
+            }
+            return roomURL
+        }()
         let deepLink = "visio://\(displayUrl)"
+        let deepShareUrl: String = {
+            if let name = roomDisplayName, !name.isEmpty {
+                var allowed = CharacterSet.urlQueryAllowed
+                allowed.remove(charactersIn: " +&=")
+                let encoded = name.addingPercentEncoding(withAllowedCharacters: allowed) ?? name
+                return "\(deepLink)?room-display-name=\(encoded)"
+            }
+            return deepLink
+        }()
 
         return ScrollView {
             VStack(alignment: .leading, spacing: 20) {
@@ -230,17 +249,17 @@ struct InCallSettingsSheet: View {
                             .foregroundStyle(VisioColors.onBackground(dark: isDark))
                         Spacer()
                         Button {
-                            UIPasteboard.general.string = roomURL
+                            UIPasteboard.general.string = shareUrl
                         } label: {
                             Image(systemName: "doc.on.doc")
                                 .font(.caption)
                         }
-                        ShareLink(item: roomURL) {
+                        ShareLink(item: shareUrl) {
                             Image(systemName: "square.and.arrow.up")
                                 .font(.caption)
                         }
                     }
-                    TextField("", text: .constant(roomURL))
+                    TextField("", text: .constant(shareUrl))
                         .font(.caption)
                         .textFieldStyle(.roundedBorder)
                         .disabled(true)
@@ -258,17 +277,17 @@ struct InCallSettingsSheet: View {
                             .foregroundStyle(VisioColors.onBackground(dark: isDark))
                         Spacer()
                         Button {
-                            UIPasteboard.general.string = deepLink
+                            UIPasteboard.general.string = deepShareUrl
                         } label: {
                             Image(systemName: "doc.on.doc")
                                 .font(.caption)
                         }
-                        ShareLink(item: roomURL) {
+                        ShareLink(item: deepShareUrl) {
                             Image(systemName: "square.and.arrow.up")
                                 .font(.caption)
                         }
                     }
-                    TextField("", text: .constant(deepLink))
+                    TextField("", text: .constant(deepShareUrl))
                         .font(.caption)
                         .textFieldStyle(.roundedBorder)
                         .disabled(true)

--- a/ios/VisioMobile/Views/PreJoinView.swift
+++ b/ios/VisioMobile/Views/PreJoinView.swift
@@ -168,6 +168,7 @@ private struct BackgroundFilterSheet: View {
 struct PreJoinView: View {
     let roomURL: String
     let initialDisplayName: String
+    var roomDisplayName: String? = nil
 
     @EnvironmentObject private var manager: VisioManager
     @Environment(\.dismiss) private var dismiss
@@ -195,10 +196,20 @@ struct PreJoinView: View {
         ScrollView {
             VStack(spacing: 20) {
                 // Room name
-                Text(slug)
-                    .font(.title2)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(VisioColors.onBackground(dark: isDark))
+                if let name = roomDisplayName {
+                    Text(name)
+                        .font(.title2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(VisioColors.onBackground(dark: isDark))
+                    Text(slug)
+                        .font(.subheadline)
+                        .foregroundStyle(VisioColors.secondaryText(dark: isDark))
+                } else {
+                    Text(slug)
+                        .font(.title2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(VisioColors.onBackground(dark: isDark))
+                }
 
                 // Display name
                 TextField(Strings.t("prejoin.displayName", lang: lang), text: $displayName)
@@ -233,7 +244,11 @@ struct PreJoinView: View {
             }
         }
         .navigationDestination(isPresented: $navigateToCall) {
-            CallView(roomURL: roomURL, displayName: displayName.trimmingCharacters(in: .whitespacesAndNewlines))
+            CallView(
+                roomURL: roomURL,
+                displayName: displayName.trimmingCharacters(in: .whitespacesAndNewlines),
+                roomDisplayName: roomDisplayName
+            )
         }
         .sheet(isPresented: $showFilterSheet) {
             BackgroundFilterSheet(backgroundMode: $backgroundMode, lang: lang, isDark: isDark)
@@ -499,7 +514,17 @@ struct PreJoinView: View {
             manager.client.setMicEnabledOnJoin(enabled: isMicOn)
         }
 
-        manager.connect(url: roomURL, username: name.isEmpty ? nil : name)
+        // Append room-display-name query param so the FFI stores it in history
+        var connectURL = roomURL
+        if let rdName = roomDisplayName, !rdName.isEmpty {
+            var allowed = CharacterSet.urlQueryAllowed
+            allowed.remove(charactersIn: " +&=")
+            let encoded = rdName.addingPercentEncoding(withAllowedCharacters: allowed) ?? rdName
+            let separator = connectURL.contains("?") ? "&" : "?"
+            connectURL += "\(separator)room-display-name=\(encoded)"
+        }
+
+        manager.connect(url: connectURL, username: name.isEmpty ? nil : name)
 
         // Start 60s timeout
         DispatchQueue.main.asyncAfter(deadline: .now() + 60) { [self] in

--- a/ios/VisioMobile/VisioMobileApp.swift
+++ b/ios/VisioMobile/VisioMobileApp.swift
@@ -40,7 +40,17 @@ struct VisioMobileApp: App {
 
                 let instances = manager.client.getMeetInstances()
                 if instances.contains(host) {
-                    manager.pendingDeepLink = "https://\(host)/\(slug)"
+                    // Preserve room-display-name query param if present
+                    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+                    let rdName = components?.queryItems?.first(where: { $0.name == "room-display-name" })?.value
+                    var pendingURL = "https://\(host)/\(slug)"
+                    if let name = rdName, !name.isEmpty {
+                        var allowed = CharacterSet.urlQueryAllowed
+                        allowed.remove(charactersIn: " +&=")
+                        let encoded = name.addingPercentEncoding(withAllowedCharacters: allowed) ?? name
+                        pendingURL += "?room-display-name=\(encoded)"
+                    }
+                    manager.pendingDeepLink = pendingURL
                 }
             }
             .onChange(of: scenePhase) { phase in


### PR DESCRIPTION
## Summary

- Add friendly display names for rooms, sourced from `?room-display-name=` URL parameter or manual user input
- Display name shown in lobby, call screen, recent rooms list, and shared links across all 3 platforms
- Backward-compatible migration of room history from `Vec<String>` to `RoomHistoryEntry { url, display_name }`
- Validation in Rust core: 1-80 chars, forbidden chars, XSS/RTL protection
- 36 new Rust unit tests

## Changes

### Rust Core (`visio-core`)
- New `room_display_name` module: validation, URL extraction, parameter stripping
- `RoomHistoryEntry` struct with custom serde deserializer for backward compatibility
- Updated `parse_meet_url`/`extract_slug` to handle query params

### FFI Layer (`visio-ffi`)
- `RoomHistoryEntry` dictionary in UDL
- Updated `connect()` to extract display name before LiveKit connection
- New `extract_room_display_name()` and `validate_room_display_name()` exposed to mobile

### Desktop
- New "Room name" input field on home screen
- Display name in recent rooms, lobby, call header, shared URLs
- Deep link support

### Android
- New input field, updated recent rooms, lobby header, call header
- Deep link extraction via `parseDeepLink()`
- Share URLs with `?room-display-name=` parameter

### iOS
- New input field, updated recent rooms, lobby header, navigation title
- Deep link extraction, share URLs with display name

### i18n
- New keys in all 6 languages (EN, FR, DE, ES, IT, NL)

## Test plan
- [x] Rust unit tests: 36 new tests covering validation, migration, URL handling
- [ ] Android: join via URL with `?room-display-name=` → name shown everywhere
- [ ] iOS: same flow
- [ ] Desktop: same flow
- [ ] Manual name input → stored and displayed
- [ ] Share/copy URL → `?room-display-name=` preserved
- [ ] Deep links → name propagated

Closes #113
Replaces PR #66 (closed)