### PR TITLE
fix(desktop): macOS camera/mic permission prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to
 
 ### Fixed
 
+- macOS camera/mic permission prompts via infoPlist (#124)
 - Timezone-aware iCal parsing with TZID support (#122)
 - Widen desktop meetings list to 640 px (#122)
 - Live countdown updates every 60 s on all platforms (#122)

--- a/crates/visio-desktop/tauri.conf.json
+++ b/crates/visio-desktop/tauri.conf.json
@@ -45,7 +45,11 @@
         "icons/128x128@2x.png"
       ],
     "macOS": {
-      "entitlements": "entitlements.plist"
+      "entitlements": "entitlements.plist",
+      "infoPlist": {
+        "NSCameraUsageDescription": "Visio needs camera access for video calls",
+        "NSMicrophoneUsageDescription": "Visio needs microphone access for audio calls"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `NSCameraUsageDescription` and `NSMicrophoneUsageDescription`
  to `tauri.conf.json` under `bundle.macOS.infoPlist`
- The standalone `Info.plist` already had these keys, but Tauri 2.x
  only reads `infoPlist` from the JSON config — the file was ignored

## Root cause

Tauri 2.x generates the app bundle's `Info.plist` from
`tauri.conf.json`. The separate `Info.plist` file in the crate
directory was not being merged into the bundle. Without the
`NS*UsageDescription` keys, macOS silently denies camera/mic
access without showing a permission dialog.

## Test plan

- [ ] Build DMG from CI artifact
- [ ] Install on clean macOS (or reset permissions with
  `tccutil reset Camera io.visio.desktop`)
- [ ] Launch app, enable camera → system prompt appears
- [ ] Enable mic → system prompt appears

Closes #124