### PR TITLE
fix: assert light theme is default (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 
 ### Fixed
 
+- Assert light theme is default on all platforms (#119)
 - Apply background blur/image in pre-join lobby camera preview (#111)
 - Fix video freeze after surface destruction and orientation distortion (#100)
 - Fix 12 SonarCloud reliability issues in desktop frontend (#92)

--- a/crates/visio-core/src/settings.rs
+++ b/crates/visio-core/src/settings.rs
@@ -609,6 +609,11 @@ mod tests {
     }
 
     #[test]
+    fn test_default_theme_is_light() {
+        assert_eq!(Settings::default().theme, "light");
+    }
+
+    #[test]
     fn test_set_theme_persists() {
         let dir = temp_dir();
         let path = dir.path().to_str().unwrap();


### PR DESCRIPTION
## Summary

- Verified all 4 platforms default to `"light"` theme:
  - **Rust**: `settings.rs:157` → `default_theme()` returns `"light"`
  - **Android**: `VisioManager.kt:176` → `currentTheme = "light"`
  - **iOS**: `VisioManager.swift:37` → `currentTheme = "light"`
  - **Desktop**: `App.tsx:4356` → `useState('light')`
- Added explicit unit test: `Settings::default().theme == "light"`
- No code path allows dark theme on fresh install

## Test plan

- [x] New test `test_default_theme_is_light` passes
- [x] All existing tests pass (184 unit tests)

Closes #119