### PR TITLE
feat: calendar sync feedback on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - Room display name via `?room-display-name=` URL param
   or manual input (#113)
+- Calendar sync feedback: toast/snackbar on all platforms
+  after sync success or error (#121)
 
 ### Changed
 

--- a/android/app/src/main/kotlin/io/visio/mobile/VisioManager.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/VisioManager.kt
@@ -37,6 +37,12 @@ import uniffi.visio.VisioEvent
 import uniffi.visio.VisioEventListener
 import uniffi.visio.WaitingParticipant
 
+sealed class CalendarSyncResult {
+    data class Success(val count: Int) : CalendarSyncResult()
+
+    data class Error(val message: String) : CalendarSyncResult()
+}
+
 object VisioManager : VisioEventListener {
     const val MEETING_CHANNEL_ID = "meetings"
 
@@ -124,6 +130,15 @@ object VisioManager : VisioEventListener {
     // Calendar: loading state (true while first fetch in progress)
     private val _calendarLoading = MutableStateFlow(false)
     val calendarLoading: StateFlow<Boolean> = _calendarLoading.asStateFlow()
+
+    // Calendar: sync result for UI feedback (snackbar)
+    private val _calendarSyncResult = MutableStateFlow<CalendarSyncResult?>(null)
+    val calendarSyncResult: StateFlow<CalendarSyncResult?> = _calendarSyncResult.asStateFlow()
+
+    /** Clear the calendar sync result after the UI has consumed it. */
+    fun clearCalendarSyncResult() {
+        _calendarSyncResult.value = null
+    }
 
     // Adaptive mode
     private val _adaptiveMode = MutableStateFlow(AdaptiveMode.OFFICE)
@@ -1204,6 +1219,7 @@ object VisioManager : VisioEventListener {
             is VisioEvent.MeetingsUpdated -> {
                 _upcomingMeetings.value = event.meetings
                 _calendarLoading.value = false
+                _calendarSyncResult.value = CalendarSyncResult.Success(event.meetings.size)
             }
             is VisioEvent.MeetingImminent -> {
                 sendMeetingNotification(event.meeting, "imminent")
@@ -1217,6 +1233,7 @@ object VisioManager : VisioEventListener {
             is VisioEvent.CalendarError -> {
                 Log.e("VisioManager", "Calendar error: ${event.message}")
                 _calendarLoading.value = false
+                _calendarSyncResult.value = CalendarSyncResult.Error(event.message)
             }
             is VisioEvent.AdaptiveModeChanged -> {
                 handleAdaptiveModeChanged(event.mode)

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/HomeScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/HomeScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.visio.mobile.CalendarSyncResult
 import io.visio.mobile.R
 import io.visio.mobile.VisioManager
 import io.visio.mobile.ui.i18n.Strings
@@ -126,6 +127,28 @@ fun HomeScreen(
         onUsernameChange = { username = it },
         onRoomDisplayNameChange = { roomDisplayName = it },
     )
+
+    // Calendar sync result feedback (toast)
+    val calendarSyncResult by VisioManager.calendarSyncResult.collectAsState()
+    LaunchedEffect(calendarSyncResult) {
+        val result = calendarSyncResult ?: return@LaunchedEffect
+        val message =
+            when (result) {
+                is CalendarSyncResult.Success -> {
+                    if (result.count > 0) {
+                        Strings.t("calendar.sync.success", lang)
+                            .replace("{count}", result.count.toString())
+                    } else {
+                        Strings.t("calendar.sync.noMeetings", lang)
+                    }
+                }
+                is CalendarSyncResult.Error -> {
+                    Strings.t("calendar.sync.error", lang)
+                }
+            }
+        android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_SHORT).show()
+        VisioManager.clearCalendarSyncResult()
+    }
 
     val nowSeconds = System.currentTimeMillis() / 1000L
     val hasImminentMeeting =

--- a/crates/visio-desktop/frontend/src/App.css
+++ b/crates/visio-desktop/frontend/src/App.css
@@ -3145,3 +3145,46 @@ main {
   opacity: 0.8;
   margin-top: 2px;
 }
+
+/* ---------------------------------------------------------------------------
+   Calendar sync toast
+   --------------------------------------------------------------------------- */
+
+.sync-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px 20px;
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 500;
+  color: white;
+  z-index: 9999;
+  animation: sync-toast-in 0.3s ease-out;
+}
+
+.sync-toast-success {
+  background: var(--accent);
+}
+
+.sync-toast-error {
+  background: #ef4444;
+}
+
+@keyframes sync-toast-in {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+.settings-save-status {
+  font-size: 13px;
+  color: var(--accent);
+  font-weight: 500;
+}

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -616,13 +616,17 @@ function MeetingsTab({
 }>) {
   const t = useT()
   const [status, setStatus] = useState<
-    'onboarding' | 'loading' | 'empty' | 'list'
+    'onboarding' | 'loading' | 'empty' | 'list' | 'error'
   >('onboarding')
   const [meetings, setMeetings] = useState<Meeting[]>([])
   const [calendarUrl, setCalendarUrl] = useState<string | null>(null)
   const [joining, setJoining] = useState<string | null>(null)
   const [loadingMessage, setLoadingMessage] = useState<string>('')
   const [lastSyncTime, setLastSyncTime] = useState<Date | null>(null)
+  const [syncToast, setSyncToast] = useState<{
+    message: string
+    isError: boolean
+  } | null>(null)
 
   // Notify parent of meeting count changes
   useEffect(() => {
@@ -652,16 +656,32 @@ function MeetingsTab({
 
   // Listen for meetings-updated events
   useEffect(() => {
-    let unlisten: (() => void) | null = null
+    let unlistenUpdated: (() => void) | null = null
+    let unlistenError: (() => void) | null = null
     listen<Meeting[]>('meetings-updated', (event) => {
       setMeetings(event.payload)
       setLastSyncTime(new Date())
       setStatus(event.payload.length === 0 ? 'empty' : 'list')
+      const count = event.payload.length
+      const msg =
+        count > 0
+          ? t('calendar.sync.success').replace('{count}', String(count))
+          : t('calendar.sync.noMeetings')
+      setSyncToast({ message: msg, isError: false })
+      setTimeout(() => setSyncToast(null), 3000)
     }).then((fn) => {
-      unlisten = fn
+      unlistenUpdated = fn
+    })
+    listen<string>('calendar-error', () => {
+      setSyncToast({ message: t('calendar.sync.error'), isError: true })
+      setTimeout(() => setSyncToast(null), 4000)
+      if (meetings.length === 0) setStatus('error')
+    }).then((fn) => {
+      unlistenError = fn
     })
     return () => {
-      unlisten?.()
+      unlistenUpdated?.()
+      unlistenError?.()
     }
   }, [])
 
@@ -688,7 +708,9 @@ function MeetingsTab({
     } catch {
       clearTimeout(t2)
       clearTimeout(t5)
-      setStatus(meetings.length > 0 ? 'list' : 'empty')
+      setSyncToast({ message: t('calendar.sync.error'), isError: true })
+      setTimeout(() => setSyncToast(null), 4000)
+      setStatus(meetings.length > 0 ? 'list' : 'error')
     }
   }
 
@@ -726,6 +748,17 @@ function MeetingsTab({
     return (
       <div className="meetings-empty">
         <p>{t('meetings.empty')}</p>
+        <button className="btn btn-secondary" onClick={handleRefresh}>
+          {t('meetings.refresh')}
+        </button>
+      </div>
+    )
+  }
+
+  if (status === 'error') {
+    return (
+      <div className="meetings-empty">
+        <p>{t('calendar.sync.error')}</p>
         <button className="btn btn-secondary" onClick={handleRefresh}>
           {t('meetings.refresh')}
         </button>
@@ -784,6 +817,13 @@ function MeetingsTab({
       {lastSyncTime && (
         <div className="meetings-sync-footer">
           {formatSyncTime(lastSyncTime, t)}
+        </div>
+      )}
+      {syncToast && (
+        <div
+          className={`sync-toast ${syncToast.isError ? 'sync-toast-error' : 'sync-toast-success'}`}
+        >
+          {syncToast.message}
         </div>
       )}
     </div>
@@ -3366,6 +3406,8 @@ function SettingsView({
       .catch(() => {})
   }, [])
 
+  const [saveStatus, setSaveStatus] = useState<string | null>(null)
+
   const save = async () => {
     await invoke('set_display_name', { name: form.displayName || null })
     await invoke('set_mic_enabled_on_join', { enabled: form.micOnJoin })
@@ -3377,8 +3419,16 @@ function SettingsView({
     await invoke('set_calendar_refresh_interval', {
       interval: calendarRefreshInterval,
     })
+    if (calendarUrl.trim()) {
+      try {
+        await invoke('refresh_calendar_now')
+      } catch {
+        // calendar refresh is best-effort on save
+      }
+    }
+    setSaveStatus(t('settings.saved'))
     onDisplayNameChange(form.displayName)
-    onClose()
+    setTimeout(() => onClose(), 800)
   }
 
   return (
@@ -3542,6 +3592,9 @@ function SettingsView({
         </div>
       </div>
       <div className="settings-page-footer">
+        {saveStatus && (
+          <span className="settings-save-status">{saveStatus}</span>
+        )}
         <button className="settings-save" onClick={save}>
           {t('settings.save')}
         </button>

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -249,5 +249,9 @@
   "call.focus.hideThumbnails": "Miniaturansichten ausblenden",
   "call.focus.showThumbnails": "Miniaturansichten einblenden",
   "call.focus.backToGrid": "Zurück zum Raster",
-  "transcribe.currentLanguage": "Deutsch (de)"
+  "transcribe.currentLanguage": "Deutsch (de)",
+  "calendar.sync.started": "Kalender wird synchronisiert...",
+  "calendar.sync.success": "{count} Meetings gefunden",
+  "calendar.sync.error": "Kalender-Synchronisation fehlgeschlagen",
+  "calendar.sync.noMeetings": "Keine bevorstehenden Meetings"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -249,5 +249,9 @@
   "call.focus.hideThumbnails": "Hide thumbnails",
   "call.focus.showThumbnails": "Show thumbnails",
   "call.focus.backToGrid": "Back to grid",
-  "transcribe.currentLanguage": "English (en)"
+  "transcribe.currentLanguage": "English (en)",
+  "calendar.sync.started": "Syncing calendar...",
+  "calendar.sync.success": "{count} meetings found",
+  "calendar.sync.error": "Calendar sync failed",
+  "calendar.sync.noMeetings": "No upcoming meetings"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -249,5 +249,9 @@
   "call.focus.hideThumbnails": "Ocultar miniaturas",
   "call.focus.showThumbnails": "Mostrar miniaturas",
   "call.focus.backToGrid": "Volver a la cuadrícula",
-  "transcribe.currentLanguage": "Español (es)"
+  "transcribe.currentLanguage": "Español (es)",
+  "calendar.sync.started": "Sincronizando calendario...",
+  "calendar.sync.success": "{count} reuniones encontradas",
+  "calendar.sync.error": "Error al sincronizar el calendario",
+  "calendar.sync.noMeetings": "No hay reuniones próximas"
 }

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -249,5 +249,9 @@
   "call.focus.hideThumbnails": "Masquer les vignettes",
   "call.focus.showThumbnails": "Afficher les vignettes",
   "call.focus.backToGrid": "Retour à la grille",
-  "transcribe.currentLanguage": "Français (fr)"
+  "transcribe.currentLanguage": "Français (fr)",
+  "calendar.sync.started": "Synchronisation du calendrier...",
+  "calendar.sync.success": "{count} réunions trouvées",
+  "calendar.sync.error": "Échec de la synchronisation du calendrier",
+  "calendar.sync.noMeetings": "Aucune réunion à venir"
 }

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -249,5 +249,9 @@
   "call.focus.hideThumbnails": "Nascondi miniature",
   "call.focus.showThumbnails": "Mostra miniature",
   "call.focus.backToGrid": "Torna alla griglia",
-  "transcribe.currentLanguage": "Italiano (it)"
+  "transcribe.currentLanguage": "Italiano (it)",
+  "calendar.sync.started": "Sincronizzazione del calendario...",
+  "calendar.sync.success": "{count} riunioni trovate",
+  "calendar.sync.error": "Sincronizzazione del calendario fallita",
+  "calendar.sync.noMeetings": "Nessuna riunione in programma"
 }

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -249,5 +249,9 @@
   "call.focus.hideThumbnails": "Miniaturen verbergen",
   "call.focus.showThumbnails": "Miniaturen tonen",
   "call.focus.backToGrid": "Terug naar raster",
-  "transcribe.currentLanguage": "Nederlands (nl)"
+  "transcribe.currentLanguage": "Nederlands (nl)",
+  "calendar.sync.started": "Kalender synchroniseren...",
+  "calendar.sync.success": "{count} vergaderingen gevonden",
+  "calendar.sync.error": "Kalender synchronisatie mislukt",
+  "calendar.sync.noMeetings": "Geen aankomende vergaderingen"
 }

--- a/ios/VisioMobile/Views/HomeView.swift
+++ b/ios/VisioMobile/Views/HomeView.swift
@@ -19,6 +19,8 @@ struct HomeView: View {
     @State private var historyJoinPending: Bool = false
     @State private var showCompactHeader: Bool = false
     @State private var selectedTab: Int = 0
+    @State private var syncToastMessage: String?
+    @State private var syncToastIsError: Bool = false
 
     private var lang: String { manager.currentLang }
     private var isDark: Bool { manager.currentTheme == "dark" }
@@ -396,6 +398,43 @@ struct HomeView: View {
         .onChange(of: manager.pendingTestConnect != nil) { hasTestConnect in
             if hasTestConnect {
                 navigateToCall = true
+            }
+        }
+        .onChange(of: manager.calendarSyncResult) { newResult in
+            guard let result = newResult else { return }
+            switch result {
+            case .success(let count):
+                if count > 0 {
+                    syncToastMessage = Strings.t("calendar.sync.success", lang: lang)
+                        .replacingOccurrences(of: "{count}", with: "\(count)")
+                } else {
+                    syncToastMessage = Strings.t("calendar.sync.noMeetings", lang: lang)
+                }
+                syncToastIsError = false
+            case .error:
+                syncToastMessage = Strings.t("calendar.sync.error", lang: lang)
+                syncToastIsError = true
+            }
+            manager.calendarSyncResult = nil
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                syncToastMessage = nil
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if let message = syncToastMessage {
+                Text(message)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(
+                        Capsule()
+                            .fill(syncToastIsError ? Color.red.opacity(0.9) : VisioColors.primary500.opacity(0.9))
+                    )
+                    .padding(.bottom, 24)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .animation(.easeInOut(duration: 0.3), value: syncToastMessage)
             }
         }
         .sheet(isPresented: $showCreateRoom) {

--- a/ios/VisioMobile/VisioManager.swift
+++ b/ios/VisioMobile/VisioManager.swift
@@ -10,6 +10,11 @@ struct TestConnectParams: Sendable {
     let mediaFile: String?
 }
 
+enum CalendarSyncResult: Equatable {
+    case success(count: Int)
+    case error(message: String)
+}
+
 /// Central state manager for the Visio app, backed by UniFFI-generated VisioClient.
 /// Conforms to VisioEventListener to receive room events from Rust.
 @MainActor
@@ -58,6 +63,7 @@ class VisioManager: ObservableObject {
     @Published var lastScreenShareParticipantSid: String? = nil
     @Published var upcomingMeetings: [Meeting] = []
     @Published var calendarLoading: Bool = false
+    @Published var calendarSyncResult: CalendarSyncResult?
 
     let authManager = OidcAuthManager()
 
@@ -1177,6 +1183,7 @@ class VisioManager: ObservableObject {
         case .meetingsUpdated(let meetings):
             self.upcomingMeetings = meetings
             self.calendarLoading = false
+            self.calendarSyncResult = .success(count: meetings.count)
 
         case .meetingImminent(let meeting):
             scheduleMeetingNotification(
@@ -1202,6 +1209,7 @@ class VisioManager: ObservableObject {
         case .calendarError(let message):
             NSLog("VisioManager: calendar error: %@", message)
             self.calendarLoading = false
+            self.calendarSyncResult = .error(message: message)
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Android**: Toast notification on sync success (meeting count)
  and error via CalendarSyncResult sealed class in VisioManager
- **iOS**: Capsule overlay toast in HomeView on sync completion,
  auto-dismissed after 3s, red for errors
- **Desktop**: Toast notification for success/error, error state
  in MeetingsTab, settings save triggers calendar refresh
- **i18n**: 4 new keys in all 6 languages (sync started, success,
  error, no meetings)

## Test plan

- [ ] Android: save calendar URL in settings → toast appears
- [ ] Android: invalid URL → error toast
- [ ] iOS: save calendar URL → overlay toast on HomeView
- [ ] iOS: invalid URL → red error toast
- [ ] Desktop: save calendar URL → toast with meeting count
- [ ] Desktop: invalid URL → error toast
- [ ] All: meetings tab shows loading then updates

Closes #121