### PR TITLE
fix(ios): add missing name param to createRoom (#145)

### DIFF
--- a/ios/VisioMobile/Views/HomeView.swift
+++ b/ios/VisioMobile/Views/HomeView.swift
@@ -784,6 +784,7 @@ private struct CreateRoomSheet: View {
                                 do {
                                     let result = try manager.client.createRoom(
                                         meetUrl: "https://\(meetInstance)",
+                                        name: "",
                                         accessLevel: accessLevel
                                     )
                                     // Add accesses for invited users


### PR DESCRIPTION
## Summary

Fix iOS build failure caused by missing `name` parameter in
`createRoom` call after slug refactor in #145.

## Test plan

- [ ] iOS build succeeds