### PR TITLE
feat(layout): default grid with pin-to-view (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 
+- Default grid layout with pin-to-view for speakers
+  and shared screens on all platforms (#142)
 - Room display name via `?room-display-name=` URL param
   or manual input (#113)
 - Calendar sync feedback: toast/snackbar on all platforms

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/LayoutEngine.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/LayoutEngine.kt
@@ -22,9 +22,6 @@ data class LayoutState(
     val lastRemoteSpeakerSid: String? = null,
 )
 
-private const val MIN_HOLD_MS = 2500L
-private const val SILENCE_TO_GRID_MS = 5000L
-
 @Suppress("kotlin:S107")
 fun computeLayout(
     participants: List<ParticipantInfo>,
@@ -45,18 +42,11 @@ fun computeLayout(
         return computePinnedLayout(displayItems, it, activeSpeakers, previousState)
     }
 
-    val speakerResult =
-        computeSpeakerLayout(
-            displayItems,
-            activeSpeakers,
-            localParticipantSid,
-            participants,
-            previousState,
-            nowMs,
-        )
-    if (speakerResult != null) return speakerResult
-
-    return computeFallbackLayout(displayItems, previousState, nowMs, adaptiveMode)
+    // Default: grid layout (no auto-focus on active speaker)
+    return Pair(
+        LayoutDecision(LayoutMode.GRID, null, displayItems, activeSpeakers.firstOrNull(), null),
+        previousState.copy(currentFocus = null, focusHoldStartMs = null),
+    )
 }
 
 private fun computeScreenShareLayout(
@@ -85,103 +75,6 @@ private fun computePinnedLayout(
     return Pair(
         LayoutDecision(LayoutMode.FOCUS, main, secondary, activeSpeakers.firstOrNull(), pinnedItem.participantSid),
         previousState.copy(currentFocus = pinnedItem),
-    )
-}
-
-private fun computeSpeakerLayout(
-    displayItems: List<DisplayItem>,
-    activeSpeakers: List<String>,
-    localParticipantSid: String,
-    participants: List<ParticipantInfo>,
-    previousState: LayoutState,
-    nowMs: Long,
-): Pair<LayoutDecision, LayoutState>? {
-    val currentSpeakerSid = activeSpeakers.firstOrNull() ?: return null
-    val isLocalSpeaking = currentSpeakerSid == localParticipantSid
-    val newLastRemote = if (!isLocalSpeaking) currentSpeakerSid else previousState.lastRemoteSpeakerSid
-
-    val targetSid =
-        resolveTargetSpeaker(isLocalSpeaking, currentSpeakerSid, previousState, participants)
-            ?: return null
-
-    val targetFocus = FocusItem(targetSid, "camera")
-    val shouldSwitch = shouldSwitchFocus(previousState, targetFocus, nowMs)
-
-    return if (shouldSwitch) {
-        val main = findDisplayItem(displayItems, targetSid, "camera")
-        val secondary = displayItems.filter { it.key != main?.key }
-        Pair(
-            LayoutDecision(LayoutMode.FOCUS, main, secondary, currentSpeakerSid, null),
-            LayoutState(targetFocus, nowMs, newLastRemote),
-        )
-    } else {
-        val currentMain =
-            previousState.currentFocus?.let {
-                findDisplayItem(displayItems, it.participantSid, it.source)
-            }
-        val secondary = displayItems.filter { it.key != currentMain?.key }
-        Pair(
-            LayoutDecision(LayoutMode.FOCUS, currentMain, secondary, currentSpeakerSid, null),
-            previousState.copy(lastRemoteSpeakerSid = newLastRemote),
-        )
-    }
-}
-
-private fun resolveTargetSpeaker(
-    isLocalSpeaking: Boolean,
-    currentSpeakerSid: String,
-    previousState: LayoutState,
-    participants: List<ParticipantInfo>,
-): String? =
-    if (isLocalSpeaking) {
-        previousState.lastRemoteSpeakerSid ?: participants.drop(1).firstOrNull()?.sid
-    } else {
-        currentSpeakerSid
-    }
-
-private fun shouldSwitchFocus(
-    previousState: LayoutState,
-    targetFocus: FocusItem,
-    nowMs: Long,
-): Boolean =
-    when {
-        previousState.currentFocus == null -> true
-        previousState.currentFocus == targetFocus -> false
-        else -> {
-            val holdElapsed = previousState.focusHoldStartMs?.let { nowMs - it } ?: Long.MAX_VALUE
-            holdElapsed >= MIN_HOLD_MS
-        }
-    }
-
-private fun computeFallbackLayout(
-    displayItems: List<DisplayItem>,
-    previousState: LayoutState,
-    nowMs: Long,
-    adaptiveMode: AdaptiveMode,
-): Pair<LayoutDecision, LayoutState> {
-    val silenceElapsed = previousState.focusHoldStartMs?.let { nowMs - it } ?: Long.MAX_VALUE
-    if (silenceElapsed > SILENCE_TO_GRID_MS && adaptiveMode == AdaptiveMode.OFFICE) {
-        return Pair(
-            LayoutDecision(LayoutMode.GRID, null, displayItems, null, null),
-            previousState.copy(currentFocus = null, focusHoldStartMs = null),
-        )
-    }
-
-    val currentMain =
-        previousState.currentFocus?.let { focus ->
-            findDisplayItem(displayItems, focus.participantSid, focus.source)
-        }
-    if (currentMain != null) {
-        val secondary = displayItems.filter { it.key != currentMain.key }
-        return Pair(
-            LayoutDecision(LayoutMode.FOCUS, currentMain, secondary, null, null),
-            previousState,
-        )
-    }
-
-    return Pair(
-        LayoutDecision(LayoutMode.GRID, null, displayItems, null, null),
-        previousState.copy(currentFocus = null),
     )
 }
 

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -2477,36 +2477,8 @@ function CallView({
     }
   }, [participants, focusedItem, localParticipant, isScreenSharing])
 
-  // Auto-focus on active speaker when there are 3+ participants and user hasn't manually pinned
-  useEffect(() => {
-    // Only auto-focus when there are enough participants to benefit from speaker view
-    const allP: Participant[] = []
-    if (localParticipant) allP.push(localParticipant)
-    allP.push(
-      ...participants.filter(
-        (p) => !localParticipant || p.sid !== localParticipant.sid
-      )
-    )
-    if (allP.length < 3) return
-    if (userPinnedRef.current) return
-    if (activeSpeakers.length === 0) return
-
-    // Find the first active speaker that is NOT the local participant
-    const remoteSpeaker = activeSpeakers.find(
-      (sid) => !localParticipant || sid !== localParticipant.sid
-    )
-    const speakerSid = remoteSpeaker || activeSpeakers[0]
-    if (!speakerSid) return
-
-    // Only switch if the speaker is different from the currently focused participant
-    if (
-      focusedItem?.participantSid === speakerSid &&
-      focusedItem?.source === 'camera'
-    )
-      return
-
-    setFocusedItem({ participantSid: speakerSid, source: 'camera' })
-  }, [activeSpeakers, participants, localParticipant])
+  // Grid is the default layout — no auto-focus on active speaker.
+  // Users must explicitly click a participant to pin them.
 
   const handleSendReaction = async (emojiId: string) => {
     try {

--- a/ios/VisioMobile/Services/LayoutEngine.swift
+++ b/ios/VisioMobile/Services/LayoutEngine.swift
@@ -24,9 +24,6 @@ struct LayoutState: Equatable {
 
 // MARK: - Layout Engine
 
-private let minHoldMs: Double = 2500  // 2.5 seconds
-private let silenceToGridMs: Double = 5000  // 5 seconds
-
 func computeLayout(
     participants: [ParticipantInfo],
     activeSpeakers: [String],
@@ -52,7 +49,7 @@ func computeLayout(
         )
     }
 
-    // 2. Pin has priority over auto-focus
+    // 2. Pin has priority — user explicitly pinned a participant
     if let pinnedItem = pinnedItem {
         let main = displayItems.first {
             $0.participant.sid == pinnedItem.participantSid && $0.source == pinnedItem.source
@@ -65,76 +62,9 @@ func computeLayout(
         )
     }
 
-    // 3. Active speaker logic with stabilization
-    let currentSpeakerSid = activeSpeakers.first
-    let isLocalSpeaking = currentSpeakerSid == localParticipantSid
-
-    if let currentSpeakerSid = currentSpeakerSid {
-        let newLastRemote = !isLocalSpeaking ? currentSpeakerSid : previousState.lastRemoteSpeakerSid
-
-        let targetSid: String? = isLocalSpeaking
-            ? (previousState.lastRemoteSpeakerSid ?? participants.dropFirst().first?.sid)
-            : currentSpeakerSid
-
-        if let targetSid = targetSid {
-            let targetFocus = FocusItem(participantSid: targetSid, source: .camera)
-
-            let shouldSwitch: Bool
-            if previousState.currentFocus == nil {
-                shouldSwitch = true
-            } else if previousState.currentFocus == targetFocus {
-                shouldSwitch = false
-            } else {
-                let holdElapsed = previousState.focusHoldStartMs.map { nowMs - $0 } ?? Double.greatestFiniteMagnitude
-                shouldSwitch = holdElapsed >= minHoldMs
-            }
-
-            if shouldSwitch {
-                let main = displayItems.first { $0.participant.sid == targetSid && $0.source == .camera }
-                let secondary = displayItems.filter { $0.id != main?.id }
-                return (
-                    LayoutDecision(mode: .focus, mainTile: main, secondaryTiles: secondary, speakerIndicatorSid: currentSpeakerSid, pinnedIndicatorSid: nil),
-                    LayoutState(currentFocus: targetFocus, focusHoldStartMs: nowMs, lastRemoteSpeakerSid: newLastRemote)
-                )
-            } else {
-                let currentMain = displayItems.first {
-                    $0.participant.sid == previousState.currentFocus?.participantSid && $0.source == previousState.currentFocus?.source
-                }
-                let secondary = displayItems.filter { $0.id != currentMain?.id }
-                return (
-                    LayoutDecision(mode: .focus, mainTile: currentMain, secondaryTiles: secondary, speakerIndicatorSid: currentSpeakerSid, pinnedIndicatorSid: nil),
-                    LayoutState(currentFocus: previousState.currentFocus, focusHoldStartMs: previousState.focusHoldStartMs, lastRemoteSpeakerSid: newLastRemote)
-                )
-            }
-        }
-    }
-
-    // 4. No speaker — check silence timeout
-    let silenceElapsed = previousState.focusHoldStartMs.map { nowMs - $0 } ?? Double.greatestFiniteMagnitude
-    if silenceElapsed > silenceToGridMs && adaptiveMode == .office {
-        return (
-            LayoutDecision(mode: .grid, mainTile: nil, secondaryTiles: displayItems, speakerIndicatorSid: nil, pinnedIndicatorSid: nil),
-            LayoutState(currentFocus: nil, focusHoldStartMs: nil, lastRemoteSpeakerSid: previousState.lastRemoteSpeakerSid)
-        )
-    }
-
-    // Keep current state
-    if let focus = previousState.currentFocus {
-        let currentMain = displayItems.first {
-            $0.participant.sid == focus.participantSid && $0.source == focus.source
-        }
-        if let currentMain = currentMain {
-            let secondary = displayItems.filter { $0.id != currentMain.id }
-            return (
-                LayoutDecision(mode: .focus, mainTile: currentMain, secondaryTiles: secondary, speakerIndicatorSid: nil, pinnedIndicatorSid: nil),
-                previousState
-            )
-        }
-    }
-
-    // Default: grid
+    // 3. Default: grid layout (no auto-focus on active speaker)
     return (
-        LayoutDecision(mode: .grid, mainTile: nil, secondaryTiles: displayItems, speakerIndicatorSid: nil, pinnedIndicatorSid: nil),
-        LayoutState(currentFocus: nil, focusHoldStartMs: previousState.focusHoldStartMs, lastRemoteSpeakerSid: previousState.lastRemoteSpeakerSid)
+        LayoutDecision(mode: .grid, mainTile: nil, secondaryTiles: displayItems, speakerIndicatorSid: activeSpeakers.first, pinnedIndicatorSid: nil),
+        LayoutState(currentFocus: nil, focusHoldStartMs: nil, lastRemoteSpeakerSid: previousState.lastRemoteSpeakerSid)
     )
 }


### PR DESCRIPTION
## Summary

- Default display is now **grid** showing all participant thumbnails
- Removed auto-focus on active speaker logic
- User can click a participant to **pin** them in main view
- Unpin returns to grid automatically
- Screen share pin preserved unchanged
- Applied across Android, iOS, Desktop

## Changes

- **Android** (`LayoutEngine.kt`): removed `computeSpeakerLayout`, `shouldSwitchFocus`, related constants
- **iOS** (`LayoutEngine.swift`): same cleanup
- **Desktop** (`App.tsx`): removed auto-focus `useEffect`

## Test plan

- [ ] Default view is grid with all participants
- [ ] Click participant → pinned in main view
- [ ] Unpin → returns to grid
- [ ] Screen share click → pinned, unpin → grid
- [ ] Verify on Android, iOS, Desktop