### PR TITLE
fix(android): minor UI and audio fixes (#135, #136, #137, #138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,15 @@ and this project adheres to
 - Resolve all 224 SonarCloud maintainability issues
   across all platforms (#95, #96)
 
+### Changed
+
+- Move room display name field from join tab to create room dialog (#137)
+
 ### Fixed
 
+- Align settings toggles by splitting adaptive mode label onto two lines (#135)
+- Show hours and minutes in planned meeting countdown (#136)
+- Preserve Bluetooth audio device selection from lobby to room (#138)
 - Keep meetings visible during manual refresh (#123)
 - macOS camera/mic permission prompts via infoPlist (#124)
 - Timezone-aware iCal parsing with TZID support (#122)

--- a/android/app/src/main/kotlin/io/visio/mobile/VisioManager.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/VisioManager.kt
@@ -528,6 +528,9 @@ object VisioManager : VisioEventListener {
             }
         if (btOutput != null) {
             Log.i("VisioManager", "Bluetooth output detected at startup: ${btOutput.productName}")
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                am.setCommunicationDevice(btOutput)
+            }
         }
         audioPlayout = AudioPlayout().also { it.start(btOutput) }
     }

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
@@ -362,6 +362,16 @@ private suspend fun handleNormalConnect(
         return
     }
 
+    // Apply audio device preferences saved from lobby (if any)
+    VisioManager.pendingOutputDevice?.let { device ->
+        try {
+            VisioManager.setAudioOutputDevice(device)
+        } catch (_: Exception) {
+            // No-op
+        }
+    }
+    VisioManager.pendingOutputDevice = null
+
     applyMicOnJoin(context, settings.micEnabledOnJoin)
     onMicState(VisioManager.client.isMicrophoneEnabled())
 
@@ -373,7 +383,10 @@ private fun applyMicOnJoin(
     context: Context,
     micEnabledOnJoin: Boolean,
 ) {
-    if (!micEnabledOnJoin) return
+    if (!micEnabledOnJoin) {
+        VisioManager.pendingInputDevice = null
+        return
+    }
     val hasMicPerm =
         ContextCompat.checkSelfPermission(
             context, Manifest.permission.RECORD_AUDIO,
@@ -381,11 +394,12 @@ private fun applyMicOnJoin(
     if (hasMicPerm) {
         try {
             VisioManager.client.setMicrophoneEnabled(true)
-            VisioManager.startAudioCapture()
+            VisioManager.startAudioCapture(VisioManager.pendingInputDevice)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to enable microphone on join", e)
         }
     }
+    VisioManager.pendingInputDevice = null
 }
 
 private fun applyCameraOnJoin(

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/HomeScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/HomeScreen.kt
@@ -207,7 +207,6 @@ fun HomeScreen(
             selectedTab = selectedTab,
             roomUrl = roomUrl,
             username = username,
-            roomDisplayName = roomDisplayName,
             roomStatus = roomStatus,
             resolvedRoomUrl = resolvedRoomUrl,
             isDark = isDark,
@@ -221,7 +220,6 @@ fun HomeScreen(
             coroutineScope = coroutineScope,
             onRoomUrlChange = { roomUrl = it },
             onUsernameChange = { username = it },
-            onRoomDisplayNameChange = { roomDisplayName = it },
             onJoin = onJoin,
             onShowCreateRoom = { showCreateRoom = true },
             onHistoryJoiningChange = { historyJoining = it },
@@ -233,9 +231,9 @@ fun HomeScreen(
         CreateRoomDialog(
             meetInstance = VisioManager.authenticatedMeetInstance,
             lang = lang,
-            onCreated = { url ->
+            onCreated = { url, displayName ->
                 showCreateRoom = false
-                onJoin(url, username, null)
+                onJoin(url, username, displayName)
             },
             onDismiss = { showCreateRoom = false },
         )
@@ -529,7 +527,6 @@ private fun ColumnScope.HomeTabContent(
     selectedTab: Int,
     roomUrl: String,
     username: String,
-    roomDisplayName: String,
     roomStatus: String,
     resolvedRoomUrl: String,
     isDark: Boolean,
@@ -543,7 +540,6 @@ private fun ColumnScope.HomeTabContent(
     coroutineScope: kotlinx.coroutines.CoroutineScope,
     onRoomUrlChange: (String) -> Unit,
     onUsernameChange: (String) -> Unit,
-    onRoomDisplayNameChange: (String) -> Unit,
     onJoin: (roomUrl: String, username: String, roomDisplayName: String?) -> Unit,
     onShowCreateRoom: () -> Unit,
     onHistoryJoiningChange: (String?) -> Unit,
@@ -556,8 +552,6 @@ private fun ColumnScope.HomeTabContent(
                 onRoomUrlChange = onRoomUrlChange,
                 username = username,
                 onUsernameChange = onUsernameChange,
-                roomDisplayName = roomDisplayName,
-                onRoomDisplayNameChange = onRoomDisplayNameChange,
                 roomStatus = roomStatus,
                 resolvedRoomUrl = resolvedRoomUrl,
                 isDark = isDark,
@@ -726,8 +720,6 @@ private fun JoinTab(
     onRoomUrlChange: (String) -> Unit,
     username: String,
     onUsernameChange: (String) -> Unit,
-    roomDisplayName: String,
-    onRoomDisplayNameChange: (String) -> Unit,
     roomStatus: String,
     resolvedRoomUrl: String,
     isDark: Boolean,
@@ -825,32 +817,10 @@ private fun JoinTab(
             shape = RoundedCornerShape(12.dp),
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
-
-        OutlinedTextField(
-            value = roomDisplayName,
-            onValueChange = onRoomDisplayNameChange,
-            label = {
-                Text(
-                    Strings.t("home.roomDisplayName", lang),
-                    color = if (isDark) VisioColors.Greyscale400 else VisioColors.LightTextSecondary,
-                )
-            },
-            placeholder = {
-                Text(
-                    Strings.t("home.roomDisplayNamePlaceholder", lang),
-                    color = if (isDark) VisioColors.Greyscale400 else VisioColors.LightTextSecondary,
-                )
-            },
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(12.dp),
-        )
-
         Spacer(modifier = Modifier.height(24.dp))
 
         Button(
-            onClick = { onJoin(resolvedRoomUrl, username.trim(), roomDisplayName.trim().ifBlank { null }) },
+            onClick = { onJoin(resolvedRoomUrl, username.trim(), null) },
             enabled = roomStatus == "valid",
             modifier = Modifier.fillMaxWidth().testTag("home_join_button"),
             colors =
@@ -1122,7 +1092,7 @@ private fun AuthenticatedCard(
 private fun CreateRoomDialog(
     meetInstance: String,
     lang: String,
-    onCreated: (roomUrl: String) -> Unit,
+    onCreated: (roomUrl: String, roomDisplayName: String?) -> Unit,
     onDismiss: () -> Unit,
 ) {
     if (meetInstance.isEmpty()) return
@@ -1130,6 +1100,7 @@ private fun CreateRoomDialog(
     var creating by remember { mutableStateOf(false) }
     var error by remember { mutableStateOf<String?>(null) }
     var createdUrl by remember { mutableStateOf<String?>(null) }
+    var roomDisplayName by remember { mutableStateOf("") }
     var searchQuery by remember { mutableStateOf("") }
     var searchResults by remember { mutableStateOf<List<UserSearchResult>>(emptyList()) }
     var invitedUsers by remember { mutableStateOf<List<UserSearchResult>>(emptyList()) }
@@ -1161,6 +1132,20 @@ private fun CreateRoomDialog(
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 if (createdUrl == null) {
+                    OutlinedTextField(
+                        value = roomDisplayName,
+                        onValueChange = { roomDisplayName = it },
+                        label = {
+                            Text(Strings.t("home.roomDisplayName", lang))
+                        },
+                        placeholder = {
+                            Text(Strings.t("home.roomDisplayNamePlaceholder", lang))
+                        },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(12.dp),
+                    )
+
                     Text(
                         text = Strings.t("home.createRoom.access", lang),
                         style = MaterialTheme.typography.labelMedium,
@@ -1378,7 +1363,7 @@ private fun CreateRoomDialog(
                                 val result =
                                     VisioManager.client.createRoom(
                                         "https://$meetInstance",
-                                        "",
+                                        roomDisplayName.trim(),
                                         accessLevel,
                                     )
                                 // Add accesses for invited users
@@ -1415,7 +1400,7 @@ private fun CreateRoomDialog(
                     )
                 }
             } else {
-                Button(onClick = { onCreated(createdUrl!!) }) {
+                Button(onClick = { onCreated(createdUrl!!, roomDisplayName.trim().ifBlank { null }) }) {
                     Text(Strings.t("home.join", lang))
                 }
             }

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/MeetingsTab.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/MeetingsTab.kt
@@ -443,9 +443,16 @@ private fun formatMeetingTime(
             Strings.t("meetings.time.inMinutes", lang).replace("{minutes}", minutesUntil.toString())
         }
         minutesUntil < 240 -> {
-            // relative hours
+            // relative hours + minutes
             val hours = minutesUntil / 60
-            Strings.t("meetings.time.inHours", lang).replace("{hours}", hours.toString())
+            val mins = minutesUntil % 60
+            if (mins > 0) {
+                Strings.t("meetings.time.inHoursMinutes", lang)
+                    .replace("{hours}", hours.toString())
+                    .replace("{minutes}", mins.toString().padStart(2, '0'))
+            } else {
+                Strings.t("meetings.time.inHours", lang).replace("{hours}", hours.toString())
+            }
         }
         startLocal.toLocalDate() == nowLocal -> {
             // same day: show time

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/PreJoinScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/PreJoinScreen.kt
@@ -319,6 +319,7 @@ fun PreJoinScreen(
                     )
             }
         val defaultOutput = externalOutput ?: audioOutputDevices.firstOrNull()
+        selectedOutputDeviceRef = defaultOutput
         selectedOutputRoute =
             if (defaultOutput != null) {
                 audioDeviceLabel(context, defaultOutput, lang)
@@ -334,6 +335,7 @@ fun PreJoinScreen(
                     )
             }
         val defaultInput = externalInput ?: audioInputDevices.firstOrNull()
+        selectedInputDeviceRef = defaultInput
         selectedInputRoute =
             if (defaultInput != null) {
                 audioDeviceLabel(context, defaultInput, lang)

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/SettingsScreen.kt
@@ -524,6 +524,7 @@ private fun SettingsToggle(
             text = label,
             style = MaterialTheme.typography.bodyLarge,
             color = if (isDark) VisioColors.White else VisioColors.LightOnBackground,
+            modifier = Modifier.weight(1f),
         )
         Switch(
             checked = checked,

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -175,7 +175,7 @@
   "call.startShare": "Bildschirm teilen",
   "call.stopShare": "Teilen beenden",
   "call.screenShare": "Bildschirm",
-  "settings.adaptiveMode": "Adaptiver Modus (auto Büro/Fußgänger/Auto)",
+  "settings.adaptiveMode": "Adaptiver Modus\n(auto, Büro, Fußgänger, Auto)",
   "adaptive.office": "Büromodus",
   "adaptive.pedestrian": "Fußgängermodus",
   "adaptive.car": "Automodus",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -175,7 +175,7 @@
   "call.startShare": "Share screen",
   "call.stopShare": "Stop sharing",
   "call.screenShare": "Screen",
-  "settings.adaptiveMode": "Adaptive mode (auto office/pedestrian/car)",
+  "settings.adaptiveMode": "Adaptive mode\n(auto, office, pedestrian, car)",
   "adaptive.office": "Office mode",
   "adaptive.pedestrian": "Pedestrian mode",
   "adaptive.car": "Car mode",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -175,7 +175,7 @@
   "call.startShare": "Compartir pantalla",
   "call.stopShare": "Dejar de compartir",
   "call.screenShare": "Pantalla",
-  "settings.adaptiveMode": "Modo adaptativo (auto oficina/peatón/coche)",
+  "settings.adaptiveMode": "Modo adaptativo\n(auto, oficina, peatón, coche)",
   "adaptive.office": "Modo oficina",
   "adaptive.pedestrian": "Modo peatón",
   "adaptive.car": "Modo coche",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -175,7 +175,7 @@
   "call.startShare": "Partager l'écran",
   "call.stopShare": "Arrêter le partage",
   "call.screenShare": "Écran",
-  "settings.adaptiveMode": "Mode adaptatif (auto bureau/piéton/voiture)",
+  "settings.adaptiveMode": "Mode adaptatif\n(auto, bureau, piéton, voiture)",
   "adaptive.office": "Mode bureau",
   "adaptive.pedestrian": "Mode piéton",
   "adaptive.car": "Mode voiture",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -175,7 +175,7 @@
   "call.startShare": "Condividi schermo",
   "call.stopShare": "Interrompi condivisione",
   "call.screenShare": "Schermo",
-  "settings.adaptiveMode": "Modalità adattiva (auto ufficio/pedonale/auto)",
+  "settings.adaptiveMode": "Modalità adattiva\n(auto, ufficio, pedonale, auto)",
   "adaptive.office": "Modalità ufficio",
   "adaptive.pedestrian": "Modalità pedonale",
   "adaptive.car": "Modalità auto",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -175,7 +175,7 @@
   "call.startShare": "Scherm delen",
   "call.stopShare": "Delen stoppen",
   "call.screenShare": "Scherm",
-  "settings.adaptiveMode": "Adaptieve modus (auto kantoor/voetganger/auto)",
+  "settings.adaptiveMode": "Adaptieve modus\n(auto, kantoor, voetganger, auto)",
   "adaptive.office": "Kantoormodus",
   "adaptive.pedestrian": "Voetgangersmodus",
   "adaptive.car": "Automodus",


### PR DESCRIPTION
## Summary

- **#135** — Split adaptive mode toggle label onto two lines + `weight(1f)` to align all toggles
- **#136** — Show hours AND minutes in meeting countdown (e.g., "Dans 1h 23min")
- **#137** — Move "Nom de la room" field from Join tab to Create Room dialog
- **#138** — Preserve Bluetooth audio device selection from lobby to room

## Test plan

- [ ] Settings: verify all 3 toggles are horizontally aligned
- [ ] Meetings tab: verify countdown shows "Dans Xh XXmin"
- [ ] Join tab: verify room name field is gone
- [ ] Create room dialog: verify room name field is present
- [ ] Connect Bluetooth headset, select in lobby, join room → verify audio routes to Bluetooth