### PR TITLE
fix(desktop): stop spurious mic permission on settings (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Fixed
 
+- Stop spurious microphone permission request when
+  opening desktop settings (#161)
 - Clarify display name labels on home and pre-join
   screens with "Your" prefix in all 6 locales (#153)
 - Rename "meeting"/"room" to "visio" in all 6 i18n files

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -4834,15 +4834,13 @@ export default function App() {
 
   // ---- Device enumeration -------------------------------------------------
   // WORKAROUND: Defer device enumeration to avoid USB blocking at startup.
-  // Enumerate when settings, mic picker, or camera picker is opened.
+  // Enumerate when mic picker or camera picker is opened (in-call only).
+  // NOTE: Do NOT enumerate on the general settings page — on macOS,
+  // cpal's input_devices() triggers a microphone permission request (#161).
   const [devicesEnumerated, setDevicesEnumerated] = useState(false)
 
   useEffect(() => {
-    if (
-      (view !== 'settings' && !showMicPicker && !showCamPicker) ||
-      devicesEnumerated
-    )
-      return
+    if ((!showMicPicker && !showCamPicker) || devicesEnumerated) return
 
     const enumerate = async () => {
       try {
@@ -4895,7 +4893,7 @@ export default function App() {
     return () => {
       unlistenFn?.()
     }
-  }, [view, showMicPicker, showCamPicker, devicesEnumerated])
+  }, [showMicPicker, showCamPicker, devicesEnumerated])
 
   // ---- Click outside to close device pickers ------------------------------
   useEffect(() => {


### PR DESCRIPTION
## Summary

Remove audio device enumeration trigger when opening settings.
On macOS, `cpal::input_devices()` calls CoreAudio which requests
mic permission — this should only happen during calls.

## Root cause

`useEffect` in `App.tsx` triggered device enumeration when
`view === 'settings'`, causing an unnecessary mic permission
prompt that also blocked audio for other apps.

## Test plan

- [ ] Open settings → no mic permission request
- [ ] Join a call → mic/camera work normally
- [ ] In-call device picker → devices listed correctly
- [ ] Verify on macOS, Linux, Windows