### PR TITLE
fix: meetings timezone, live countdown, indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to
 
 ### Fixed
 
+- Timezone-aware iCal parsing with TZID support (#122)
+- Widen desktop meetings list to 640 px (#122)
+- Live countdown updates every 60 s on all platforms (#122)
+- Imminent meeting badge turns red on all platforms (#122)
+- Desktop notification on meeting-reminder event (#122)
 - Keep planned meetings during transient sync failures (#126)
 - Redesign desktop dark theme colors and contrast (#120)
 - Assert light theme is default on all platforms (#119)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,6 +877,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4771,6 +4781,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4870,6 +4889,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher 1.0.2",
 ]
@@ -7721,6 +7749,7 @@ name = "visio-core"
 version = "0.6.0"
 dependencies = [
  "chrono",
+ "chrono-tz",
  "futures-util",
  "ical",
  "livekit",

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/HomeScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/HomeScreen.kt
@@ -150,7 +150,15 @@ fun HomeScreen(
         VisioManager.clearCalendarSyncResult()
     }
 
-    val nowSeconds = System.currentTimeMillis() / 1000L
+    // Fix 3: live-updating "now" so countdowns and imminent badge refresh
+    var nowSeconds by remember { mutableStateOf(System.currentTimeMillis() / 1000L) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(60_000)
+            nowSeconds = System.currentTimeMillis() / 1000L
+        }
+    }
+
     val hasImminentMeeting =
         upcomingMeetings.any { meeting ->
             val minutesUntil = (meeting.startTime - nowSeconds) / 60
@@ -579,6 +587,7 @@ private fun ColumnScope.HomeTabContent(
                 isLoading = calendarLoading,
                 isDark = isDark,
                 lang = lang,
+                nowSeconds = nowSeconds,
                 onSettings = onSettings,
                 onJoinMeeting = { meetingRoomUrl, _ ->
                     onJoin(meetingRoomUrl, username.trim(), null)

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/MeetingsTab.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/MeetingsTab.kt
@@ -56,6 +56,7 @@ fun MeetingsTab(
     isLoading: Boolean,
     isDark: Boolean,
     lang: String,
+    nowSeconds: Long = System.currentTimeMillis() / 1000L,
     onSettings: () -> Unit,
     onJoinMeeting: (roomUrl: String, serverName: String) -> Unit,
 ) {
@@ -74,6 +75,7 @@ fun MeetingsTab(
                 meetings = meetings,
                 isDark = isDark,
                 lang = lang,
+                nowSeconds = nowSeconds,
                 onJoinMeeting = onJoinMeeting,
             )
         }
@@ -200,9 +202,10 @@ private fun MeetingsList(
     meetings: List<Meeting>,
     isDark: Boolean,
     lang: String,
+    nowSeconds: Long = System.currentTimeMillis() / 1000L,
     onJoinMeeting: (roomUrl: String, serverName: String) -> Unit,
 ) {
-    val now = System.currentTimeMillis() / 1000L
+    val now = nowSeconds
 
     // Separate in-progress meetings (started) from upcoming
     val inProgress = meetings.filter { it.startTime <= now && it.endTime > now }

--- a/crates/visio-core/Cargo.toml
+++ b/crates/visio-core/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 chrono = "0.4"
+chrono-tz = "0.10"
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/visio-core/src/calendar.rs
+++ b/crates/visio-core/src/calendar.rs
@@ -8,7 +8,8 @@ use std::io::BufReader;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use chrono::{NaiveDateTime, TimeZone, Utc};
+use chrono::{NaiveDate, NaiveDateTime, TimeZone, Utc};
+use chrono_tz::Tz;
 use regex::Regex;
 
 use crate::events::{EventEmitter, Meeting, VisioEvent};
@@ -23,18 +24,68 @@ use crate::settings::{CalendarRefreshInterval, SettingsStore};
 ///
 /// Returns `None` if the string cannot be parsed.
 pub fn parse_ical_timestamp(ts: &str) -> Option<i64> {
-    // Strip trailing 'Z' if present — we always treat as UTC.
-    let ts = ts.trim_end_matches('Z');
-    // Accept both "YYYYMMDDTHHMMSS" and "YYYYMMDDTHHMMSS" variants.
-    let fmt = if ts.contains('T') {
-        "%Y%m%dT%H%M%S"
-    } else {
-        "%Y%m%d"
-    };
-    let ndt = NaiveDateTime::parse_from_str(ts, fmt)
-        .or_else(|_| NaiveDateTime::parse_from_str(&format!("{}T000000", ts), "%Y%m%dT%H%M%S"))
-        .ok()?;
+    parse_ical_datetime(ts, None)
+}
+
+/// Parse an iCal datetime value into a Unix timestamp, with optional TZID.
+///
+/// Rules:
+/// - If the value ends with `Z` → parse as UTC.
+/// - If `tzid` is provided → parse as naive local time in the given timezone.
+/// - Otherwise (floating time) → treat as UTC and log a warning.
+pub fn parse_ical_datetime(value: &str, tzid: Option<&str>) -> Option<i64> {
+    if let Some(bare) = value.strip_suffix('Z') {
+        // Explicit UTC
+        let ndt = parse_naive_datetime(bare)?;
+        return Some(Utc.from_utc_datetime(&ndt).timestamp());
+    }
+
+    if let Some(tz_name) = tzid {
+        let ndt = parse_naive_datetime(value)?;
+        let tz: Tz = match tz_name.parse() {
+            Ok(t) => t,
+            Err(_) => {
+                tracing::warn!("calendar: unknown TZID '{}', treating as UTC", tz_name);
+                return Some(Utc.from_utc_datetime(&ndt).timestamp());
+            }
+        };
+        // Use the earliest valid mapping for ambiguous times (e.g. DST fall-back)
+        return tz
+            .from_local_datetime(&ndt)
+            .earliest()
+            .map(|dt| dt.with_timezone(&Utc).timestamp());
+    }
+
+    // Floating time — no Z, no TZID. Treat as UTC (best-effort).
+    tracing::debug!(
+        "calendar: floating timestamp '{}' with no TZID, treating as UTC",
+        value
+    );
+    let ndt = parse_naive_datetime(value)?;
     Some(Utc.from_utc_datetime(&ndt).timestamp())
+}
+
+/// Parse a naive datetime from common iCal formats.
+fn parse_naive_datetime(ts: &str) -> Option<NaiveDateTime> {
+    if ts.contains('T') {
+        NaiveDateTime::parse_from_str(ts, "%Y%m%dT%H%M%S").ok()
+    } else {
+        // Date-only: treat as midnight
+        NaiveDate::parse_from_str(ts, "%Y%m%d")
+            .ok()
+            .and_then(|d| d.and_hms_opt(0, 0, 0))
+    }
+}
+
+/// Extract the TZID parameter from a named property in an iCal event.
+fn get_tzid(event: &ical::parser::ical::component::IcalEvent, prop_name: &str) -> Option<String> {
+    event
+        .properties
+        .iter()
+        .find(|p| p.name == prop_name)
+        .and_then(|p| p.params.as_ref())
+        .and_then(|params| params.iter().find(|(k, _)| k == "TZID"))
+        .and_then(|(_, values)| values.first().cloned())
 }
 
 // ---------------------------------------------------------------------------
@@ -117,11 +168,13 @@ pub fn parse_meeting_from_vevent(
     };
 
     let dtstart_str = get_prop("DTSTART")?;
-    let start_time = parse_ical_timestamp(&dtstart_str)?;
+    let start_tzid = get_tzid(event, "DTSTART");
+    let start_time = parse_ical_datetime(&dtstart_str, start_tzid.as_deref())?;
     // DURATION (e.g. PT1H30M) is not supported — assume 1h default if DTEND absent.
     // iCal exports from SabreDAV/TwCalendar always expand DTEND, so this is a safe fallback.
+    let end_tzid = get_tzid(event, "DTEND");
     let end_time = get_prop("DTEND")
-        .and_then(|s| parse_ical_timestamp(&s))
+        .and_then(|s| parse_ical_datetime(&s, end_tzid.as_deref()))
         .unwrap_or(start_time + 3600);
 
     // Exclude events that ended before now or start after the cutoff.
@@ -996,6 +1049,118 @@ END:VCALENDAR";
         if let Some(VisioEvent::MeetingsUpdated(m)) = updated {
             assert!(m.is_empty());
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Timezone-aware parsing tests (#122)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_ical_datetime_utc_z_suffix() {
+        let ts = parse_ical_datetime("20260623T140000Z", None).unwrap();
+        let dt = Utc.timestamp_opt(ts, 0).unwrap();
+        assert_eq!(
+            dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2026-06-23 14:00:00"
+        );
+    }
+
+    #[test]
+    fn test_parse_ical_datetime_tzid_paris_summer() {
+        // 2026-06-23 is summer time in Paris → UTC+2
+        // 14:00 Europe/Paris = 12:00 UTC
+        let ts = parse_ical_datetime("20260623T140000", Some("Europe/Paris")).unwrap();
+        let dt = Utc.timestamp_opt(ts, 0).unwrap();
+        assert_eq!(
+            dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2026-06-23 12:00:00"
+        );
+    }
+
+    #[test]
+    fn test_parse_ical_datetime_tzid_paris_winter() {
+        // 2026-01-15 is winter time in Paris → UTC+1
+        // 14:00 Europe/Paris = 13:00 UTC
+        let ts = parse_ical_datetime("20260115T140000", Some("Europe/Paris")).unwrap();
+        let dt = Utc.timestamp_opt(ts, 0).unwrap();
+        assert_eq!(
+            dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2026-01-15 13:00:00"
+        );
+    }
+
+    #[test]
+    fn test_parse_ical_datetime_floating_no_tz() {
+        // No Z, no TZID → treated as UTC
+        let ts = parse_ical_datetime("20260323T100000", None).unwrap();
+        let dt = Utc.timestamp_opt(ts, 0).unwrap();
+        assert_eq!(
+            dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2026-03-23 10:00:00"
+        );
+    }
+
+    #[test]
+    fn test_parse_ical_datetime_date_only() {
+        // Date-only → midnight UTC
+        let ts = parse_ical_datetime("20260323", None).unwrap();
+        let dt = Utc.timestamp_opt(ts, 0).unwrap();
+        assert_eq!(
+            dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2026-03-23 00:00:00"
+        );
+    }
+
+    /// Helper: build an event with TZID parameters on DTSTART/DTEND.
+    fn make_event_with_tzid(
+        props: &[(&str, &str)],
+        tzid_start: Option<&str>,
+        tzid_end: Option<&str>,
+    ) -> ical::parser::ical::component::IcalEvent {
+        use ical::property::Property;
+        let mut event = ical::parser::ical::component::IcalEvent::new();
+        for (name, value) in props {
+            let mut p = Property::new();
+            p.name = name.to_string();
+            p.value = Some(value.to_string());
+            let tzid = match *name {
+                "DTSTART" => tzid_start,
+                "DTEND" => tzid_end,
+                _ => None,
+            };
+            if let Some(tz) = tzid {
+                p.params = Some(vec![("TZID".to_string(), vec![tz.to_string()])]);
+            }
+            event.properties.push(p);
+        }
+        event
+    }
+
+    #[test]
+    fn test_parse_meeting_with_tzid_params() {
+        // 14:00 Europe/Paris in summer = 12:00 UTC
+        let event = make_event_with_tzid(
+            &[
+                ("UID", "uid-tz-001"),
+                ("DTSTART", "20260623T140000"),
+                ("DTEND", "20260623T150000"),
+                ("SUMMARY", "Paris meeting"),
+                ("LOCATION", "https://meet.linagora.com/paris-room"),
+            ],
+            Some("Europe/Paris"),
+            Some("Europe/Paris"),
+        );
+
+        // Use a "now" that is well before the meeting in UTC
+        let now_utc = 1_750_000_000; // ~2025-06-15
+        let cutoff = now_utc + 400 * 24 * 3600;
+        let m = parse_meeting_from_vevent(&event, &default_servers(), now_utc, cutoff).unwrap();
+
+        // 2026-06-23T14:00 Europe/Paris = 2026-06-23T12:00 UTC
+        let start_dt = Utc.timestamp_opt(m.start_time, 0).unwrap();
+        assert_eq!(start_dt.format("%H:%M").to_string(), "12:00");
+        let end_dt = Utc.timestamp_opt(m.end_time, 0).unwrap();
+        assert_eq!(end_dt.format("%H:%M").to_string(), "13:00");
     }
 
     /// Past meetings (end_time < now) must be excluded from get_meetings().

--- a/crates/visio-desktop/frontend/src/App.css
+++ b/crates/visio-desktop/frontend/src/App.css
@@ -3090,7 +3090,7 @@ main {
   scrollbar-gutter: stable;
   max-height: 460px;
   width: 100%;
-  max-width: 480px;
+  max-width: 640px;
 }
 
 .meetings-list-header {
@@ -3115,6 +3115,21 @@ main {
   font-weight: 600;
   margin-left: 6px;
   padding: 0 6px;
+}
+
+.tab-badge-imminent {
+  background: var(--error);
+  animation: badge-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes badge-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
 }
 
 .meetings-day-group {

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -885,6 +885,15 @@ function HomeView({
   const [resolvedUrl, setResolvedUrl] = useState('')
   const [roomHistory, setRoomHistory] = useState<RoomHistoryEntry[]>([])
   const [meetingCount, setMeetingCount] = useState(0)
+  const [tick, setTick] = useState(0)
+  const [hasImminentMeeting, setHasImminentMeeting] = useState(false)
+  const [reminderToast, setReminderToast] = useState<string | null>(null)
+
+  // Fix 3: Tick every 60 s so countdown labels and imminent state update live
+  useEffect(() => {
+    const id = setInterval(() => setTick((n) => n + 1), 60_000)
+    return () => clearInterval(id)
+  }, [])
 
   useEffect(() => {
     invoke<RoomHistoryEntry[]>('get_room_history')
@@ -895,11 +904,17 @@ function HomeView({
   // Load meeting count from cache on mount (so badge shows immediately)
   useEffect(() => {
     invoke<Meeting[]>('get_upcoming_meetings')
-      .then((list) => setMeetingCount(list.length))
+      .then((list) => {
+        setMeetingCount(list.length)
+        setHasImminentMeeting(
+          list.some((m) => isMeetingImminent(m) || isMeetingOngoing(m))
+        )
+      })
       .catch(() => {})
   }, [])
 
   // Also listen for meetings-updated to keep badge in sync even when not on meetings tab
+  const meetingsRef = useRef<Meeting[]>([])
   useEffect(() => {
     let unlisten: (() => void) | null = null
     listen<Meeting[]>('meetings-updated', (event) => {
@@ -907,8 +922,55 @@ function HomeView({
       // count when payload is empty (retention guard, #126).
       if (event.payload.length > 0) {
         setMeetingCount(event.payload.length)
+        meetingsRef.current = event.payload
+        setHasImminentMeeting(
+          event.payload.some((m) => isMeetingImminent(m) || isMeetingOngoing(m))
+        )
       }
     }).then((fn) => {
+      unlisten = fn
+    })
+    return () => {
+      unlisten?.()
+    }
+  }, [])
+
+  // Fix 3+4: Recompute imminent state on each tick
+  useEffect(() => {
+    if (meetingsRef.current.length > 0) {
+      setHasImminentMeeting(
+        meetingsRef.current.some(
+          (m) => isMeetingImminent(m) || isMeetingOngoing(m)
+        )
+      )
+    }
+  }, [tick])
+
+  // Fix 5: Listen for meeting-reminder events and show notification
+  useEffect(() => {
+    let unlisten: (() => void) | null = null
+    listen<{ summary: string; start_time: number }>(
+      'meeting-reminder',
+      (event) => {
+        const { summary } = event.payload
+        const msg = summary
+          ? `${summary} — ${t('meetings.time.inMinutes').replace('{minutes}', '15')}`
+          : t('meetings.time.inMinutes').replace('{minutes}', '15')
+        setReminderToast(msg)
+        setTimeout(() => setReminderToast(null), 5000)
+        // Also try system notification if available
+        if ('Notification' in window && Notification.permission === 'granted') {
+          new Notification(summary || t('home.tab.meetings'), {
+            body: t('meetings.time.inMinutes').replace('{minutes}', '15'),
+          })
+        } else if (
+          'Notification' in window &&
+          Notification.permission === 'default'
+        ) {
+          Notification.requestPermission()
+        }
+      }
+    ).then((fn) => {
       unlisten = fn
     })
     return () => {
@@ -1060,7 +1122,11 @@ function HomeView({
           >
             {t('home.tab.meetings')}
             {meetingCount > 0 && (
-              <span className="tab-badge">{meetingCount}</span>
+              <span
+                className={`tab-badge${hasImminentMeeting ? ' tab-badge-imminent' : ''}`}
+              >
+                {meetingCount}
+              </span>
             )}
           </button>
         </div>
@@ -1414,6 +1480,9 @@ function HomeView({
           }}
           onCancel={() => setShowCreateRoom(false)}
         />
+      )}
+      {reminderToast && (
+        <div className="sync-toast sync-toast-success">{reminderToast}</div>
       )}
     </div>
   )

--- a/ios/VisioMobile/Views/HomeView.swift
+++ b/ios/VisioMobile/Views/HomeView.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 import visioFFI
 
@@ -21,9 +22,21 @@ struct HomeView: View {
     @State private var selectedTab: Int = 0
     @State private var syncToastMessage: String?
     @State private var syncToastIsError: Bool = false
+    @State private var now = Date()
+    private let minuteTimer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
 
     private var lang: String { manager.currentLang }
     private var isDark: Bool { manager.currentTheme == "dark" }
+
+    private var hasImminentMeeting: Bool {
+        let nowTs = now.timeIntervalSince1970
+        return manager.upcomingMeetings.contains { meeting in
+            let start = TimeInterval(meeting.startTime)
+            let end = TimeInterval(meeting.endTime)
+            let minutesUntil = (start - nowTs) / 60
+            return (minutesUntil >= 0 && minutesUntil < 15) || (start <= nowTs && end > nowTs)
+        }
+    }
 
     private static let slugPattern = /^[a-z]{3}-[a-z]{4}-[a-z]{3}$/
 
@@ -50,7 +63,14 @@ struct HomeView: View {
                         : meetingsBase + " (\(manager.upcomingMeetings.count))"
                 Picker("", selection: $selectedTab) {
                     Text(Strings.t("home.tab.join", lang: lang)).tag(0)
-                    Text(meetingsLabel).tag(1)
+                    HStack(spacing: 4) {
+                        Text(meetingsLabel)
+                        if hasImminentMeeting {
+                            Circle()
+                                .fill(Color.red)
+                                .frame(width: 8, height: 8)
+                        }
+                    }.tag(1)
                 }
                 .pickerStyle(.segmented)
                 .padding(.horizontal, 16)
@@ -349,6 +369,7 @@ struct HomeView: View {
             SettingsView()
                 .environmentObject(manager)
         }
+        .onReceive(minuteTimer) { _ in now = Date() }
         .onAppear {
             // Pre-fill display name from manager (includes OIDC identity)
             let name = manager.displayName

--- a/ios/VisioMobile/Views/MeetingsTabView.swift
+++ b/ios/VisioMobile/Views/MeetingsTabView.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 import visioFFI
 
@@ -11,16 +12,23 @@ struct MeetingsTabView: View {
     let onRefresh: () -> Void
     let onJoinMeeting: (Meeting) -> Void
 
+    // Fix 3: live-updating date so countdowns and imminent state refresh
+    @State private var now = Date()
+    private let timer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
+
     var body: some View {
-        if !hasCalendarUrl {
-            onboardingView
-        } else if isLoading && meetings.isEmpty {
-            loadingView
-        } else if meetings.isEmpty {
-            emptyView
-        } else {
-            listView
+        Group {
+            if !hasCalendarUrl {
+                onboardingView
+            } else if isLoading && meetings.isEmpty {
+                loadingView
+            } else if meetings.isEmpty {
+                emptyView
+            } else {
+                listView
+            }
         }
+        .onReceive(timer) { _ in now = Date() }
     }
 
     // MARK: - States
@@ -96,6 +104,7 @@ struct MeetingsTabView: View {
                                 meeting: meeting,
                                 isDark: isDark,
                                 lang: lang,
+                                currentDate: now,
                                 onJoin: { onJoinMeeting(meeting) }
                             )
                             .padding(.horizontal, 16)
@@ -179,9 +188,10 @@ private struct MeetingRow: View {
     let meeting: Meeting
     let isDark: Bool
     let lang: String
+    var currentDate: Date = Date()
     let onJoin: () -> Void
 
-    private var now: Date { Date() }
+    private var now: Date { currentDate }
 
     private var startDate: Date {
         Date(timeIntervalSince1970: TimeInterval(meeting.startTime))


### PR DESCRIPTION
## Summary

5 fixes for meetings display (#122):

1. **Timezone-aware iCal parsing** — new `parse_ical_datetime()`
   handles TZID params (e.g. `Europe/Paris`), Z suffix (UTC),
   and floating time. Uses `chrono-tz`. 7 new tests.

2. **Meetings list width** — `max-width` from 480px to 640px
   on Desktop.

3. **Live countdown updates** — 60s timer on all platforms:
   Desktop (`setInterval`), Android (`LaunchedEffect` +
   `delay`), iOS (`Timer.publish`). Relative times now
   update without manual refresh.

4. **Imminent meeting tab indicator** — Desktop: red pulsing
   badge. Android: live `nowSeconds` fixes stale badge.
   iOS: red dot next to meetings tab.

5. **Desktop notifications** — listen for `meeting-reminder`
   Tauri event, show toast + system `Notification` if
   permission granted.

## Test plan

- [x] 7 new timezone unit tests (UTC, Paris summer/winter,
  floating, date-only)
- [x] All 192 unit tests pass
- [ ] Desktop: verify meeting times match calendar
- [ ] Desktop: countdown updates every 60s
- [ ] Desktop: red badge when meeting < 15 min
- [ ] Desktop: notification toast on meeting reminder
- [ ] Android: countdown updates, red badge live
- [ ] iOS: countdown updates, red dot indicator

Closes #122