### PR TITLE
fix(desktop): keep meetings during manual refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to
 
 ### Fixed
 
+- Keep meetings visible during manual refresh (#123)
 - macOS camera/mic permission prompts via infoPlist (#124)
 - Timezone-aware iCal parsing with TZID support (#122)
 - Widen desktop meetings list to 640 px (#122)

--- a/crates/visio-desktop/frontend/src/App.css
+++ b/crates/visio-desktop/frontend/src/App.css
@@ -3102,6 +3102,37 @@ main {
   color: var(--text-secondary);
 }
 
+.meetings-list-header .btn-icon {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  transition: color 0.2s;
+}
+
+.meetings-list-header .btn-icon:hover {
+  color: var(--text);
+}
+
+.meetings-list-header .btn-icon:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.meetings-list-header .btn-icon.refreshing svg {
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .tab-badge {
   display: inline-flex;
   align-items: center;

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -623,6 +623,7 @@ function MeetingsTab({
   const [joining, setJoining] = useState<string | null>(null)
   const [loadingMessage, setLoadingMessage] = useState<string>('')
   const [lastSyncTime, setLastSyncTime] = useState<Date | null>(null)
+  const [refreshing, setRefreshing] = useState(false)
   const [syncToast, setSyncToast] = useState<{
     message: string
     isError: boolean
@@ -698,31 +699,26 @@ function MeetingsTab({
   }, [])
 
   const handleRefresh = async () => {
-    setStatus('loading')
-    setLoadingMessage(t('meetings.calendar.downloading'))
-    const t2 = setTimeout(
-      () => setLoadingMessage(t('meetings.calendar.analyzing')),
-      2000
-    )
-    const t5 = setTimeout(
-      () => setLoadingMessage(t('meetings.calendar.updatingLarge')),
-      5000
-    )
+    // Only show full loading screen on initial load (no meetings yet)
+    if (meetings.length === 0) {
+      setStatus('loading')
+      setLoadingMessage(t('meetings.calendar.downloading'))
+    }
+    setRefreshing(true)
     try {
       await invoke('refresh_calendar_now')
-      clearTimeout(t2)
-      clearTimeout(t5)
-      setLoadingMessage(t('meetings.calendar.updating'))
       const list: Meeting[] = await invoke('get_upcoming_meetings')
       setMeetings(list)
       setLastSyncTime(new Date())
       setStatus(list.length === 0 ? 'empty' : 'list')
     } catch {
-      clearTimeout(t2)
-      clearTimeout(t5)
       setSyncToast({ message: t('calendar.sync.error'), isError: true })
       setTimeout(() => setSyncToast(null), 4000)
-      setStatus(meetings.length > 0 ? 'list' : 'error')
+      if (meetings.length === 0) {
+        setStatus('error')
+      }
+    } finally {
+      setRefreshing(false)
     }
   }
 
@@ -787,8 +783,9 @@ function MeetingsTab({
           {meetings.length} {t('meetings.count')}
         </span>
         <button
-          className="btn-icon"
+          className={`btn-icon${refreshing ? ' refreshing' : ''}`}
           onClick={handleRefresh}
+          disabled={refreshing}
           title={t('meetings.refresh')}
         >
           <RiRefreshLine size={18} />


### PR DESCRIPTION
## Summary

- Manual refresh no longer clears the meetings list
- Existing meetings stay visible while sync runs
- Spinning animation on refresh button shows progress
- Full loading screen only on initial load (no cached data)
- Error toast without clearing list on failure

## Root cause

`handleRefresh()` called `setStatus('loading')` which replaced
the entire meetings view with a spinner. Now it uses a separate
`refreshing` state that only affects the button appearance.

## Platforms

- [x] Desktop (fixed)
- Android/iOS already correct (show spinner only when empty)

## Test plan

- [ ] With meetings visible, click refresh → list stays, icon
  spins
- [ ] Refresh succeeds → list updates in place
- [ ] Refresh fails → error toast, list unchanged
- [ ] First load with no cache → full loading screen shown

Closes #123