### PR TITLE
fix(desktop): redesign dark theme colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to
 
 ### Fixed
 
+- Redesign desktop dark theme colors and contrast (#120)
 - Assert light theme is default on all platforms (#119)
 - Bluetooth device shows real name instead of generic "Bluetooth" (#118)
 - Release Bluetooth SCO audio channel on disconnect (#118)

--- a/crates/visio-desktop/frontend/src/App.css
+++ b/crates/visio-desktop/frontend/src/App.css
@@ -24,12 +24,114 @@
   --bg: #161622;
   --bg-secondary: #222234;
   --bg-tertiary: #2d2d46;
-  --border: #2d2d46;
-  --text: #ffffff;
-  --text-secondary: #929292;
-  --text-tertiary: #5a5a8f;
+  --border: #3a3a54;
+  --text: #f0f0f5;
+  --text-secondary: #b0b0b8;
+  --text-tertiary: #8888b8;
+  --accent: #6a6af4;
   --error-bg: #6c302e;
+  --error: #ff6b6b;
   --error-text: #ee6a66;
+  --success: #4ade80;
+  --warning: #fbbf24;
+  --hand-raise: #fde047;
+}
+
+/* -- Dark mode component refinements --------------------------------------- */
+
+[data-theme='dark'] .btn-primary {
+  background: #6a6af4;
+}
+
+[data-theme='dark'] .btn-primary:hover:not(:disabled) {
+  background: #7f7dff;
+}
+
+[data-theme='dark'] .settings-save {
+  background: #6a6af4;
+}
+
+[data-theme='dark'] .settings-save:hover {
+  background: #7f7dff;
+}
+
+[data-theme='dark'] .form-group input {
+  background: #1e1e30;
+  border-color: #3a3a54;
+}
+
+[data-theme='dark'] .form-group input:focus {
+  border-color: #6a6af4;
+  box-shadow: 0 0 0 2px rgba(106, 106, 244, 0.2);
+}
+
+[data-theme='dark'] .settings-input {
+  background: #1e1e30;
+  border-color: #3a3a54;
+}
+
+[data-theme='dark'] .settings-input:focus {
+  border-color: #6a6af4;
+  box-shadow: 0 0 0 2px rgba(106, 106, 244, 0.2);
+}
+
+[data-theme='dark'] .settings-section select {
+  background: #1e1e30;
+  border-color: #3a3a54;
+}
+
+[data-theme='dark'] .room-history-item {
+  background: rgba(106, 106, 244, 0.08);
+}
+
+[data-theme='dark'] .room-history-item:hover {
+  background: rgba(106, 106, 244, 0.16);
+}
+
+[data-theme='dark'] .home-tab-active {
+  color: #6a6af4;
+  background: #1e1e30;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme='dark'] .settings-modal {
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
+}
+
+[data-theme='dark'] .auth-card {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+[data-theme='dark'] .chat-input {
+  background: #1e1e30;
+  border-color: #3a3a54;
+}
+
+[data-theme='dark'] .chat-input:focus {
+  border-color: #6a6af4;
+}
+
+[data-theme='dark'] .info-link-input {
+  background: #1e1e30;
+  border-color: #3a3a54;
+}
+
+/* Scrollbar dark mode */
+[data-theme='dark'] ::-webkit-scrollbar {
+  width: 8px;
+}
+
+[data-theme='dark'] ::-webkit-scrollbar-track {
+  background: #161622;
+}
+
+[data-theme='dark'] ::-webkit-scrollbar-thumb {
+  background: #3a3a54;
+  border-radius: 4px;
+}
+
+[data-theme='dark'] ::-webkit-scrollbar-thumb:hover {
+  background: #4a4a64;
 }
 
 * {


### PR DESCRIPTION
## Summary

- Override `--accent` to `#6a6af4` in dark mode (matching
  Android/iOS `Primary500`), fixing invisible buttons/links
- Fix text contrast: `--text-secondary` from `#929292` to
  `#b0b0b8` (~4.7:1), `--text-tertiary` from `#5a5a8f` to
  `#8888b8` (~3.6:1)
- Visible borders: `--border` from `#2d2d46` to `#3a3a54`
- Component-specific dark refinements:
  - Inputs: darker background `#1e1e30`, focus glow
  - Buttons: purple accent with lighter hover
  - Tabs: active tab with contrast background + shadow
  - Room history: purple-tinted hover states
  - Settings modal: stronger shadow
  - Chat input: consistent dark styling
  - Scrollbars: visible dark thumb
- Add missing dark overrides: `--success`, `--warning`,
  `--error`, `--hand-raise`

## Test plan

- [ ] Toggle to dark theme in settings
- [ ] Verify buttons are visible (purple, not dark navy)
- [ ] Verify text labels are readable
- [ ] Check input fields have distinct background
- [ ] Check tabs show clear active/inactive state
- [ ] Check scrollbar visibility
- [ ] Verify settings modal is readable
- [ ] Switch back to light — no regressions

Closes #120