### PR TITLE
fix(meetings): handle in-progress meetings with red indicator (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to
   "waiting for authorization" for public rooms (#140)
 - Align settings toggles by splitting adaptive mode label onto two lines (#135)
 - Show hours and minutes in planned meeting countdown (#136)
+- Red pulsing dot and "En cours" label for
+  in-progress meetings instead of negative countdown (#136)
 - Preserve Bluetooth audio device selection from lobby to room (#138)
 - Keep meetings visible during manual refresh (#123)
 - macOS camera/mic permission prompts via infoPlist (#124)

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/MeetingsTab.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/MeetingsTab.kt
@@ -371,7 +371,9 @@ private fun MeetingCardDetails(
             horizontalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             if (isImminent || isInProgress) {
-                PulsingDot(color = Color(0xFF4ADE80))
+                PulsingDot(
+                    color = if (isInProgress) VisioColors.Error500 else Color(0xFF4ADE80),
+                )
             }
             Text(
                 text = meeting.summary,
@@ -433,10 +435,13 @@ private fun formatMeetingTime(
 
     return when {
         minutesUntil < 0 -> {
-            // in progress
+            // in progress — show "En cours" + until time
             val endLocal = Instant.ofEpochSecond(meeting.endTime).atZone(zone).toLocalDateTime()
             val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
-            Strings.t("meetings.time.until", lang).replace("{time}", timeFormatter.format(endLocal))
+            val untilStr =
+                Strings.t("meetings.time.until", lang)
+                    .replace("{time}", timeFormatter.format(endLocal))
+            "${Strings.t("meetings.time.inProgress", lang)} · $untilStr"
         }
         minutesUntil < 60 -> {
             // relative time for imminent meetings (< 1h)

--- a/crates/visio-desktop/frontend/src/App.css
+++ b/crates/visio-desktop/frontend/src/App.css
@@ -3231,6 +3231,10 @@ main {
   animation: pulse 1.5s infinite;
 }
 
+.meeting-imminent-dot.meeting-ongoing-dot {
+  background: #ef413d;
+}
+
 @keyframes pulse {
   0%,
   100% {

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -531,10 +531,11 @@ function formatMeetingRelativeTime(m: Meeting, t: TFunction): string {
 
   if (isMeetingOngoing(m)) {
     const end = new Date(m.end_time * 1000)
-    return t('meetings.time.until').replace(
+    const untilStr = t('meetings.time.until').replace(
       '{time}',
       end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
     )
+    return `${t('meetings.time.inProgress')} \u00B7 ${untilStr}`
   }
   if (minutesUntil < 60) {
     return t('meetings.time.inMinutes').replace(
@@ -795,15 +796,20 @@ function MeetingsTab({
         <div key={group.label} className="meetings-day-group">
           <div className="meetings-day-header">{group.label}</div>
           {group.meetings.map((m) => {
-            const imminent = isMeetingImminent(m) || isMeetingOngoing(m)
+            const ongoing = isMeetingOngoing(m)
+            const imminent = isMeetingImminent(m) || ongoing
             return (
               <div
                 key={m.id}
-                className={`meeting-item${imminent ? ' meeting-imminent' : ''}`}
+                className={`meeting-item${imminent ? ' meeting-imminent' : ''}${ongoing ? ' meeting-ongoing' : ''}`}
               >
                 <div className="meeting-info">
                   <span className="meeting-summary">
-                    {imminent && <span className="meeting-imminent-dot" />}
+                    {imminent && (
+                      <span
+                        className={`meeting-imminent-dot${ongoing ? ' meeting-ongoing-dot' : ''}`}
+                      />
+                    )}
                     {m.summary || t('meetings.noTitle')}
                   </span>
                   <span className="meeting-time">

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -234,6 +234,8 @@
   "meetings.onboarding.title": "Kalender verbinden",
   "meetings.onboarding.configure": "Kalender konfigurieren",
   "meetings.empty.subtitle": "Genießen Sie Ihre Freizeit!",
+  "meetings.time.inProgress": "Läuft gerade",
+  "meetings.time.startedAgo": "Begonnen vor {minutes} Min.",
   "meetings.time.until": "Bis {time}",
   "meetings.time.inMinutes": "In {minutes} Min.",
   "meetings.time.inHours": "In {hours} Std.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -234,6 +234,8 @@
   "meetings.onboarding.title": "Connect your calendar",
   "meetings.onboarding.configure": "Configure calendar",
   "meetings.empty.subtitle": "Enjoy your free time!",
+  "meetings.time.inProgress": "In progress",
+  "meetings.time.startedAgo": "Started {minutes} min ago",
   "meetings.time.until": "Until {time}",
   "meetings.time.inMinutes": "In {minutes} min",
   "meetings.time.inHours": "In {hours}h",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -234,6 +234,8 @@
   "meetings.onboarding.title": "Conecta tu agenda",
   "meetings.onboarding.configure": "Configurar calendario",
   "meetings.empty.subtitle": "¡Disfruta de tu tiempo libre!",
+  "meetings.time.inProgress": "En curso",
+  "meetings.time.startedAgo": "Comenzó hace {minutes} min",
   "meetings.time.until": "Hasta {time}",
   "meetings.time.inMinutes": "En {minutes} min",
   "meetings.time.inHours": "En {hours}h",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -234,6 +234,8 @@
   "meetings.onboarding.title": "Connectez votre agenda",
   "meetings.onboarding.configure": "Configurer le calendrier",
   "meetings.empty.subtitle": "Profitez de votre temps libre !",
+  "meetings.time.inProgress": "En cours",
+  "meetings.time.startedAgo": "Commencée depuis {minutes} min",
   "meetings.time.until": "Jusqu'à {time}",
   "meetings.time.inMinutes": "Dans {minutes} min",
   "meetings.time.inHours": "Dans {hours}h",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -234,6 +234,8 @@
   "meetings.onboarding.title": "Collega la tua agenda",
   "meetings.onboarding.configure": "Configura calendario",
   "meetings.empty.subtitle": "Goditi il tuo tempo libero!",
+  "meetings.time.inProgress": "In corso",
+  "meetings.time.startedAgo": "Iniziato {minutes} min fa",
   "meetings.time.until": "Fino a {time}",
   "meetings.time.inMinutes": "Tra {minutes} min",
   "meetings.time.inHours": "Tra {hours}h",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -234,6 +234,8 @@
   "meetings.onboarding.title": "Verbind je agenda",
   "meetings.onboarding.configure": "Kalender configureren",
   "meetings.empty.subtitle": "Geniet van je vrije tijd!",
+  "meetings.time.inProgress": "Bezig",
+  "meetings.time.startedAgo": "Begonnen {minutes} min geleden",
   "meetings.time.until": "Tot {time}",
   "meetings.time.inMinutes": "Over {minutes} min",
   "meetings.time.inHours": "Over {hours}u",

--- a/ios/VisioMobile/Views/MeetingsTabView.swift
+++ b/ios/VisioMobile/Views/MeetingsTabView.swift
@@ -220,7 +220,9 @@ private struct MeetingRow: View {
         if isInProgress {
             formatter.dateFormat = "HH:mm"
             let endStr = formatter.string(from: endDate)
-            return Strings.t("meetings.time.until", lang: lang).replacingOccurrences(of: "{time}", with: endStr)
+            let untilStr = Strings.t("meetings.time.until", lang: lang).replacingOccurrences(of: "{time}", with: endStr)
+            let inProgressStr = Strings.t("meetings.time.inProgress", lang: lang)
+            return "\(inProgressStr) \u{00B7} \(untilStr)"
         }
 
         if interval < 4 * 3600 && interval > 0 {
@@ -258,7 +260,11 @@ private struct MeetingRow: View {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
                     if isAccent {
-                        PulsingDot()
+                        PulsingDot(
+                            color: isInProgress
+                                ? Color(red: 0.94, green: 0.25, blue: 0.24)
+                                : Color(red: 0.29, green: 0.87, blue: 0.5)
+                        )
                     }
                     Text(meeting.summary)
                         .font(.body)
@@ -322,11 +328,12 @@ private struct MeetingRow: View {
 }
 
 private struct PulsingDot: View {
+    var color: Color = Color(red: 0.29, green: 0.87, blue: 0.5)
     @State private var isAnimating = false
 
     var body: some View {
         Circle()
-            .fill(Color(red: 0.29, green: 0.87, blue: 0.5))
+            .fill(color)
             .frame(width: 8, height: 8)
             .opacity(isAnimating ? 0.3 : 1.0)
             .onAppear {


### PR DESCRIPTION
## Summary

- Fix negative countdown display (e.g., "Dans -53min") for meetings that have already started
- In-progress meetings now show "En cours" with end time instead of negative countdown
- Pulsing indicator dot changes from green to **red** when meeting is in progress
- Applied across all 3 platforms (Android, iOS, Desktop) and all 6 i18n locales

## Root cause

`formatMeetingTime()` computed `minutesUntil` which could go negative, displaying values like "Dans -53min".

## Test plan

- [ ] Start time in the past → should show "En cours" with red dot
- [ ] Start time in the future → green dot and normal countdown
- [ ] Verify on Desktop, Android, iOS
- [ ] Check all 6 languages display correctly