### PR TITLE
fix: keep planned meetings during transient sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to
 
 ### Fixed
 
+- Keep planned meetings during transient sync failures (#126)
 - Redesign desktop dark theme colors and contrast (#120)
 - Assert light theme is default on all platforms (#119)
 - Bluetooth device shows real name instead of generic "Bluetooth" (#118)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +984,15 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "combine"
@@ -2549,6 +2568,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,6 +2750,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,9 +2765,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http 1.4.0",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -3750,6 +3796,31 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.2",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -6162,6 +6233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6904,6 +6981,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -7647,6 +7725,7 @@ dependencies = [
  "ical",
  "livekit",
  "livekit-api",
+ "mockito",
  "rand 0.8.5",
  "regex",
  "reqwest 0.12.28",

--- a/crates/visio-core/Cargo.toml
+++ b/crates/visio-core/Cargo.toml
@@ -25,3 +25,4 @@ ical = "0.11"
 tempfile = "3"
 tokio = { workspace = true }
 livekit-api = { workspace = true }
+mockito = "1"

--- a/crates/visio-core/src/calendar.rs
+++ b/crates/visio-core/src/calendar.rs
@@ -346,6 +346,24 @@ impl CalendarService {
             }
         }
 
+        // Retention guard: if refresh found 0 meetings but the cached
+        // list still has non-expired entries, treat this as a transient
+        // failure rather than silently clearing the UI.
+        if meetings.is_empty() {
+            let guard = self.meetings.lock().unwrap_or_else(|e| e.into_inner());
+            let has_valid_cached = guard.iter().any(|m| m.end_time >= now_ts);
+            if has_valid_cached {
+                tracing::warn!(
+                    "calendar: refresh returned 0 meetings but cache has valid entries — keeping cache"
+                );
+                // Re-emit the existing cached meetings so listeners stay in sync
+                let cached = guard.clone();
+                drop(guard);
+                self.emitter.emit(VisioEvent::MeetingsUpdated(cached));
+                return;
+            }
+        }
+
         {
             let mut guard = self.meetings.lock().unwrap_or_else(|e| e.into_inner());
             *guard = meetings.clone();
@@ -847,6 +865,137 @@ END:VCALENDAR";
         assert_eq!(meetings[0].server_name, "meet.linagora.com");
         assert_eq!(meetings[1].summary, "Point BC");
         assert!(meetings[1].room_url.contains("qay-glwz-xxq"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Retention guard tests (#126)
+    // -----------------------------------------------------------------------
+
+    /// When refresh returns 0 meetings but the cache still holds valid
+    /// (non-expired) entries, the cache must be preserved and re-emitted.
+    #[tokio::test]
+    async fn test_retention_guard_keeps_cache_on_empty_refresh() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().to_str().unwrap().to_string();
+        std::mem::forget(dir);
+
+        let store = Arc::new(SettingsStore::new(&data_dir));
+        let emitter = EventEmitter::new();
+        let captured: Arc<Mutex<Vec<VisioEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        emitter.add_listener(Arc::new(EventCapture {
+            events: captured.clone(),
+        }));
+
+        // Configure a calendar URL that will return invalid (non-iCal) content
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/cal.ics")
+            .with_status(200)
+            .with_body("<html>Error</html>")
+            .create_async()
+            .await;
+
+        store.set_calendar_url(Some(format!("{}/cal.ics", server.url())));
+        store.set_meet_instances(vec!["meet.linagora.com".to_string()]);
+
+        let svc = CalendarService::new(store, emitter, data_dir);
+
+        // Pre-populate cache with a valid future meeting
+        let now_ts = Utc::now().timestamp();
+        let cached_meeting = Meeting {
+            id: "retain-001".to_string(),
+            summary: "Kept meeting".to_string(),
+            start_time: now_ts + 3600,
+            end_time: now_ts + 7200,
+            room_url: "https://meet.linagora.com/kept".to_string(),
+            deep_link: "visio://meet.linagora.com/kept".to_string(),
+            server_name: "meet.linagora.com".to_string(),
+        };
+        {
+            let mut guard = svc.meetings.lock().unwrap();
+            *guard = vec![cached_meeting.clone()];
+        }
+
+        // Refresh — server returns HTML, parse yields 0 meetings
+        svc.refresh().await;
+        mock.assert_async().await;
+
+        // Cache should still contain the original meeting
+        let meetings = svc.get_meetings();
+        assert_eq!(meetings.len(), 1, "cached meeting must be retained");
+        assert_eq!(meetings[0].id, "retain-001");
+
+        // Should have emitted MeetingsUpdated with the cached list
+        let events = captured.lock().unwrap();
+        let updated = events
+            .iter()
+            .find(|e| matches!(e, VisioEvent::MeetingsUpdated(_)));
+        assert!(updated.is_some(), "should re-emit cached meetings");
+        if let Some(VisioEvent::MeetingsUpdated(m)) = updated {
+            assert_eq!(m.len(), 1);
+            assert_eq!(m[0].id, "retain-001");
+        }
+    }
+
+    /// When refresh returns 0 meetings and the cache is also empty (or all
+    /// expired), the empty result should be accepted normally.
+    #[tokio::test]
+    async fn test_retention_guard_allows_empty_when_cache_expired() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().to_str().unwrap().to_string();
+        std::mem::forget(dir);
+
+        let store = Arc::new(SettingsStore::new(&data_dir));
+        let emitter = EventEmitter::new();
+        let captured: Arc<Mutex<Vec<VisioEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        emitter.add_listener(Arc::new(EventCapture {
+            events: captured.clone(),
+        }));
+
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/cal.ics")
+            .with_status(200)
+            .with_body("<html>Error</html>")
+            .create_async()
+            .await;
+
+        store.set_calendar_url(Some(format!("{}/cal.ics", server.url())));
+        store.set_meet_instances(vec!["meet.linagora.com".to_string()]);
+
+        let svc = CalendarService::new(store, emitter, data_dir);
+
+        // Pre-populate cache with an expired meeting
+        let now_ts = Utc::now().timestamp();
+        {
+            let mut guard = svc.meetings.lock().unwrap();
+            *guard = vec![Meeting {
+                id: "expired-001".to_string(),
+                summary: "Expired".to_string(),
+                start_time: now_ts - 7200,
+                end_time: now_ts - 3600,
+                room_url: "https://meet.linagora.com/old".to_string(),
+                deep_link: "visio://meet.linagora.com/old".to_string(),
+                server_name: "meet.linagora.com".to_string(),
+            }];
+        }
+
+        svc.refresh().await;
+        mock.assert_async().await;
+
+        // Cache should be cleared (no valid meetings to retain)
+        let meetings = svc.get_meetings();
+        assert_eq!(meetings.len(), 0, "expired cache should be cleared");
+
+        // Should have emitted MeetingsUpdated with empty list
+        let events = captured.lock().unwrap();
+        let updated = events
+            .iter()
+            .find(|e| matches!(e, VisioEvent::MeetingsUpdated(_)));
+        assert!(updated.is_some());
+        if let Some(VisioEvent::MeetingsUpdated(m)) = updated {
+            assert!(m.is_empty());
+        }
     }
 
     /// Past meetings (end_time < now) must be excluded from get_meetings().

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -659,10 +659,22 @@ function MeetingsTab({
     let unlistenUpdated: (() => void) | null = null
     let unlistenError: (() => void) | null = null
     listen<Meeting[]>('meetings-updated', (event) => {
-      setMeetings(event.payload)
+      const newMeetings = event.payload
+      // Retention guard: if the backend sends an empty list but we had
+      // meetings, keep the existing list (defense-in-depth for #126).
+      setMeetings((prev) => {
+        if (newMeetings.length === 0 && prev.length > 0) {
+          return prev
+        }
+        return newMeetings
+      })
       setLastSyncTime(new Date())
-      setStatus(event.payload.length === 0 ? 'empty' : 'list')
-      const count = event.payload.length
+      if (newMeetings.length > 0) {
+        setStatus('list')
+      } else {
+        setStatus((prev) => (prev === 'list' ? 'list' : 'empty'))
+      }
+      const count = newMeetings.length
       const msg =
         count > 0
           ? t('calendar.sync.success').replace('{count}', String(count))
@@ -891,7 +903,11 @@ function HomeView({
   useEffect(() => {
     let unlisten: (() => void) | null = null
     listen<Meeting[]>('meetings-updated', (event) => {
-      setMeetingCount(event.payload.length)
+      // Only update badge count if we received meetings; keep previous
+      // count when payload is empty (retention guard, #126).
+      if (event.payload.length > 0) {
+        setMeetingCount(event.payload.length)
+      }
     }).then((fn) => {
       unlisten = fn
     })


### PR DESCRIPTION
## Summary

- **Rust core**: retention guard in `refresh()` — if parsing
  returns 0 meetings but cache has non-expired entries, keep
  cache and re-emit it instead of wiping
- **Desktop frontend**: defense-in-depth — `meetings-updated`
  listener retains previous meetings when payload is empty
- 2 new async tests with mockito for retention guard

## Root cause

When periodic calendar refresh succeeds (HTTP 200) but the
body is not valid iCal (session expired, redirect to HTML,
rate limit), the parser returns 0 events and the cache was
overwritten with an empty list, clearing the UI.

## Fix logic

- Refresh finds meetings → normal update
- Refresh finds 0 AND cache has valid meetings → keep cache
- Refresh finds 0 AND cache empty/expired → emit empty

## Test plan

- [x] `test_retention_guard_keeps_cache_on_empty_refresh`
- [x] `test_retention_guard_allows_empty_when_cache_expired`
- [ ] Manual: configure calendar, wait for refresh, verify
  meetings persist

Closes #126