### PR TITLE
fix(desktop): bypass auth wait for public room creator (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ and this project adheres to
 
 ### Fixed
 
-- Desktop: room creator no longer stuck on "waiting for authorization" for public rooms (#140)
+- Desktop: room creator no longer stuck on
+  "waiting for authorization" for public rooms (#140)
 - Align settings toggles by splitting adaptive mode label onto two lines (#135)
 - Show hours and minutes in planned meeting countdown (#136)
 - Preserve Bluetooth audio device selection from lobby to room (#138)

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -1467,12 +1467,25 @@ function HomeView({
       {showCreateRoom && authenticatedMeetInstance && (
         <CreateRoomDialog
           meetInstance={authenticatedMeetInstance}
-          onCreated={async (createdUrl, roomId, accessLevel, livekitUrl, livekitToken) => {
+          onCreated={async (
+            createdUrl,
+            roomId,
+            accessLevel,
+            livekitUrl,
+            livekitToken
+          ) => {
             setShowCreateRoom(false)
             const uname = displayName.trim() || null
             try {
               await invoke('set_display_name', { name: uname })
-              onJoin(createdUrl, uname, roomId, accessLevel, livekitUrl, livekitToken)
+              onJoin(
+                createdUrl,
+                uname,
+                roomId,
+                accessLevel,
+                livekitUrl,
+                livekitToken
+              )
             } catch (e) {
               setError(String(e))
             }
@@ -1495,7 +1508,13 @@ function CreateRoomDialog({
   onCancel,
 }: Readonly<{
   meetInstance: string
-  onCreated: (meetUrl: string, roomId?: string, accessLevel?: string, livekitUrl?: string, livekitToken?: string) => void
+  onCreated: (
+    meetUrl: string,
+    roomId?: string,
+    accessLevel?: string,
+    livekitUrl?: string,
+    livekitToken?: string
+  ) => void
   onCancel: () => void
 }>) {
   const t = useT()
@@ -1548,7 +1567,12 @@ function CreateRoomDialog({
     setError('')
     const meetUrl = `https://${meetInstance}`
     try {
-      const result = await invoke<{ slug: string; id: string; livekit_url?: string; livekit_token?: string }>('create_room', {
+      const result = await invoke<{
+        slug: string
+        id: string
+        livekit_url?: string
+        livekit_token?: string
+      }>('create_room', {
         meetUrl,
         name: '',
         accessLevel,
@@ -1814,7 +1838,15 @@ function CreateRoomDialog({
             <button
               className="btn btn-primary"
               style={{ width: 'auto' }}
-              onClick={() => onCreated(createdUrl, createdRoomId, accessLevel, createdLivekitUrl, createdLivekitToken)}
+              onClick={() =>
+                onCreated(
+                  createdUrl,
+                  createdRoomId,
+                  accessLevel,
+                  createdLivekitUrl,
+                  createdLivekitToken
+                )
+              }
             >
               {t('home.join')}
             </button>
@@ -4470,7 +4502,9 @@ export default function App() {
   const [lobbyRoomUrl, setLobbyRoomUrl] = useState('')
   const [lobbyUsername, setLobbyUsername] = useState<string | null>(null)
   const [lobbyLivekitUrl, setLobbyLivekitUrl] = useState<string | null>(null)
-  const [lobbyLivekitToken, setLobbyLivekitToken] = useState<string | null>(null)
+  const [lobbyLivekitToken, setLobbyLivekitToken] = useState<string | null>(
+    null
+  )
   const [currentRoomDisplayName, setCurrentRoomDisplayName] = useState<
     string | null
   >(null)
@@ -5098,7 +5132,9 @@ export default function App() {
     setLobbyRoomUrl(meetUrl)
     setLobbyUsername(username ?? null)
     setLobbyLivekitUrl(livekitUrl && livekitUrl.length > 0 ? livekitUrl : null)
-    setLobbyLivekitToken(livekitToken && livekitToken.length > 0 ? livekitToken : null)
+    setLobbyLivekitToken(
+      livekitToken && livekitToken.length > 0 ? livekitToken : null
+    )
     setView('lobby')
   }
 


### PR DESCRIPTION
## Summary

- Room creator no longer gets stuck on "En attente d'autorisation..." when creating a public room
- LiveKit credentials returned by `create_room` are now propagated through `CreateRoomDialog` → `HomeView.onJoin` → `PreJoinScreen`
- When valid credentials exist, `connect_with_token` is called directly, bypassing the lobby polling flow

## Root cause

The `create_room` backend response includes LiveKit credentials (`livekit_url` + `livekit_token`), but the frontend was ignoring them and going through the normal `connect` → `request_token` flow. That call received `livekit: null` (room not yet "opened"), triggering `WaitingForHost` polling. Since nobody else is in the room to approve the creator, they got stuck.

## Test plan

- [ ] Desktop: create a public room → should connect directly without auth wait
- [ ] Desktop: join an existing room normally → should still go through lobby as before
- [ ] Android/iOS: verify room creation still works (no regression)