### PR TITLE
refactor: unify device enumeration across platforms (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to
 
 - Button to clear recent visios history in settings (#152)
 
+### Changed
+
+- Extract `useDeviceEnumeration` hook to unify device
+  enumeration across lobby and in-call picker (#163)
+
 ### Fixed
 
 - PiP only activates during an active call; no longer triggers

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/AudioDeviceUtils.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/AudioDeviceUtils.kt
@@ -1,0 +1,274 @@
+package io.visio.mobile.ui
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import android.media.AudioDeviceCallback
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import io.visio.mobile.ui.i18n.Strings
+
+// ---------------------------------------------------------------------------
+// Type constants
+// ---------------------------------------------------------------------------
+
+internal val BUILTIN_TYPES =
+    setOf(
+        AudioDeviceInfo.TYPE_BUILTIN_MIC,
+        AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
+        AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
+    )
+
+internal val BLUETOOTH_TYPES =
+    setOf(
+        AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+        AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
+        AudioDeviceInfo.TYPE_BLE_HEADSET,
+        AudioDeviceInfo.TYPE_BLE_SPEAKER,
+    )
+
+internal val INPUT_TYPES =
+    setOf(
+        AudioDeviceInfo.TYPE_BUILTIN_MIC,
+        AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+        AudioDeviceInfo.TYPE_BLE_HEADSET,
+        AudioDeviceInfo.TYPE_USB_HEADSET,
+        AudioDeviceInfo.TYPE_WIRED_HEADSET,
+    )
+
+internal val OUTPUT_TYPES =
+    setOf(
+        AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
+        AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
+        AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
+        AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+        AudioDeviceInfo.TYPE_BLE_HEADSET,
+        AudioDeviceInfo.TYPE_BLE_SPEAKER,
+        AudioDeviceInfo.TYPE_HEARING_AID,
+        AudioDeviceInfo.TYPE_WIRED_HEADSET,
+        AudioDeviceInfo.TYPE_WIRED_HEADPHONES,
+        AudioDeviceInfo.TYPE_USB_HEADSET,
+        AudioDeviceInfo.TYPE_USB_DEVICE,
+    )
+
+// ---------------------------------------------------------------------------
+// Filtering & deduplication
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns filtered and deduplicated input devices from the system.
+ */
+internal fun getFilteredInputDevices(audioManager: AudioManager): List<AudioDeviceInfo> {
+    return audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)
+        .filter { it.type in INPUT_TYPES }
+        .deduplicateBluetooth()
+}
+
+/**
+ * Returns filtered and deduplicated output devices from the system.
+ */
+internal fun getFilteredOutputDevices(audioManager: AudioManager): List<AudioDeviceInfo> {
+    return audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+        .filter { it.type in OUTPUT_TYPES }
+        .deduplicateBluetooth()
+}
+
+/**
+ * Deduplicate Bluetooth devices: SCO + A2DP + BLE for the same physical
+ * device appear as separate AudioDeviceInfo entries. Keep one per physical
+ * device (prefer SCO for bidirectional audio), plus all non-Bluetooth
+ * devices deduplicated by type.
+ */
+internal fun List<AudioDeviceInfo>.deduplicateBluetooth(): List<AudioDeviceInfo> {
+    val (bt, nonBt) = partition { it.type in BLUETOOTH_TYPES }
+    // Group Bluetooth devices by address (same physical device),
+    // preferring SCO (bidirectional) over A2DP (output-only)
+    val uniqueBt =
+        bt.groupBy { it.address.ifBlank { "bt-${it.id}" } }
+            .values
+            .map { group ->
+                group.firstOrNull { it.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO }
+                    ?: group.first()
+            }
+    return nonBt.distinctBy { it.type } + uniqueBt
+}
+
+// ---------------------------------------------------------------------------
+// Composable: audio device callback hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Data class holding the current device lists plus a refresh key that
+ * increments on every device add/remove event.
+ */
+data class AudioDeviceState(
+    val inputDevices: List<AudioDeviceInfo>,
+    val outputDevices: List<AudioDeviceInfo>,
+    val refreshKey: Int,
+)
+
+/**
+ * Composable that registers an [AudioDeviceCallback] and returns a
+ * reactive [AudioDeviceState] updated on device connect/disconnect.
+ *
+ * This replaces the duplicate DisposableEffect + callback registration
+ * in both PreJoinScreen and InCallSettingsSheet.
+ */
+@Composable
+internal fun rememberAudioDeviceState(audioManager: AudioManager): AudioDeviceState {
+    var refreshKey by remember { mutableIntStateOf(0) }
+
+    DisposableEffect(audioManager) {
+        val callback =
+            object : AudioDeviceCallback() {
+                override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>?) {
+                    refreshKey++
+                }
+
+                override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>?) {
+                    refreshKey++
+                }
+            }
+        audioManager.registerAudioDeviceCallback(
+            callback,
+            Handler(Looper.getMainLooper()),
+        )
+        onDispose {
+            audioManager.unregisterAudioDeviceCallback(callback)
+        }
+    }
+
+    val inputs = remember(refreshKey) { getFilteredInputDevices(audioManager) }
+    val outputs = remember(refreshKey) { getFilteredOutputDevices(audioManager) }
+
+    return AudioDeviceState(inputs, outputs, refreshKey)
+}
+
+/**
+ * Returns the active communication device ID (API 31+), or null.
+ */
+internal fun getActiveCommunicationDeviceId(audioManager: AudioManager): Int? {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        audioManager.communicationDevice?.id
+    } else {
+        null
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Labeling
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a user-facing label for an audio device. Uses the Bluetooth
+ * adapter name when available (most reliable for BT devices), then
+ * falls back to AudioDeviceInfo.productName, then to a type-based label.
+ */
+internal fun audioDeviceLabel(
+    context: Context,
+    device: AudioDeviceInfo,
+    lang: String,
+): String {
+    // Try Bluetooth adapter name first (most reliable for BT devices)
+    resolveBluetoothName(context, device)?.let { return it }
+    // Then try AudioDeviceInfo.productName for non-builtin devices
+    if (device.type !in BUILTIN_TYPES) {
+        val name = device.productName?.toString()?.ifBlank { null }
+        if (name != null) return name
+    }
+    return audioDeviceTypeLabel(device.type, lang)
+}
+
+/**
+ * Overload without context — used in InCallSettingsSheet where Bluetooth
+ * adapter name resolution is not needed.
+ */
+internal fun audioDeviceLabel(
+    device: AudioDeviceInfo,
+    lang: String,
+): String {
+    if (device.type in BUILTIN_TYPES) {
+        return audioDeviceTypeLabel(device.type, lang)
+    }
+    return device.productName?.toString()?.ifBlank { null }
+        ?: audioDeviceTypeLabel(device.type, lang)
+}
+
+internal fun audioDeviceTypeLabel(
+    type: Int,
+    lang: String,
+): String =
+    when (type) {
+        AudioDeviceInfo.TYPE_BUILTIN_MIC ->
+            Strings.t("device.microphone", lang)
+        AudioDeviceInfo.TYPE_BUILTIN_SPEAKER ->
+            Strings.t("audio.speaker", lang)
+        AudioDeviceInfo.TYPE_BUILTIN_EARPIECE ->
+            Strings.t("audio.earpiece", lang)
+        AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+        AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
+        ->
+            Strings.t("audio.bluetooth", lang)
+        AudioDeviceInfo.TYPE_BLE_HEADSET,
+        AudioDeviceInfo.TYPE_BLE_SPEAKER,
+        ->
+            Strings.t("audio.bluetooth", lang)
+        AudioDeviceInfo.TYPE_HEARING_AID ->
+            Strings.t("audio.hearingAid", lang)
+        AudioDeviceInfo.TYPE_WIRED_HEADSET,
+        AudioDeviceInfo.TYPE_WIRED_HEADPHONES,
+        ->
+            Strings.t("audio.wiredHeadset", lang)
+        AudioDeviceInfo.TYPE_USB_HEADSET,
+        AudioDeviceInfo.TYPE_USB_DEVICE,
+        ->
+            Strings.t("audio.usbHeadset", lang)
+        else -> "Audio"
+    }
+
+/**
+ * Resolve the Bluetooth device name from BluetoothAdapter.bondedDevices.
+ * AudioDeviceInfo.productName is often empty or generic for BT devices.
+ */
+@SuppressLint("MissingPermission")
+internal fun resolveBluetoothName(
+    context: Context,
+    device: AudioDeviceInfo,
+): String? {
+    if (device.type !in BLUETOOTH_TYPES) return null
+    val btManager =
+        context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+            ?: return null
+    val adapter = btManager.adapter ?: return null
+    // Match by address if available
+    val address = device.address
+    if (address.isNotBlank()) {
+        try {
+            adapter.bondedDevices?.firstOrNull { it.address == address }
+                ?.name?.let { return it }
+        } catch (_: SecurityException) {
+            // BLUETOOTH_CONNECT not granted
+        }
+    }
+    // Fallback: match by product name
+    val productName = device.productName?.toString()?.ifBlank { null }
+    if (productName != null) {
+        try {
+            adapter.bondedDevices?.firstOrNull {
+                it.name?.equals(productName, ignoreCase = true) == true
+            }?.name?.let { return it }
+        } catch (_: SecurityException) {
+            // BLUETOOTH_CONNECT not granted
+        }
+    }
+    return null
+}

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/HomeScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/HomeScreen.kt
@@ -96,7 +96,7 @@ fun HomeScreen(
     var resolvedRoomUrl by remember { mutableStateOf("") }
     var username by remember { mutableStateOf("") }
     var roomDisplayName by remember { mutableStateOf("") }
-    var roomHistory by remember { mutableStateOf(listOf<uniffi.visio.RoomHistoryEntry>()) }
+    var roomHistory by remember { mutableStateOf(listOf<uniffi.visio.VisioHistoryEntry>()) }
     val lang = VisioManager.currentLang
     val isDark = VisioManager.currentTheme == "dark"
     var roomStatus by remember { mutableStateOf("idle") }
@@ -248,7 +248,7 @@ private fun HomeScreenEffects(
     username: String,
     slugRegex: Regex,
     meetInstances: List<String>,
-    onRoomHistoryLoaded: (List<uniffi.visio.RoomHistoryEntry>) -> Unit,
+    onRoomHistoryLoaded: (List<uniffi.visio.VisioHistoryEntry>) -> Unit,
     onHasCalendarUrlChange: (Boolean) -> Unit,
     onRoomUrlChange: (String) -> Unit,
     onMeetInstancesLoaded: (List<String>) -> Unit,
@@ -259,7 +259,7 @@ private fun HomeScreenEffects(
 ) {
     LaunchedEffect(Unit) {
         try {
-            onRoomHistoryLoaded(VisioManager.client.getRoomHistory())
+            onRoomHistoryLoaded(VisioManager.client.getVisioHistory())
             val hasCal = VisioManager.client.getCalendarUrl() != null
             onHasCalendarUrlChange(hasCal)
             if (hasCal) VisioManager.refreshCalendarNow()
@@ -525,7 +525,7 @@ private fun ColumnScope.HomeTabContent(
     resolvedRoomUrl: String,
     isDark: Boolean,
     lang: String,
-    roomHistory: List<uniffi.visio.RoomHistoryEntry>,
+    roomHistory: List<uniffi.visio.VisioHistoryEntry>,
     historyJoining: String?,
     upcomingMeetings: List<uniffi.visio.Meeting>,
     hasCalendarUrl: Boolean,
@@ -719,11 +719,11 @@ private fun JoinTab(
     isDark: Boolean,
     lang: String,
     isAuthenticated: Boolean,
-    roomHistory: List<uniffi.visio.RoomHistoryEntry>,
+    roomHistory: List<uniffi.visio.VisioHistoryEntry>,
     historyJoining: String?,
     onJoin: (roomUrl: String, username: String, roomDisplayName: String?) -> Unit,
     onShowCreateRoom: () -> Unit,
-    onHistoryClick: (uniffi.visio.RoomHistoryEntry) -> Unit,
+    onHistoryClick: (uniffi.visio.VisioHistoryEntry) -> Unit,
 ) {
     Column(
         modifier =
@@ -896,11 +896,11 @@ private fun RoomStatusIndicator(
 
 @Composable
 private fun RoomHistoryList(
-    roomHistory: List<uniffi.visio.RoomHistoryEntry>,
+    roomHistory: List<uniffi.visio.VisioHistoryEntry>,
     historyJoining: String?,
     isDark: Boolean,
     lang: String,
-    onHistoryClick: (uniffi.visio.RoomHistoryEntry) -> Unit,
+    onHistoryClick: (uniffi.visio.VisioHistoryEntry) -> Unit,
 ) {
     Spacer(modifier = Modifier.height(24.dp))
     Text(
@@ -925,12 +925,12 @@ private fun RoomHistoryList(
 
 @Composable
 private fun RoomHistoryItem(
-    entry: uniffi.visio.RoomHistoryEntry,
+    entry: uniffi.visio.VisioHistoryEntry,
     index: Int,
     isJoining: Boolean,
     isEnabled: Boolean,
     isDark: Boolean,
-    onHistoryClick: (uniffi.visio.RoomHistoryEntry) -> Unit,
+    onHistoryClick: (uniffi.visio.VisioHistoryEntry) -> Unit,
 ) {
     val url = entry.url
     val slug = if ('/' in url) url.substringAfterLast('/') else url

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/InCallSettingsSheet.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/InCallSettingsSheet.kt
@@ -2,12 +2,9 @@ package io.visio.mobile.ui
 
 import android.content.Context
 import android.graphics.BitmapFactory
-import android.media.AudioDeviceCallback
 import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.os.Build
-import android.os.Handler
-import android.os.Looper
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -55,7 +52,6 @@ import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -271,53 +267,23 @@ private fun MicroTab(
     onSelectAudioOutput: (AudioDeviceInfo) -> Unit,
 ) {
     val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-
-    var inputDevices by remember { mutableStateOf(getFilteredInputDevices(audioManager)) }
-    var outputDevices by remember { mutableStateOf(getFilteredOutputDevices(audioManager)) }
+    val deviceState = rememberAudioDeviceState(audioManager)
+    val inputDevices = deviceState.inputDevices
+    val outputDevices = deviceState.outputDevices
 
     // Track active input and output devices independently
     var activeInputDeviceId by remember {
-        mutableStateOf(
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                audioManager.communicationDevice?.id
-            } else {
-                null
-            },
-        )
+        mutableStateOf(getActiveCommunicationDeviceId(audioManager))
     }
     var activeOutputDeviceId by remember {
-        mutableStateOf(
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                audioManager.communicationDevice?.id
-            } else {
-                null
-            },
-        )
+        mutableStateOf(getActiveCommunicationDeviceId(audioManager))
     }
 
-    // React to device connect/disconnect events
-    DisposableEffect(audioManager) {
-        val callback =
-            object : AudioDeviceCallback() {
-                override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>?) {
-                    inputDevices = getFilteredInputDevices(audioManager)
-                    outputDevices = getFilteredOutputDevices(audioManager)
-                }
-
-                override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>?) {
-                    inputDevices = getFilteredInputDevices(audioManager)
-                    outputDevices = getFilteredOutputDevices(audioManager)
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                        val commId = audioManager.communicationDevice?.id
-                        activeInputDeviceId = commId
-                        activeOutputDeviceId = commId
-                    }
-                }
-            }
-        audioManager.registerAudioDeviceCallback(callback, Handler(Looper.getMainLooper()))
-        onDispose {
-            audioManager.unregisterAudioDeviceCallback(callback)
-        }
+    // Update active device IDs when devices change
+    androidx.compose.runtime.LaunchedEffect(deviceState.refreshKey) {
+        val commId = getActiveCommunicationDeviceId(audioManager)
+        activeInputDeviceId = commId
+        activeOutputDeviceId = commId
     }
 
     // Resolve which input is active: match by device ID, or for built-in mic
@@ -949,98 +915,5 @@ private fun SectionHeader(title: String) {
     )
 }
 
-private val BUILTIN_TYPES =
-    setOf(
-        AudioDeviceInfo.TYPE_BUILTIN_MIC,
-        AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
-        AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
-    )
-
-private val BLUETOOTH_TYPES =
-    setOf(
-        AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
-        AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
-    )
-
-private val INPUT_TYPES =
-    listOf(
-        AudioDeviceInfo.TYPE_BUILTIN_MIC,
-        AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
-        AudioDeviceInfo.TYPE_USB_HEADSET,
-        AudioDeviceInfo.TYPE_WIRED_HEADSET,
-    )
-
-private val OUTPUT_TYPES =
-    listOf(
-        AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
-        AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
-        AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
-        AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
-        AudioDeviceInfo.TYPE_WIRED_HEADSET,
-        AudioDeviceInfo.TYPE_WIRED_HEADPHONES,
-        AudioDeviceInfo.TYPE_USB_HEADSET,
-    )
-
-private fun getFilteredInputDevices(audioManager: AudioManager): List<AudioDeviceInfo> {
-    val seenBuiltinTypes = mutableSetOf<Int>()
-    return audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)
-        .filter { it.type in INPUT_TYPES }
-        .filter { device ->
-            if (device.type in BUILTIN_TYPES) seenBuiltinTypes.add(device.type) else true
-        }
-}
-
-private fun getFilteredOutputDevices(audioManager: AudioManager): List<AudioDeviceInfo> {
-    val seenBuiltinTypes = mutableSetOf<Int>()
-    val seenBtNames = mutableSetOf<String>()
-    return audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
-        .filter { it.type in OUTPUT_TYPES }
-        // Dedup built-in devices (multiple mics/speakers reported by system)
-        .filter { device ->
-            if (device.type in BUILTIN_TYPES) seenBuiltinTypes.add(device.type) else true
-        }
-        // Dedup Bluetooth: A2DP and SCO often report the same headset.
-        // Keep SCO (communication profile) and drop A2DP duplicates.
-        .filter { device ->
-            if (device.type in BLUETOOTH_TYPES) {
-                val name = device.productName?.toString() ?: ""
-                // SCO always passes; A2DP only if no SCO with same name was seen
-                if (device.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO) {
-                    seenBtNames.add(name)
-                    true
-                } else {
-                    !seenBtNames.contains(name).also { seenBtNames.add(name) }
-                }
-            } else {
-                true
-            }
-        }
-}
-
-private fun audioDeviceLabel(
-    device: AudioDeviceInfo,
-    lang: String,
-): String {
-    return if (device.type in BUILTIN_TYPES) {
-        audioDeviceTypeName(device.type, lang)
-    } else {
-        device.productName?.toString()?.ifBlank { null }
-            ?: audioDeviceTypeName(device.type, lang)
-    }
-}
-
-private fun audioDeviceTypeName(
-    type: Int,
-    lang: String,
-): String =
-    when (type) {
-        AudioDeviceInfo.TYPE_BUILTIN_MIC -> Strings.t("device.microphone", lang)
-        AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> Strings.t("audio.speaker", lang)
-        AudioDeviceInfo.TYPE_BUILTIN_EARPIECE -> Strings.t("audio.earpiece", lang)
-        AudioDeviceInfo.TYPE_BLUETOOTH_A2DP -> Strings.t("audio.bluetooth", lang)
-        AudioDeviceInfo.TYPE_BLUETOOTH_SCO -> Strings.t("audio.bluetooth", lang)
-        AudioDeviceInfo.TYPE_WIRED_HEADSET -> Strings.t("audio.wiredHeadset", lang)
-        AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> Strings.t("audio.wiredHeadphones", lang)
-        AudioDeviceInfo.TYPE_USB_HEADSET -> Strings.t("audio.usbHeadset", lang)
-        else -> Strings.t("audio.device", lang)
-    }
+// Type constants, filtering, deduplication, and labeling functions have
+// been moved to AudioDeviceUtils.kt

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/PreJoinScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/PreJoinScreen.kt
@@ -2,7 +2,6 @@ package io.visio.mobile.ui
 
 import android.Manifest
 import android.annotation.SuppressLint
-import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.BitmapFactory
@@ -244,59 +243,12 @@ fun PreJoinScreen(
         }
     }
 
-    // ── Audio device state ────────────────────────────────────────────────────
+    // ── Audio device state (shared via AudioDeviceUtils) ────────────────────
     val audioManager = remember { context.getSystemService(Context.AUDIO_SERVICE) as AudioManager }
-    var audioDeviceRefreshKey by remember { mutableStateOf(0) }
-
-    DisposableEffect(Unit) {
-        val listener =
-            object : android.media.AudioDeviceCallback() {
-                override fun onAudioDevicesAdded(
-                    @Suppress("kotlin:S1172") addedDevices: Array<out AudioDeviceInfo>,
-                ) {
-                    audioDeviceRefreshKey++
-                }
-
-                override fun onAudioDevicesRemoved(
-                    @Suppress("kotlin:S1172") removedDevices: Array<out AudioDeviceInfo>,
-                ) {
-                    audioDeviceRefreshKey++
-                }
-            }
-        audioManager.registerAudioDeviceCallback(listener, null)
-        onDispose { audioManager.unregisterAudioDeviceCallback(listener) }
-    }
-
-    val audioOutputDevices =
-        remember(audioDeviceRefreshKey) {
-            audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
-                .filter {
-                    it.type in
-                        listOf(
-                            AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
-                            AudioDeviceInfo.TYPE_BLUETOOTH_SCO, AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
-                            AudioDeviceInfo.TYPE_BLE_HEADSET, AudioDeviceInfo.TYPE_BLE_SPEAKER,
-                            AudioDeviceInfo.TYPE_HEARING_AID,
-                            AudioDeviceInfo.TYPE_WIRED_HEADSET, AudioDeviceInfo.TYPE_WIRED_HEADPHONES,
-                            AudioDeviceInfo.TYPE_USB_HEADSET, AudioDeviceInfo.TYPE_USB_DEVICE,
-                        )
-                }
-                .deduplicateBluetooth()
-        }
-
-    val audioInputDevices =
-        remember(audioDeviceRefreshKey) {
-            audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)
-                .filter {
-                    it.type in
-                        listOf(
-                            AudioDeviceInfo.TYPE_BUILTIN_MIC,
-                            AudioDeviceInfo.TYPE_BLUETOOTH_SCO, AudioDeviceInfo.TYPE_BLE_HEADSET,
-                            AudioDeviceInfo.TYPE_WIRED_HEADSET, AudioDeviceInfo.TYPE_USB_HEADSET,
-                        )
-                }
-                .deduplicateBluetooth()
-        }
+    val deviceState = rememberAudioDeviceState(audioManager)
+    val audioOutputDevices = deviceState.outputDevices
+    val audioInputDevices = deviceState.inputDevices
+    val audioDeviceRefreshKey = deviceState.refreshKey
 
     var selectedOutputRoute by remember { mutableStateOf<String?>(null) }
     var selectedInputRoute by remember { mutableStateOf<String?>(null) }
@@ -1397,93 +1349,5 @@ private fun PreJoinSectionLabel(
     )
 }
 
-private val BUILTIN_TYPES =
-    listOf(
-        AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
-        AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
-        AudioDeviceInfo.TYPE_BUILTIN_MIC,
-    )
-
-private val BLUETOOTH_TYPES =
-    listOf(
-        AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
-        AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
-        AudioDeviceInfo.TYPE_BLE_HEADSET,
-        AudioDeviceInfo.TYPE_BLE_SPEAKER,
-    )
-
-/**
- * Deduplicate Bluetooth devices: SCO + A2DP + BLE for the same physical device
- * appear as separate AudioDeviceInfo entries. Keep one per physical device
- * (prefer SCO for bidirectional audio), plus all non-Bluetooth devices as-is.
- */
-private fun List<AudioDeviceInfo>.deduplicateBluetooth(): List<AudioDeviceInfo> {
-    val (bt, nonBt) = partition { it.type in BLUETOOTH_TYPES }
-    // Group Bluetooth devices by address (same physical device),
-    // preferring SCO (bidirectional) over A2DP (output-only)
-    val uniqueBt =
-        bt.groupBy { it.address.ifBlank { "bt-${it.id}" } }
-            .values
-            .map { group ->
-                group.firstOrNull { it.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO }
-                    ?: group.first()
-            }
-    return nonBt.distinctBy { it.type } + uniqueBt
-}
-
-/**
- * Resolve the Bluetooth device name from BluetoothAdapter.bondedDevices.
- * AudioDeviceInfo.productName is often empty or generic for BT devices.
- */
-@SuppressLint("MissingPermission")
-private fun resolveBluetoothName(
-    context: Context,
-    device: AudioDeviceInfo,
-): String? {
-    if (device.type !in BLUETOOTH_TYPES) return null
-    val btManager =
-        context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
-            ?: return null
-    val adapter = btManager.adapter ?: return null
-    // Match by address if available
-    val address = device.address
-    if (address.isNotBlank()) {
-        val bonded = adapter.bondedDevices?.firstOrNull { it.address == address }
-        if (bonded != null) return bonded.name
-    }
-    // Fallback: if only one Bluetooth device is bonded and connected, use its name
-    val bondedBt = adapter.bondedDevices?.toList() ?: return null
-    if (bondedBt.size == 1) return bondedBt.first().name
-    return null
-}
-
-private fun audioDeviceLabel(
-    context: Context,
-    device: AudioDeviceInfo,
-    lang: String,
-): String {
-    // Try Bluetooth adapter name first (most reliable for BT devices)
-    resolveBluetoothName(context, device)?.let { return it }
-    // Then try AudioDeviceInfo.productName for non-builtin devices
-    if (device.type !in BUILTIN_TYPES) {
-        val name = device.productName?.toString()?.ifBlank { null }
-        if (name != null) return name
-    }
-    return audioDeviceTypeLabel(device.type, lang)
-}
-
-private fun audioDeviceTypeLabel(
-    type: Int,
-    lang: String,
-): String =
-    when (type) {
-        AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> Strings.t("audio.speaker", lang)
-        AudioDeviceInfo.TYPE_BUILTIN_EARPIECE -> Strings.t("audio.earpiece", lang)
-        AudioDeviceInfo.TYPE_BUILTIN_MIC -> Strings.t(KEY_DEVICE_MICROPHONE, lang)
-        AudioDeviceInfo.TYPE_BLUETOOTH_SCO, AudioDeviceInfo.TYPE_BLUETOOTH_A2DP -> Strings.t("audio.bluetooth", lang)
-        AudioDeviceInfo.TYPE_BLE_HEADSET, AudioDeviceInfo.TYPE_BLE_SPEAKER -> Strings.t("audio.bluetooth", lang)
-        AudioDeviceInfo.TYPE_HEARING_AID -> Strings.t("audio.hearingAid", lang)
-        AudioDeviceInfo.TYPE_WIRED_HEADSET, AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> Strings.t("audio.wiredHeadset", lang)
-        AudioDeviceInfo.TYPE_USB_HEADSET, AudioDeviceInfo.TYPE_USB_DEVICE -> Strings.t("audio.usbHeadset", lang)
-        else -> "Audio"
-    }
+// Type constants, filtering, deduplication, labeling, and Bluetooth name
+// resolution have been moved to AudioDeviceUtils.kt

--- a/crates/visio-core/src/settings.rs
+++ b/crates/visio-core/src/settings.rs
@@ -7,25 +7,25 @@ use serde_json::Value;
 
 use crate::room_display_name::strip_room_display_name_param;
 
-/// A single entry in the room join history.
+/// A single entry in the visio join history.
 ///
 /// Supports backward-compatible deserialization: old format stores bare strings,
 /// new format stores `{"url": "...", "display_name": "..."}` objects.
 #[derive(Debug, Clone, Serialize, PartialEq)]
-pub struct RoomHistoryEntry {
+pub struct VisioHistoryEntry {
     pub url: String,
     pub display_name: Option<String>,
 }
 
-impl<'de> Deserialize<'de> for RoomHistoryEntry {
+impl<'de> Deserialize<'de> for VisioHistoryEntry {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        struct RoomHistoryEntryVisitor;
+        struct VisioHistoryEntryVisitor;
 
-        impl<'de> Visitor<'de> for RoomHistoryEntryVisitor {
-            type Value = RoomHistoryEntry;
+        impl<'de> Visitor<'de> for VisioHistoryEntryVisitor {
+            type Value = VisioHistoryEntry;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 formatter.write_str("a string URL or an object with url and optional display_name")
@@ -35,7 +35,7 @@ impl<'de> Deserialize<'de> for RoomHistoryEntry {
             where
                 E: de::Error,
             {
-                Ok(RoomHistoryEntry {
+                Ok(VisioHistoryEntry {
                     url: v.to_string(),
                     display_name: None,
                 })
@@ -45,7 +45,7 @@ impl<'de> Deserialize<'de> for RoomHistoryEntry {
             where
                 E: de::Error,
             {
-                Ok(RoomHistoryEntry {
+                Ok(VisioHistoryEntry {
                     url: v,
                     display_name: None,
                 })
@@ -74,11 +74,11 @@ impl<'de> Deserialize<'de> for RoomHistoryEntry {
                 }
 
                 let url = url.ok_or_else(|| de::Error::missing_field("url"))?;
-                Ok(RoomHistoryEntry { url, display_name })
+                Ok(VisioHistoryEntry { url, display_name })
             }
         }
 
-        deserializer.deserialize_any(RoomHistoryEntryVisitor)
+        deserializer.deserialize_any(VisioHistoryEntryVisitor)
     }
 }
 
@@ -90,6 +90,17 @@ pub enum CalendarRefreshInterval {
     Hour1,
     Hours4,
     Manual,
+}
+
+/// A friendly alias mapping a human-readable name to a room slug.
+///
+/// Stored case-preserving but resolved case-insensitively.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct VisioAlias {
+    /// Human-readable alias (e.g. "COMEX").
+    pub name: String,
+    /// Full canonical URL (e.g. "https://meet.example.com/abc-defg-hij").
+    pub url: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -118,8 +129,8 @@ pub struct Settings {
     pub audio_mode: String,
     #[serde(default)]
     pub adaptive_mode_enabled: bool,
-    #[serde(default)]
-    pub room_history: Vec<RoomHistoryEntry>,
+    #[serde(default, alias = "room_history")]
+    pub visio_history: Vec<VisioHistoryEntry>,
     #[serde(default = "default_true")]
     pub noise_reduction_enabled: bool,
     /// Preferred audio input device name.
@@ -140,6 +151,9 @@ pub struct Settings {
     /// How often to refresh the calendar feed.
     #[serde(default)]
     pub calendar_refresh_interval: CalendarRefreshInterval,
+    /// Friendly URL aliases mapping display names to room slugs.
+    #[serde(default)]
+    pub visio_aliases: Vec<VisioAlias>,
 }
 
 fn default_video_resolution() -> String {
@@ -184,7 +198,7 @@ impl Default for Settings {
             background_mode: "off".to_string(),
             audio_mode: "computer".to_string(),
             adaptive_mode_enabled: false,
-            room_history: Vec::new(),
+            visio_history: Vec::new(),
             noise_reduction_enabled: true,
             audio_input_device: None,
             audio_output_device: None,
@@ -192,6 +206,7 @@ impl Default for Settings {
             video_resolution: "720p".to_string(),
             calendar_url: None,
             calendar_refresh_interval: CalendarRefreshInterval::Minutes15,
+            visio_aliases: Vec::new(),
         }
     }
 }
@@ -345,39 +360,39 @@ impl SettingsStore {
         self.save();
     }
 
-    pub fn add_room_to_history(&self, url: String, display_name: Option<String>) {
+    pub fn add_visio_to_history(&self, url: String, display_name: Option<String>) {
         let canonical = strip_room_display_name_param(&url);
         let mut s = self.settings.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(pos) = s.room_history.iter().position(|e| e.url == canonical) {
-            let existing_name = s.room_history[pos].display_name.take();
+        if let Some(pos) = s.visio_history.iter().position(|e| e.url == canonical) {
+            let existing_name = s.visio_history[pos].display_name.take();
             let merged_name = display_name.or(existing_name);
-            s.room_history.remove(pos);
-            s.room_history.insert(
+            s.visio_history.remove(pos);
+            s.visio_history.insert(
                 0,
-                RoomHistoryEntry {
+                VisioHistoryEntry {
                     url: canonical,
                     display_name: merged_name,
                 },
             );
         } else {
-            s.room_history.insert(
+            s.visio_history.insert(
                 0,
-                RoomHistoryEntry {
+                VisioHistoryEntry {
                     url: canonical,
                     display_name,
                 },
             );
         }
-        s.room_history.truncate(10);
+        s.visio_history.truncate(10);
         drop(s);
         self.save();
     }
 
-    pub fn get_room_history(&self) -> Vec<RoomHistoryEntry> {
+    pub fn get_visio_history(&self) -> Vec<VisioHistoryEntry> {
         self.settings
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .room_history
+            .visio_history
             .clone()
     }
 
@@ -493,13 +508,73 @@ impl SettingsStore {
         self.save();
     }
 
-    pub fn clear_room_history(&self) {
+    pub fn clear_visio_history(&self) {
         self.settings
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .room_history
+            .visio_history
             .clear();
         self.save();
+    }
+
+    /// Store or update a friendly alias mapping a display name to a canonical URL.
+    ///
+    /// If an alias with the same name (case-insensitive) already exists, its URL
+    /// is updated to the new value.
+    pub fn add_visio_alias(&self, name: String, url: String) {
+        let canonical = strip_room_display_name_param(&url);
+        let mut s = self.settings.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(existing) = s
+            .visio_aliases
+            .iter_mut()
+            .find(|a| a.name.eq_ignore_ascii_case(&name))
+        {
+            existing.url = canonical;
+            existing.name = name;
+        } else {
+            s.visio_aliases.push(VisioAlias {
+                name,
+                url: canonical,
+            });
+        }
+        drop(s);
+        self.save();
+    }
+
+    /// Resolve a friendly alias to its canonical URL.
+    ///
+    /// Matching is case-insensitive.
+    pub fn resolve_visio_alias(&self, name: &str) -> Option<String> {
+        self.settings
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .visio_aliases
+            .iter()
+            .find(|a| a.name.eq_ignore_ascii_case(name))
+            .map(|a| a.url.clone())
+    }
+
+    /// Check whether an alias name already maps to a different URL.
+    ///
+    /// Returns `Some(existing_url)` when a conflict exists, `None` otherwise.
+    pub fn check_visio_alias_conflict(&self, name: &str, url: &str) -> Option<String> {
+        let canonical = strip_room_display_name_param(url);
+        self.settings
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .visio_aliases
+            .iter()
+            .find(|a| a.name.eq_ignore_ascii_case(name) && a.url != canonical)
+            .map(|a| a.url.clone())
+    }
+
+    /// Return all stored aliases.
+    pub fn get_visio_aliases(&self) -> Vec<VisioAlias> {
+        self.settings
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .visio_aliases
+            .clone()
     }
 
     fn save(&self) {
@@ -754,17 +829,17 @@ mod tests {
         let dir = temp_dir();
         let store = SettingsStore::new(dir.path().to_str().unwrap());
 
-        store.add_room_to_history("https://meet.example.com/room1".to_string(), None);
-        store.add_room_to_history("https://meet.example.com/room2".to_string(), None);
-        store.add_room_to_history("https://meet.example.com/room1".to_string(), None); // dedup, moves to front
+        store.add_visio_to_history("https://meet.example.com/room1".to_string(), None);
+        store.add_visio_to_history("https://meet.example.com/room2".to_string(), None);
+        store.add_visio_to_history("https://meet.example.com/room1".to_string(), None); // dedup, moves to front
 
-        let history = store.get_room_history();
+        let history = store.get_visio_history();
         assert_eq!(history.len(), 2);
         assert_eq!(history[0].url, "https://meet.example.com/room1");
         assert_eq!(history[1].url, "https://meet.example.com/room2");
 
-        store.clear_room_history();
-        assert!(store.get_room_history().is_empty());
+        store.clear_visio_history();
+        assert!(store.get_visio_history().is_empty());
     }
 
     #[test]
@@ -773,10 +848,10 @@ mod tests {
         let store = SettingsStore::new(dir.path().to_str().unwrap());
 
         for i in 0..15 {
-            store.add_room_to_history(format!("https://meet.example.com/room{i}"), None);
+            store.add_visio_to_history(format!("https://meet.example.com/room{i}"), None);
         }
 
-        let history = store.get_room_history();
+        let history = store.get_visio_history();
         assert_eq!(history.len(), 10);
         assert_eq!(history[0].url, "https://meet.example.com/room14");
     }
@@ -787,10 +862,10 @@ mod tests {
         let path = dir.path().to_str().unwrap();
         {
             let store = SettingsStore::new(path);
-            store.add_room_to_history("https://meet.example.com/room1".to_string(), None);
+            store.add_visio_to_history("https://meet.example.com/room1".to_string(), None);
         }
         let store = SettingsStore::new(path);
-        let history = store.get_room_history();
+        let history = store.get_visio_history();
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].url, "https://meet.example.com/room1");
     }
@@ -957,28 +1032,28 @@ mod tests {
         );
     }
 
-    // --- RoomHistoryEntry and migration tests ---
+    // --- VisioHistoryEntry and migration tests ---
 
     #[test]
     fn room_history_entry_round_trip() {
-        let entry = RoomHistoryEntry {
+        let entry = VisioHistoryEntry {
             url: "https://meet.example.com/room".to_string(),
             display_name: Some("My Room".to_string()),
         };
         let json = serde_json::to_string(&entry).unwrap();
-        let decoded: RoomHistoryEntry = serde_json::from_str(&json).unwrap();
+        let decoded: VisioHistoryEntry = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.url, "https://meet.example.com/room");
         assert_eq!(decoded.display_name, Some("My Room".to_string()));
     }
 
     #[test]
     fn room_history_entry_without_name() {
-        let entry = RoomHistoryEntry {
+        let entry = VisioHistoryEntry {
             url: "https://meet.example.com/room".to_string(),
             display_name: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
-        let decoded: RoomHistoryEntry = serde_json::from_str(&json).unwrap();
+        let decoded: VisioHistoryEntry = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.url, "https://meet.example.com/room");
         assert_eq!(decoded.display_name, None);
     }
@@ -993,7 +1068,7 @@ mod tests {
         )
         .unwrap();
         let store = SettingsStore::new(path);
-        let history = store.get_room_history();
+        let history = store.get_visio_history();
         assert_eq!(history.len(), 2);
         assert_eq!(history[0].url, "https://meet.example.com/room1");
         assert_eq!(history[0].display_name, None);
@@ -1011,7 +1086,7 @@ mod tests {
         )
         .unwrap();
         let store = SettingsStore::new(path);
-        let history = store.get_room_history();
+        let history = store.get_visio_history();
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].url, "https://meet.example.com/room");
         assert_eq!(history[0].display_name, Some("My Room".to_string()));
@@ -1027,7 +1102,7 @@ mod tests {
         )
         .unwrap();
         let store = SettingsStore::new(path);
-        let history = store.get_room_history();
+        let history = store.get_visio_history();
         assert_eq!(history.len(), 2);
         assert_eq!(history[0].url, "https://meet.example.com/room1");
         assert_eq!(history[0].display_name, None);
@@ -1039,15 +1114,15 @@ mod tests {
     fn add_room_updates_display_name() {
         let dir = temp_dir();
         let store = SettingsStore::new(dir.path().to_str().unwrap());
-        store.add_room_to_history(
+        store.add_visio_to_history(
             "https://meet.example.com/room".to_string(),
             Some("Old Name".to_string()),
         );
-        store.add_room_to_history(
+        store.add_visio_to_history(
             "https://meet.example.com/room".to_string(),
             Some("New Name".to_string()),
         );
-        let history = store.get_room_history();
+        let history = store.get_visio_history();
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].url, "https://meet.example.com/room");
         assert_eq!(history[0].display_name, Some("New Name".to_string()));
@@ -1057,12 +1132,12 @@ mod tests {
     fn add_room_without_name_preserves_existing() {
         let dir = temp_dir();
         let store = SettingsStore::new(dir.path().to_str().unwrap());
-        store.add_room_to_history(
+        store.add_visio_to_history(
             "https://meet.example.com/room".to_string(),
             Some("Keep Me".to_string()),
         );
-        store.add_room_to_history("https://meet.example.com/room".to_string(), None);
-        let history = store.get_room_history();
+        store.add_visio_to_history("https://meet.example.com/room".to_string(), None);
+        let history = store.get_visio_history();
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].url, "https://meet.example.com/room");
         assert_eq!(history[0].display_name, Some("Keep Me".to_string()));
@@ -1073,14 +1148,104 @@ mod tests {
         let dir = temp_dir();
         let store = SettingsStore::new(dir.path().to_str().unwrap());
         for i in 0..12 {
-            store.add_room_to_history(
+            store.add_visio_to_history(
                 format!("https://meet.example.com/room{i}"),
                 Some(format!("Room {i}")),
             );
         }
-        let history = store.get_room_history();
+        let history = store.get_visio_history();
         assert_eq!(history.len(), 10);
         assert_eq!(history[0].url, "https://meet.example.com/room11");
         assert_eq!(history[0].display_name, Some("Room 11".to_string()));
+    }
+
+    // --- VisioAlias tests ---
+
+    #[test]
+    fn alias_add_and_resolve() {
+        let dir = temp_dir();
+        let store = SettingsStore::new(dir.path().to_str().unwrap());
+        store.add_visio_alias(
+            "COMEX".to_string(),
+            "https://meet.example.com/abc-defg-hij".to_string(),
+        );
+        assert_eq!(
+            store.resolve_visio_alias("COMEX"),
+            Some("https://meet.example.com/abc-defg-hij".to_string())
+        );
+    }
+
+    #[test]
+    fn alias_case_insensitive_resolve() {
+        let dir = temp_dir();
+        let store = SettingsStore::new(dir.path().to_str().unwrap());
+        store.add_visio_alias(
+            "COMEX".to_string(),
+            "https://meet.example.com/abc-defg-hij".to_string(),
+        );
+        assert_eq!(
+            store.resolve_visio_alias("comex"),
+            Some("https://meet.example.com/abc-defg-hij".to_string())
+        );
+        assert_eq!(
+            store.resolve_visio_alias("Comex"),
+            Some("https://meet.example.com/abc-defg-hij".to_string())
+        );
+    }
+
+    #[test]
+    fn alias_update_existing() {
+        let dir = temp_dir();
+        let store = SettingsStore::new(dir.path().to_str().unwrap());
+        store.add_visio_alias(
+            "COMEX".to_string(),
+            "https://meet.example.com/old-slug-xxx".to_string(),
+        );
+        store.add_visio_alias(
+            "comex".to_string(),
+            "https://meet.example.com/new-slug-yyy".to_string(),
+        );
+        let aliases = store.get_visio_aliases();
+        assert_eq!(aliases.len(), 1);
+        assert_eq!(aliases[0].name, "comex");
+        assert_eq!(aliases[0].url, "https://meet.example.com/new-slug-yyy");
+    }
+
+    #[test]
+    fn alias_conflict_detection() {
+        let dir = temp_dir();
+        let store = SettingsStore::new(dir.path().to_str().unwrap());
+        store.add_visio_alias(
+            "COMEX".to_string(),
+            "https://meet.example.com/abc-defg-hij".to_string(),
+        );
+        // Same name, same URL => no conflict
+        assert_eq!(
+            store.check_visio_alias_conflict("COMEX", "https://meet.example.com/abc-defg-hij"),
+            None
+        );
+        // Same name, different URL => conflict
+        assert_eq!(
+            store.check_visio_alias_conflict("comex", "https://meet.example.com/xyz-abcd-efg"),
+            Some("https://meet.example.com/abc-defg-hij".to_string())
+        );
+    }
+
+    #[test]
+    fn alias_persists_across_reload() {
+        let dir = temp_dir();
+        let path = dir.path().to_str().unwrap();
+        {
+            let store = SettingsStore::new(path);
+            store.add_visio_alias(
+                "Weekly".to_string(),
+                "https://meet.example.com/abc-defg-hij".to_string(),
+            );
+        }
+        let store = SettingsStore::new(path);
+        assert_eq!(
+            store.resolve_visio_alias("weekly"),
+            Some("https://meet.example.com/abc-defg-hij".to_string())
+        );
     }
 }

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -47,6 +47,11 @@ import {
   RiVolumeMuteLine,
   RiAddLine,
 } from '@remixicon/react'
+import {
+  useDeviceEnumeration,
+  type NativeAudioDevice,
+  type NativeVideoDevice,
+} from './useDeviceEnumeration'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -155,7 +160,7 @@ interface Meeting {
   server_name: string
 }
 
-interface RoomHistoryEntry {
+interface VisioHistoryEntry {
   url: string
   display_name: string | null
 }
@@ -204,15 +209,8 @@ const translations: Record<string, Record<string, string>> = {
 }
 const SUPPORTED_LANGS = Object.keys(translations)
 
-interface NativeAudioDevice {
-  name: string
-  is_default: boolean
-}
-interface NativeVideoDevice {
-  name: string
-  unique_id: string
-  is_default: boolean
-}
+// NativeAudioDevice and NativeVideoDevice are imported from
+// useDeviceEnumeration.ts
 
 const SLUG_REGEX = /^[a-z]{3}-[a-z]{4}-[a-z]{3}$/
 
@@ -912,7 +910,7 @@ function HomeView({
   const [meetUrl, setMeetUrl] = useState('')
   const [roomDisplayName, setRoomDisplayName] = useState('')
   const [resolvedUrl, setResolvedUrl] = useState('')
-  const [roomHistory, setRoomHistory] = useState<RoomHistoryEntry[]>([])
+  const [visioHistory, setRoomHistory] = useState<VisioHistoryEntry[]>([])
   const [meetingCount, setMeetingCount] = useState(0)
   const [tick, setTick] = useState(0)
   const [hasImminentMeeting, setHasImminentMeeting] = useState(false)
@@ -925,7 +923,7 @@ function HomeView({
   }, [])
 
   useEffect(() => {
-    invoke<RoomHistoryEntry[]>('get_room_history')
+    invoke<VisioHistoryEntry[]>('get_visio_history')
       .then(setRoomHistory)
       .catch(() => {})
   }, [])
@@ -1425,10 +1423,10 @@ function HomeView({
               </div>
             )}
             <div className="error-msg">{error}</div>
-            {roomHistory.length > 0 && (
+            {visioHistory.length > 0 && (
               <div className="room-history">
                 <h4>{t('home.recentRooms')}</h4>
-                {roomHistory.map((entry) => {
+                {visioHistory.map((entry) => {
                   const { url, display_name } = entry
                   const slug = url.includes('/') ? url.split('/').pop() : url
                   let host: string
@@ -3737,7 +3735,7 @@ function SettingsView({
         <button
           className="settings-clear-history"
           onClick={async () => {
-            await invoke('clear_room_history')
+            await invoke('clear_visio_history')
             setSaveStatus(t('settings.historyCleared'))
             setTimeout(() => setSaveStatus(null), 2000)
           }}
@@ -3759,108 +3757,15 @@ function SettingsView({
 // Shared hook: audio device fallback on Bluetooth connect/disconnect
 // ---------------------------------------------------------------------------
 
-/**
- * Returns a fallback device name when the currently selected device disappears.
- * If the current selection is still present, returns it unchanged.
- */
-function resolveAudioFallback(
-  prev: string,
-  devices: NativeAudioDevice[],
-  selectCommand: string
-): string {
-  if (!prev || devices.some((d) => d.name === prev)) return prev
-  const def = devices.find((d) => d.is_default)
-  const fallback = def ? def.name : (devices[0]?.name ?? '')
-  invoke(selectCommand, { deviceName: fallback }).catch(() => {})
-  return fallback
-}
-
-/**
- * Handles the audio-devices-changed event by re-enumerating devices
- * and falling back to defaults when the selected device disappears.
- */
-async function handleAudioDevicesChanged(
-  setInputs: (devices: NativeAudioDevice[]) => void,
-  setOutputs: (devices: NativeAudioDevice[]) => void,
-  setSelectedInput: (updater: (prev: string) => string) => void,
-  setSelectedOutput: (updater: (prev: string) => string) => void,
-  onInputFallback?: () => void
-) {
-  const [inputs, outputs] = await Promise.all([
-    invoke<NativeAudioDevice[]>('list_audio_input_devices'),
-    invoke<NativeAudioDevice[]>('list_audio_output_devices'),
-  ])
-  setInputs(inputs)
-  setOutputs(outputs)
-
-  setSelectedInput((prev) => {
-    const result = resolveAudioFallback(prev, inputs, 'select_audio_input')
-    if (result !== prev) onInputFallback?.()
-    return result
-  })
-
-  setSelectedOutput((prev) =>
-    resolveAudioFallback(prev, outputs, 'select_audio_output')
-  )
-}
-
-/**
- * Subscribes to the `audio-devices-changed` Tauri event and:
- *  1. Re-enumerates input/output audio devices.
- *  2. Falls back to the default device if the currently selected one disappears.
- *
- * @param setInputs   - Setter for the input device list state.
- * @param setOutputs  - Setter for the output device list state.
- * @param setSelected - Setters for the currently selected device names.
- * @param onInputFallback - Optional callback invoked after an input fallback
- *                          (e.g. to restart a mic preview).
- */
-function useAudioDeviceFallback({
-  setInputs,
-  setOutputs,
-  setSelectedInput,
-  setSelectedOutput,
-  onInputFallback,
-}: {
-  setInputs: (devices: NativeAudioDevice[]) => void
-  setOutputs: (devices: NativeAudioDevice[]) => void
-  setSelectedInput: (updater: (prev: string) => string) => void
-  setSelectedOutput: (updater: (prev: string) => string) => void
-  onInputFallback?: () => void
-}) {
-  useEffect(() => {
-    let unlistenFn: (() => void) | null = null
-    listen('audio-devices-changed', () => {
-      handleAudioDevicesChanged(
-        setInputs,
-        setOutputs,
-        setSelectedInput,
-        setSelectedOutput,
-        onInputFallback
-      ).catch((e) => {
-        console.warn('Failed to re-enumerate audio devices after change:', e)
-      })
-    }).then((fn) => {
-      unlistenFn = fn
-    })
-    return () => {
-      unlistenFn?.()
-    }
-  }, [])
-}
+// resolveAudioFallback, handleAudioDevicesChanged, and
+// useAudioDeviceFallback have been moved into useDeviceEnumeration.ts
 
 // ---------------------------------------------------------------------------
 // Pre-Join Screen
 // ---------------------------------------------------------------------------
 
-// AudioDeviceInfo is an alias for NativeAudioDevice (same shape, local name).
-type AudioDeviceInfo = NativeAudioDevice
-
-interface VideoDeviceInfo {
-  name: string
-  unique_id: string
-  is_default: boolean
-}
+// NativeAudioDevice and NativeVideoDevice aliases removed — using
+// NativeAudioDevice and NativeVideoDevice from useDeviceEnumeration.ts
 
 /** Save user preferences (display name, mic/camera state, audio mode) before joining. */
 async function savePreJoinPreferences(
@@ -3932,12 +3837,26 @@ function PreJoinScreen({
   const [isMicOn, setIsMicOn] = useState(true)
   const [audioMode, setAudioMode] = useState<'computer' | 'none'>('computer')
   const [previewFrame, setPreviewFrame] = useState<string | null>(null)
-  const [videoDevices, setVideoDevices] = useState<VideoDeviceInfo[]>([])
-  const [inputDevices, setInputDevices] = useState<AudioDeviceInfo[]>([])
-  const [outputDevices, setOutputDevices] = useState<AudioDeviceInfo[]>([])
-  const [selectedCamera, setSelectedCamera] = useState('')
-  const [selectedInput, setSelectedInput] = useState('')
-  const [selectedOutput, setSelectedOutput] = useState('')
+  // Unified device enumeration (lobby context — enumerates on mount)
+  const devices = useDeviceEnumeration({
+    onInputFallback: () => {
+      invoke('stop_mic_preview')
+        .catch(() => {})
+        .then(() => invoke('start_mic_preview'))
+        .catch(() => {})
+    },
+  })
+  const {
+    audioInputs: inputDevices,
+    audioOutputs: outputDevices,
+    videoInputs: videoDevices,
+    selectedAudioInput: selectedInput,
+    selectedAudioOutput: selectedOutput,
+    selectedVideoInput: selectedCamera,
+    setSelectedAudioInput: setSelectedInput,
+    setSelectedAudioOutput: setSelectedOutput,
+    setSelectedVideoInput: setSelectedCamera,
+  } = devices
   const [micLevel, setMicLevel] = useState(0)
   const [showFilters, setShowFilters] = useState(false)
   const [backgroundMode, setBackgroundMode] = useState('off')
@@ -3972,24 +3891,8 @@ function PreJoinScreen({
       })
       .catch(() => {})
 
-    // Load device lists
-    Promise.all([
-      invoke<AudioDeviceInfo[]>('list_audio_input_devices'),
-      invoke<AudioDeviceInfo[]>('list_audio_output_devices'),
-      invoke<VideoDeviceInfo[]>('list_video_input_devices'),
-    ])
-      .then(([inputs, outputs, cameras]) => {
-        setInputDevices(inputs)
-        setOutputDevices(outputs)
-        setVideoDevices(cameras)
-        const defInput = inputs.find((d) => d.is_default)
-        const defOutput = outputs.find((d) => d.is_default)
-        const defCam = cameras.find((d) => d.is_default)
-        if (defInput) setSelectedInput(defInput.name)
-        if (defOutput) setSelectedOutput(defOutput.name)
-        if (defCam) setSelectedCamera(defCam.unique_id)
-      })
-      .catch(() => {})
+    // Load device lists via unified hook
+    devices.enumerate()
 
     // Subscribe to video frame events
     listen<{ track_sid: string; data: string; width: number; height: number }>(
@@ -4051,20 +3954,7 @@ function PreJoinScreen({
     }
   }, [isMicOn, audioMode])
 
-  // ---- Effect: audio device changes (Bluetooth connect/disconnect) ---------
-  // Restart mic preview when the input falls back to a new device.
-  useAudioDeviceFallback({
-    setInputs: setInputDevices,
-    setOutputs: setOutputDevices,
-    setSelectedInput,
-    setSelectedOutput,
-    onInputFallback: () => {
-      invoke('stop_mic_preview')
-        .catch(() => {})
-        .then(() => invoke('start_mic_preview'))
-        .catch(() => {})
-    },
-  })
+  // Audio device fallback is now handled by useDeviceEnumeration hook.
 
   // ---- Handlers -----------------------------------------------------------
   const handleSelectCamera = async (uniqueId: string) => {
@@ -4810,90 +4700,32 @@ export default function App() {
     document.documentElement.dataset.theme = theme
   }, [theme])
 
-  // Device enumeration
-  const [audioInputs, setAudioInputs] = useState<NativeAudioDevice[]>([])
-  const [audioOutputs, setAudioOutputs] = useState<NativeAudioDevice[]>([])
-  const [videoInputs, setVideoInputs] = useState<NativeVideoDevice[]>([])
-  const [selectedAudioInput, setSelectedAudioInput] = useState('')
-  const [selectedAudioOutput, setSelectedAudioOutput] = useState('')
-  const [selectedVideoInput, setSelectedVideoInput] = useState('')
+  // ---- Unified device enumeration (in-call context) -----------------------
+  // Lazy: does NOT enumerate until a picker is opened (avoids macOS mic
+  // permission issue #161). Fallback + audio-devices-changed handled by hook.
+  const inCallDevices = useDeviceEnumeration()
+  const {
+    audioInputs,
+    audioOutputs,
+    videoInputs,
+    selectedAudioInput,
+    selectedAudioOutput,
+    selectedVideoInput,
+    setSelectedAudioInput,
+    setSelectedAudioOutput,
+    setSelectedVideoInput,
+    devicesEnumerated,
+    enumerate: enumerateDevices,
+  } = inCallDevices
 
   const viewRef = useRef(view)
   viewRef.current = view
 
-  // ---- Audio device change listener (in-call) -----------------------------
-  // Handles Bluetooth headset connect/disconnect during an active call.
-  // Re-enumerates devices and falls back to default if the selected device
-  // is no longer available.
-  useAudioDeviceFallback({
-    setInputs: setAudioInputs,
-    setOutputs: setAudioOutputs,
-    setSelectedInput: setSelectedAudioInput,
-    setSelectedOutput: setSelectedAudioOutput,
-  })
-
-  // ---- Device enumeration -------------------------------------------------
-  // WORKAROUND: Defer device enumeration to avoid USB blocking at startup.
-  // Enumerate when mic picker or camera picker is opened (in-call only).
-  // NOTE: Do NOT enumerate on the general settings page — on macOS,
-  // cpal's input_devices() triggers a microphone permission request (#161).
-  const [devicesEnumerated, setDevicesEnumerated] = useState(false)
-
+  // Trigger enumeration lazily when a device picker is first opened.
   useEffect(() => {
     if ((!showMicPicker && !showCamPicker) || devicesEnumerated) return
-
-    const enumerate = async () => {
-      try {
-        console.log('Enumerating audio/video devices...')
-        const inputs: NativeAudioDevice[] = await invoke(
-          'list_audio_input_devices'
-        )
-        const outputs: NativeAudioDevice[] = await invoke(
-          'list_audio_output_devices'
-        )
-        const cameras: NativeVideoDevice[] = await invoke(
-          'list_video_input_devices'
-        )
-        setAudioInputs(inputs)
-        setAudioOutputs(outputs)
-        setVideoInputs(cameras)
-        setDevicesEnumerated(true)
-
-        // Auto-select defaults on first load
-        setSelectedAudioInput((prev) => {
-          if (prev) return prev
-          const def = inputs.find((d) => d.is_default)
-          return def ? def.name : ''
-        })
-        setSelectedAudioOutput((prev) => {
-          if (prev) return prev
-          const def = outputs.find((d) => d.is_default)
-          return def ? def.name : ''
-        })
-        setSelectedVideoInput((prev) => {
-          if (prev) return prev
-          const def = cameras.find((d) => d.is_default)
-          return def ? def.unique_id : ''
-        })
-      } catch (e) {
-        console.warn('Device enumeration failed:', e)
-      }
-    }
-    enumerate()
-
-    // Listen for audio device errors (e.g. USB unplug) to re-enumerate
-    let unlistenFn: (() => void) | null = null
-    listen('audio-device-error', (event) => {
-      console.warn('Audio device error:', event.payload)
-      enumerate()
-    }).then((fn_) => {
-      unlistenFn = fn_
-    })
-
-    return () => {
-      unlistenFn?.()
-    }
-  }, [showMicPicker, showCamPicker, devicesEnumerated])
+    enumerateDevices()
+  }, [showMicPicker, showCamPicker, devicesEnumerated, enumerateDevices])
 
   // ---- Click outside to close device pickers ------------------------------
   useEffect(() => {

--- a/crates/visio-desktop/frontend/src/useDeviceEnumeration.ts
+++ b/crates/visio-desktop/frontend/src/useDeviceEnumeration.ts
@@ -1,0 +1,192 @@
+/**
+ * useDeviceEnumeration — unified device enumeration hook.
+ *
+ * Replaces the three separate enumeration sites (lobby mount, in-call
+ * picker, in-call refresh) with a single lazy hook that:
+ *  - Enumerates audio input, output, AND video devices
+ *  - Auto-selects the default device on first load
+ *  - Falls back to the default device when the selected one disappears
+ *  - Exposes a `devicesEnumerated` flag
+ *  - Listens for `audio-devices-changed` and `audio-device-error` events
+ *  - Does NOT enumerate until `enumerate()` is called (lazy — avoids
+ *    the macOS mic permission issue, see #161)
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
+
+// ---------------------------------------------------------------------------
+// Types (canonical — shared across lobby + in-call)
+// ---------------------------------------------------------------------------
+
+export interface NativeAudioDevice {
+  name: string
+  is_default: boolean
+}
+
+export interface NativeVideoDevice {
+  name: string
+  unique_id: string
+  is_default: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a fallback device name when the currently selected device
+ * disappears. If the current selection is still present, returns it
+ * unchanged.
+ */
+function resolveAudioFallback(
+  prev: string,
+  devices: NativeAudioDevice[],
+  selectCommand: string
+): string {
+  if (!prev || devices.some((d) => d.name === prev)) return prev
+  const def = devices.find((d) => d.is_default)
+  const fallback = def ? def.name : (devices[0]?.name ?? '')
+  invoke(selectCommand, { deviceName: fallback }).catch(() => {})
+  return fallback
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface DeviceEnumerationState {
+  audioInputs: NativeAudioDevice[]
+  audioOutputs: NativeAudioDevice[]
+  videoInputs: NativeVideoDevice[]
+  selectedAudioInput: string
+  selectedAudioOutput: string
+  selectedVideoInput: string
+  setSelectedAudioInput: React.Dispatch<React.SetStateAction<string>>
+  setSelectedAudioOutput: React.Dispatch<React.SetStateAction<string>>
+  setSelectedVideoInput: React.Dispatch<React.SetStateAction<string>>
+  devicesEnumerated: boolean
+  /** Trigger device enumeration. Safe to call multiple times. */
+  enumerate: () => Promise<void>
+}
+
+export interface UseDeviceEnumerationOptions {
+  /**
+   * Called after the selected audio input falls back to a different
+   * device (e.g. Bluetooth headset unplugged). Useful for restarting
+   * mic preview in the lobby.
+   */
+  onInputFallback?: () => void
+}
+
+export function useDeviceEnumeration(
+  options: UseDeviceEnumerationOptions = {}
+): DeviceEnumerationState {
+  const [audioInputs, setAudioInputs] = useState<NativeAudioDevice[]>([])
+  const [audioOutputs, setAudioOutputs] = useState<NativeAudioDevice[]>([])
+  const [videoInputs, setVideoInputs] = useState<NativeVideoDevice[]>([])
+  const [selectedAudioInput, setSelectedAudioInput] = useState('')
+  const [selectedAudioOutput, setSelectedAudioOutput] = useState('')
+  const [selectedVideoInput, setSelectedVideoInput] = useState('')
+  const [devicesEnumerated, setDevicesEnumerated] = useState(false)
+
+  // Keep a stable ref to the callback so the listener doesn't go stale.
+  const onInputFallbackRef = useRef(options.onInputFallback)
+  onInputFallbackRef.current = options.onInputFallback
+
+  // ---- Core enumerate function -------------------------------------------
+  const enumerate = useCallback(async () => {
+    try {
+      const [inputs, outputs, cameras] = await Promise.all([
+        invoke<NativeAudioDevice[]>('list_audio_input_devices'),
+        invoke<NativeAudioDevice[]>('list_audio_output_devices'),
+        invoke<NativeVideoDevice[]>('list_video_input_devices'),
+      ])
+      setAudioInputs(inputs)
+      setAudioOutputs(outputs)
+      setVideoInputs(cameras)
+      setDevicesEnumerated(true)
+
+      // Auto-select defaults when nothing is selected yet.
+      setSelectedAudioInput((prev) => {
+        if (prev) return prev
+        const def = inputs.find((d) => d.is_default)
+        return def ? def.name : ''
+      })
+      setSelectedAudioOutput((prev) => {
+        if (prev) return prev
+        const def = outputs.find((d) => d.is_default)
+        return def ? def.name : ''
+      })
+      setSelectedVideoInput((prev) => {
+        if (prev) return prev
+        const def = cameras.find((d) => d.is_default)
+        return def ? def.unique_id : ''
+      })
+    } catch (e) {
+      console.warn('Device enumeration failed:', e)
+    }
+  }, [])
+
+  // ---- Audio-device-changed listener (fallback logic) --------------------
+  useEffect(() => {
+    let unlistenChanged: (() => void) | null = null
+    let unlistenError: (() => void) | null = null
+
+    listen('audio-devices-changed', async () => {
+      try {
+        const [inputs, outputs] = await Promise.all([
+          invoke<NativeAudioDevice[]>('list_audio_input_devices'),
+          invoke<NativeAudioDevice[]>('list_audio_output_devices'),
+        ])
+        setAudioInputs(inputs)
+        setAudioOutputs(outputs)
+
+        setSelectedAudioInput((prev) => {
+          const result = resolveAudioFallback(
+            prev,
+            inputs,
+            'select_audio_input'
+          )
+          if (result !== prev) onInputFallbackRef.current?.()
+          return result
+        })
+
+        setSelectedAudioOutput((prev) =>
+          resolveAudioFallback(prev, outputs, 'select_audio_output')
+        )
+      } catch (e) {
+        console.warn('Failed to re-enumerate audio devices after change:', e)
+      }
+    }).then((fn) => {
+      unlistenChanged = fn
+    })
+
+    listen('audio-device-error', (event) => {
+      console.warn('Audio device error:', event.payload)
+      enumerate()
+    }).then((fn) => {
+      unlistenError = fn
+    })
+
+    return () => {
+      unlistenChanged?.()
+      unlistenError?.()
+    }
+  }, [enumerate])
+
+  return {
+    audioInputs,
+    audioOutputs,
+    videoInputs,
+    selectedAudioInput,
+    selectedAudioOutput,
+    selectedVideoInput,
+    setSelectedAudioInput,
+    setSelectedAudioOutput,
+    setSelectedVideoInput,
+    devicesEnumerated,
+    enumerate,
+  }
+}

--- a/crates/visio-desktop/src/lib.rs
+++ b/crates/visio-desktop/src/lib.rs
@@ -130,7 +130,7 @@ fn handle_connection_state_changed(
             if let Some((url, _)) = room.lock().await.last_connection_info().await {
                 let display_name = visio_core::extract_room_display_name(&url);
                 let clean_url = visio_core::strip_room_display_name_param(&url);
-                settings.add_room_to_history(clean_url, display_name);
+                settings.add_visio_to_history(clean_url, display_name);
             }
         });
     }
@@ -929,18 +929,18 @@ fn set_meet_instances(state: tauri::State<'_, VisioState>, instances: Vec<String
 }
 
 #[derive(serde::Serialize)]
-struct RoomHistoryEntryJs {
+struct VisioHistoryEntryJs {
     url: String,
     display_name: Option<String>,
 }
 
 #[tauri::command]
-fn get_room_history(state: tauri::State<'_, VisioState>) -> Result<Vec<RoomHistoryEntryJs>, String> {
+fn get_visio_history(state: tauri::State<'_, VisioState>) -> Result<Vec<VisioHistoryEntryJs>, String> {
     Ok(state
         .settings
-        .get_room_history()
+        .get_visio_history()
         .into_iter()
-        .map(|e| RoomHistoryEntryJs {
+        .map(|e| VisioHistoryEntryJs {
             url: e.url,
             display_name: e.display_name,
         })
@@ -953,8 +953,8 @@ fn validate_room_display_name_cmd(name: String) -> Option<String> {
 }
 
 #[tauri::command]
-fn clear_room_history(state: tauri::State<'_, VisioState>) {
-    state.settings.clear_room_history();
+fn clear_visio_history(state: tauri::State<'_, VisioState>) {
+    state.settings.clear_visio_history();
 }
 
 // ---------------------------------------------------------------------------
@@ -2154,8 +2154,8 @@ pub fn run() {
             play_speaker_test,
             set_adaptive_mode_enabled,
             check_media_permissions,
-            get_room_history,
-            clear_room_history,
+            get_visio_history,
+            clear_visio_history,
             validate_room_display_name_cmd,
             get_calendar_url,
             set_calendar_url,

--- a/crates/visio-ffi/src/lib.rs
+++ b/crates/visio-ffi/src/lib.rs
@@ -278,13 +278,13 @@ impl From<CalendarRefreshInterval> for CoreCalendarRefreshInterval {
 }
 
 #[derive(Debug, Clone)]
-pub struct RoomHistoryEntry {
+pub struct VisioHistoryEntry {
     pub url: String,
     pub display_name: Option<String>,
 }
 
-impl From<visio_core::settings::RoomHistoryEntry> for RoomHistoryEntry {
-    fn from(e: visio_core::settings::RoomHistoryEntry) -> Self {
+impl From<visio_core::settings::VisioHistoryEntry> for VisioHistoryEntry {
+    fn from(e: visio_core::settings::VisioHistoryEntry) -> Self {
         Self {
             url: e.url,
             display_name: e.display_name,
@@ -801,7 +801,7 @@ impl BridgeListener {
         let settings = self.settings.clone();
         tokio::spawn(async move {
             if let Some((url, _)) = rm.last_connection_info().await {
-                settings.add_room_to_history(url, None);
+                settings.add_visio_to_history(url, None);
             }
         });
     }
@@ -977,7 +977,7 @@ impl VisioClient {
                 }
 
                 self.settings
-                    .add_room_to_history(clean_url.clone(), display_name);
+                    .add_visio_to_history(clean_url.clone(), display_name);
 
                 Ok(())
             }
@@ -1255,20 +1255,20 @@ impl VisioClient {
         self.settings.set_camera_device(name);
     }
 
-    pub fn add_room_to_history(&self, url: String, display_name: Option<String>) {
-        self.settings.add_room_to_history(url, display_name);
+    pub fn add_visio_to_history(&self, url: String, display_name: Option<String>) {
+        self.settings.add_visio_to_history(url, display_name);
     }
 
-    pub fn get_room_history(&self) -> Vec<RoomHistoryEntry> {
+    pub fn get_visio_history(&self) -> Vec<VisioHistoryEntry> {
         self.settings
-            .get_room_history()
+            .get_visio_history()
             .into_iter()
             .map(Into::into)
             .collect()
     }
 
-    pub fn clear_room_history(&self) {
-        self.settings.clear_room_history();
+    pub fn clear_visio_history(&self) {
+        self.settings.clear_visio_history();
     }
 
     pub fn extract_room_display_name(&self, url: String) -> Option<String> {

--- a/crates/visio-ffi/src/visio.udl
+++ b/crates/visio-ffi/src/visio.udl
@@ -207,7 +207,7 @@ dictionary Meeting {
     string server_name;
 };
 
-dictionary RoomHistoryEntry {
+dictionary VisioHistoryEntry {
     string url;
     string? display_name;
 };
@@ -360,11 +360,11 @@ interface VisioClient {
 
     void stop_video_renderer(string track_sid);
 
-    void add_room_to_history(string url, string? display_name);
+    void add_visio_to_history(string url, string? display_name);
 
-    sequence<RoomHistoryEntry> get_room_history();
+    sequence<VisioHistoryEntry> get_visio_history();
 
-    void clear_room_history();
+    void clear_visio_history();
 
     string? extract_room_display_name(string url);
 

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -140,7 +140,7 @@
   "home.createRoom.error": "Visio-Erstellung fehlgeschlagen",
   "settings.incall.roomInfo": "Visio-Info",
   "settings.incall.roomLink": "Visio-Link",
-  "settings.incall.deepLink": "App-Link",
+  "settings.incall.deepLink": "Visio App-Link",
   "settings.incall.share": "Link teilen",
   "settings.incall.copied": "Kopiert!",
   "lobby.waiting": "Warte auf Genehmigung des Gastgebers...",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -144,7 +144,7 @@
   "home.createRoom.error": "Visio creation failed",
   "settings.incall.roomInfo": "Visio info",
   "settings.incall.roomLink": "Visio link",
-  "settings.incall.deepLink": "App link",
+  "settings.incall.deepLink": "Visio app link",
   "settings.incall.share": "Share link",
   "settings.incall.copied": "Copied!",
   "lobby.waiting": "Waiting for host approval...",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -140,7 +140,7 @@
   "home.createRoom.error": "Error al crear la visio",
   "settings.incall.roomInfo": "Info de visio",
   "settings.incall.roomLink": "Enlace de la visio",
-  "settings.incall.deepLink": "Enlace de app",
+  "settings.incall.deepLink": "Enlace de app Visio",
   "settings.incall.share": "Compartir enlace",
   "settings.incall.copied": "¡Copiado!",
   "lobby.waiting": "Esperando la aprobación del anfitrión...",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -144,7 +144,7 @@
   "home.createRoom.error": "Échec de la création de la visio",
   "settings.incall.roomInfo": "Infos visio",
   "settings.incall.roomLink": "Lien de la visio",
-  "settings.incall.deepLink": "Lien application",
+  "settings.incall.deepLink": "Lien Visio application",
   "settings.incall.share": "Partager le lien",
   "settings.incall.copied": "Copié !",
   "lobby.waiting": "En attente d'approbation de l'hôte...",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -140,7 +140,7 @@
   "home.createRoom.error": "Creazione visio fallita",
   "settings.incall.roomInfo": "Info visio",
   "settings.incall.roomLink": "Link della visio",
-  "settings.incall.deepLink": "Link app",
+  "settings.incall.deepLink": "Link app Visio",
   "settings.incall.share": "Condividi link",
   "settings.incall.copied": "Copiato!",
   "lobby.waiting": "In attesa dell'approvazione dell'host...",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -140,7 +140,7 @@
   "home.createRoom.error": "Visio aanmaken mislukt",
   "settings.incall.roomInfo": "Visio-info",
   "settings.incall.roomLink": "Visio-link",
-  "settings.incall.deepLink": "App-link",
+  "settings.incall.deepLink": "Visio App-link",
   "settings.incall.share": "Link delen",
   "settings.incall.copied": "Gekopieerd!",
   "lobby.waiting": "Wachten op goedkeuring van de host...",

--- a/ios/VisioMobile.xcodeproj/project.pbxproj
+++ b/ios/VisioMobile.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		A10001000000000000000016 /* ToolbarFix.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000200000000000000001A /* ToolbarFix.swift */; };
 		A10001000000000000000017 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1000200000000000000001B /* Assets.xcassets */; };
 		A10001000000000000000018 /* InCallSettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000200000000000000001C /* InCallSettingsSheet.swift */; };
+		A10001000000000000000033 /* AudioDeviceUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10002000000000000000033 /* AudioDeviceUtils.swift */; };
 		A1000100000000000000000B /* libvisio_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A1000200000000000000000B /* libvisio_ffi.a */; };
 		A1000100000000000000000D /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = A1000200000000000000000D /* libresolv.tbd */; };
 		A10001000000000000000019 /* OidcAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000200000000000000001D /* OidcAuthManager.swift */; };
@@ -81,6 +82,7 @@
 		A10002000000000000000030 /* MediaFileCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaFileCapture.swift; sourceTree = "<group>"; };
 		A10002000000000000000031 /* NV12Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NV12Util.swift; sourceTree = "<group>"; };
 		A10002000000000000000032 /* AudioCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCapture.swift; sourceTree = "<group>"; };
+		A10002000000000000000033 /* AudioDeviceUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDeviceUtils.swift; sourceTree = "<group>"; };
 		A10003000000000000000001 /* VisioMobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VisioMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B10002000000000000000001 /* VisioMobileUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisioMobileUITests.swift; sourceTree = "<group>"; };
 		B10003000000000000000001 /* VisioMobileUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VisioMobileUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -165,6 +167,7 @@
 				A10002000000000000000022 /* PreJoinView.swift */,
 				A10002000000000000000023 /* AudioRoutePickerButton.swift */,
 				A10002000000000000000024 /* BlurredCameraPreviewView.swift */,
+				A10002000000000000000033 /* AudioDeviceUtils.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -403,6 +406,7 @@
 				A10001000000000000000030 /* MediaFileCapture.swift in Sources */,
 				A10001000000000000000031 /* NV12Util.swift in Sources */,
 				A10001000000000000000032 /* AudioCapture.swift in Sources */,
+				A10001000000000000000033 /* AudioDeviceUtils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/VisioMobile/Views/AudioDeviceUtils.swift
+++ b/ios/VisioMobile/Views/AudioDeviceUtils.swift
@@ -1,0 +1,73 @@
+import AVFoundation
+import SwiftUI
+
+// MARK: - Audio Device Utilities
+
+/// Shared audio device enumeration and helper functions used by both
+/// InCallSettingsSheet (MicroTabContent) and CallView (AudioDeviceSheet).
+
+/// Loads current audio input/output device state from AVAudioSession.
+struct AudioDeviceSnapshot {
+    var availableInputs: [AVAudioSessionPortDescription]
+    var currentOutputs: [AVAudioSessionPortDescription]
+    var currentInput: AVAudioSessionPortDescription?
+    var isSpeakerOverride: Bool
+
+    static func current() -> AudioDeviceSnapshot {
+        let session = AVAudioSession.sharedInstance()
+        let outputs = session.currentRoute.outputs
+        return AudioDeviceSnapshot(
+            availableInputs: session.availableInputs ?? [],
+            currentOutputs: outputs,
+            currentInput: session.currentRoute.inputs.first,
+            isSpeakerOverride: outputs.contains { $0.portType == .builtInSpeaker }
+        )
+    }
+}
+
+/// Sets the preferred audio input port.
+func selectAudioInput(_ port: AVAudioSessionPortDescription) {
+    do { try AVAudioSession.sharedInstance().setPreferredInput(port) }
+    catch { NSLog("Failed to set preferred input: %@", error.localizedDescription) }
+}
+
+/// Returns true if the port is an external output (Bluetooth, headphones, etc.)
+func isExternalAudioOutput(_ port: AVAudioSessionPortDescription) -> Bool {
+    switch port.portType {
+    case .bluetoothA2DP, .bluetoothLE, .bluetoothHFP,
+         .headphones, .airPlay, .carAudio, .usbAudio:
+        return true
+    default:
+        return false
+    }
+}
+
+/// Returns an SF Symbol name for an audio output port.
+func iconForAudioOutputPort(_ port: AVAudioSessionPortDescription) -> String {
+    switch port.portType {
+    case .bluetoothA2DP, .bluetoothLE, .bluetoothHFP:
+        return "wave.3.right"
+    case .headphones:
+        return "headphones"
+    case .airPlay:
+        return "airplayaudio"
+    case .carAudio:
+        return "car"
+    default:
+        return "speaker.wave.2"
+    }
+}
+
+/// Returns an SF Symbol name for an audio input port.
+func iconForAudioInputPort(_ port: AVAudioSessionPortDescription) -> String {
+    switch port.portType {
+    case .bluetoothHFP:
+        return "wave.3.right"
+    case .headsetMic:
+        return "headphones"
+    case .builtInMic:
+        return "iphone"
+    default:
+        return "mic"
+    }
+}

--- a/ios/VisioMobile/Views/CallView.swift
+++ b/ios/VisioMobile/Views/CallView.swift
@@ -1357,10 +1357,10 @@ struct ParticipantTile: View {
 
 struct AudioDeviceSheet: View {
     @EnvironmentObject private var manager: VisioManager
-    @State private var availableInputs: [AVAudioSessionPortDescription] = []
-    @State private var currentOutputs: [AVAudioSessionPortDescription] = []
-    @State private var currentInput: AVAudioSessionPortDescription?
-    @State private var isSpeakerOverride: Bool = false
+    @State private var snapshot = AudioDeviceSnapshot(
+        availableInputs: [], currentOutputs: [],
+        currentInput: nil, isSpeakerOverride: false
+    )
     @Environment(\.dismiss) private var dismiss
 
     private var lang: String { manager.currentLang }
@@ -1373,7 +1373,7 @@ struct AudioDeviceSheet: View {
                     Button {
                         do { try AVAudioSession.sharedInstance().overrideOutputAudioPort(.speaker) }
                         catch { NSLog("Failed to override audio to speaker: %@", error.localizedDescription) }
-                        loadDevices()
+                        snapshot = AudioDeviceSnapshot.current()
                     } label: {
                         HStack {
                             Image(systemName: "speaker.wave.2.fill")
@@ -1381,7 +1381,7 @@ struct AudioDeviceSheet: View {
                             Text(Strings.t("audio.speaker", lang: lang))
                                 .foregroundStyle(VisioColors.onSurface(dark: isDark))
                             Spacer()
-                            if isSpeakerOverride {
+                            if snapshot.isSpeakerOverride {
                                 Image(systemName: "checkmark")
                                     .foregroundStyle(VisioColors.primary500)
                             }
@@ -1391,7 +1391,7 @@ struct AudioDeviceSheet: View {
                     Button {
                         do { try AVAudioSession.sharedInstance().overrideOutputAudioPort(.none) }
                         catch { NSLog("Failed to override audio to earpiece: %@", error.localizedDescription) }
-                        loadDevices()
+                        snapshot = AudioDeviceSnapshot.current()
                     } label: {
                         HStack {
                             Image(systemName: "iphone")
@@ -1399,16 +1399,16 @@ struct AudioDeviceSheet: View {
                             Text(Strings.t("audio.earpiece", lang: lang))
                                 .foregroundStyle(VisioColors.onSurface(dark: isDark))
                             Spacer()
-                            if !isSpeakerOverride && currentOutputs.contains(where: { $0.portType == .builtInReceiver || $0.portType == .builtInSpeaker }) && !currentOutputs.contains(where: { isExternalOutput($0) }) {
+                            if !snapshot.isSpeakerOverride && snapshot.currentOutputs.contains(where: { $0.portType == .builtInReceiver || $0.portType == .builtInSpeaker }) && !snapshot.currentOutputs.contains(where: { isExternalAudioOutput($0) }) {
                                 Image(systemName: "checkmark")
                                     .foregroundStyle(VisioColors.primary500)
                             }
                         }
                     }
 
-                    ForEach(currentOutputs.filter { isExternalOutput($0) }, id: \.uid) { port in
+                    ForEach(snapshot.currentOutputs.filter { isExternalAudioOutput($0) }, id: \.uid) { port in
                         HStack {
-                            Image(systemName: iconForOutputPort(port))
+                            Image(systemName: iconForAudioOutputPort(port))
                                 .foregroundStyle(VisioColors.primary500)
                             Text(port.portName)
                                 .foregroundStyle(VisioColors.onSurface(dark: isDark))
@@ -1420,17 +1420,18 @@ struct AudioDeviceSheet: View {
                 }
 
                 Section(Strings.t("audio.input", lang: lang)) {
-                    ForEach(availableInputs, id: \.uid) { port in
+                    ForEach(snapshot.availableInputs, id: \.uid) { port in
                         Button {
-                            selectInput(port)
+                            selectAudioInput(port)
+                            snapshot = AudioDeviceSnapshot.current()
                         } label: {
                             HStack {
-                                Image(systemName: iconForInputPort(port))
+                                Image(systemName: iconForAudioInputPort(port))
                                     .foregroundStyle(VisioColors.primary500)
                                 Text(port.portName)
                                     .foregroundStyle(VisioColors.onSurface(dark: isDark))
                                 Spacer()
-                                if port.uid == currentInput?.uid {
+                                if port.uid == snapshot.currentInput?.uid {
                                     Image(systemName: "checkmark")
                                         .foregroundStyle(VisioColors.primary500)
                                 }
@@ -1453,58 +1454,7 @@ struct AudioDeviceSheet: View {
                 }
             }
         }
-        .onAppear { loadDevices() }
-    }
-
-    private func loadDevices() {
-        let session = AVAudioSession.sharedInstance()
-        availableInputs = session.availableInputs ?? []
-        currentInput = session.currentRoute.inputs.first
-        currentOutputs = session.currentRoute.outputs
-        isSpeakerOverride = currentOutputs.contains { $0.portType == .builtInSpeaker }
-    }
-
-    private func selectInput(_ port: AVAudioSessionPortDescription) {
-        do { try AVAudioSession.sharedInstance().setPreferredInput(port) }
-        catch { NSLog("Failed to set preferred input: %@", error.localizedDescription) }
-        currentInput = port
-    }
-
-    private func isExternalOutput(_ port: AVAudioSessionPortDescription) -> Bool {
-        switch port.portType {
-        case .bluetoothA2DP, .bluetoothLE, .bluetoothHFP, .headphones, .airPlay, .carAudio, .usbAudio:
-            return true
-        default:
-            return false
-        }
-    }
-
-    private func iconForOutputPort(_ port: AVAudioSessionPortDescription) -> String {
-        switch port.portType {
-        case .bluetoothA2DP, .bluetoothLE, .bluetoothHFP:
-            return "wave.3.right"
-        case .headphones:
-            return "headphones"
-        case .airPlay:
-            return "airplayaudio"
-        case .carAudio:
-            return "car"
-        default:
-            return "speaker.wave.2"
-        }
-    }
-
-    private func iconForInputPort(_ port: AVAudioSessionPortDescription) -> String {
-        switch port.portType {
-        case .bluetoothHFP:
-            return "wave.3.right"
-        case .headsetMic:
-            return "headphones"
-        case .builtInMic:
-            return "iphone"
-        default:
-            return "mic"
-        }
+        .onAppear { snapshot = AudioDeviceSnapshot.current() }
     }
 }
 

--- a/ios/VisioMobile/Views/HomeView.swift
+++ b/ios/VisioMobile/Views/HomeView.swift
@@ -16,7 +16,7 @@ struct HomeView: View {
     @State private var customServer: String = ""
     @State private var showCreateRoom: Bool = false
     @State private var roomDisplayName: String = ""
-    @State private var roomHistory: [RoomHistoryEntry] = []
+    @State private var roomHistory: [VisioHistoryEntry] = []
     @State private var historyJoinPending: Bool = false
     @State private var showCompactHeader: Bool = false
     @State private var selectedTab: Int = 0
@@ -375,7 +375,7 @@ struct HomeView: View {
             // Load meet instances
             meetInstances = manager.client.getMeetInstances()
             // Load room history
-            roomHistory = manager.client.getRoomHistory()
+            roomHistory = manager.client.getVisioHistory()
             // Load cached meetings immediately, then refresh from network
             let cached = manager.client.getUpcomingMeetings()
             if !cached.isEmpty {

--- a/ios/VisioMobile/Views/InCallSettingsSheet.swift
+++ b/ios/VisioMobile/Views/InCallSettingsSheet.swift
@@ -302,10 +302,10 @@ struct InCallSettingsSheet: View {
 
 private struct MicroTabContent: View {
     @EnvironmentObject private var manager: VisioManager
-    @State private var availableInputs: [AVAudioSessionPortDescription] = []
-    @State private var currentOutputs: [AVAudioSessionPortDescription] = []
-    @State private var currentInput: AVAudioSessionPortDescription?
-    @State private var isSpeakerOverride: Bool = false
+    @State private var snapshot = AudioDeviceSnapshot(
+        availableInputs: [], currentOutputs: [],
+        currentInput: nil, isSpeakerOverride: false
+    )
 
     private var lang: String { manager.currentLang }
     private var isDark: Bool { manager.currentTheme == "dark" }
@@ -317,7 +317,7 @@ private struct MicroTabContent: View {
                 Button {
                     do { try AVAudioSession.sharedInstance().overrideOutputAudioPort(.speaker) }
                     catch { NSLog("Failed to override audio to speaker: %@", error.localizedDescription) }
-                    loadDevices()
+                    snapshot = AudioDeviceSnapshot.current()
                 } label: {
                     HStack {
                         Image(systemName: "speaker.wave.2.fill")
@@ -325,7 +325,7 @@ private struct MicroTabContent: View {
                         Text(Strings.t("audio.speaker", lang: lang))
                             .foregroundStyle(VisioColors.onSurface(dark: isDark))
                         Spacer()
-                        if isSpeakerOverride {
+                        if snapshot.isSpeakerOverride {
                             Image(systemName: "checkmark")
                                 .foregroundStyle(VisioColors.primary500)
                         }
@@ -335,7 +335,7 @@ private struct MicroTabContent: View {
                 Button {
                     do { try AVAudioSession.sharedInstance().overrideOutputAudioPort(.none) }
                     catch { NSLog("Failed to override audio to earpiece: %@", error.localizedDescription) }
-                    loadDevices()
+                    snapshot = AudioDeviceSnapshot.current()
                 } label: {
                     HStack {
                         Image(systemName: "iphone")
@@ -343,16 +343,16 @@ private struct MicroTabContent: View {
                         Text(Strings.t("audio.earpiece", lang: lang))
                             .foregroundStyle(VisioColors.onSurface(dark: isDark))
                         Spacer()
-                        if !isSpeakerOverride && currentOutputs.contains(where: { $0.portType == .builtInReceiver || $0.portType == .builtInSpeaker }) && !currentOutputs.contains(where: { isExternalOutput($0) }) {
+                        if !snapshot.isSpeakerOverride && snapshot.currentOutputs.contains(where: { $0.portType == .builtInReceiver || $0.portType == .builtInSpeaker }) && !snapshot.currentOutputs.contains(where: { isExternalAudioOutput($0) }) {
                             Image(systemName: "checkmark")
                                 .foregroundStyle(VisioColors.primary500)
                         }
                     }
                 }
 
-                ForEach(currentOutputs.filter { isExternalOutput($0) }, id: \.uid) { port in
+                ForEach(snapshot.currentOutputs.filter { isExternalAudioOutput($0) }, id: \.uid) { port in
                     HStack {
-                        Image(systemName: iconForOutputPort(port))
+                        Image(systemName: iconForAudioOutputPort(port))
                             .foregroundStyle(VisioColors.primary500)
                         Text(port.portName)
                             .foregroundStyle(VisioColors.onSurface(dark: isDark))
@@ -365,17 +365,18 @@ private struct MicroTabContent: View {
 
             // Input section
             Section(Strings.t("settings.incall.audioInput", lang: lang)) {
-                ForEach(availableInputs, id: \.uid) { port in
+                ForEach(snapshot.availableInputs, id: \.uid) { port in
                     Button {
-                        selectInput(port)
+                        selectAudioInput(port)
+                        snapshot = AudioDeviceSnapshot.current()
                     } label: {
                         HStack {
-                            Image(systemName: iconForInputPort(port))
+                            Image(systemName: iconForAudioInputPort(port))
                                 .foregroundStyle(VisioColors.primary500)
                             Text(port.portName)
                                 .foregroundStyle(VisioColors.onSurface(dark: isDark))
                             Spacer()
-                            if port.uid == currentInput?.uid {
+                            if port.uid == snapshot.currentInput?.uid {
                                 Image(systemName: "checkmark")
                                     .foregroundStyle(VisioColors.primary500)
                             }
@@ -386,58 +387,7 @@ private struct MicroTabContent: View {
         }
         .scrollContentBackground(.hidden)
         .background(VisioColors.background(dark: isDark))
-        .onAppear { loadDevices() }
-    }
-
-    private func loadDevices() {
-        let session = AVAudioSession.sharedInstance()
-        availableInputs = session.availableInputs ?? []
-        currentInput = session.currentRoute.inputs.first
-        currentOutputs = session.currentRoute.outputs
-        isSpeakerOverride = currentOutputs.contains { $0.portType == .builtInSpeaker }
-    }
-
-    private func selectInput(_ port: AVAudioSessionPortDescription) {
-        do { try AVAudioSession.sharedInstance().setPreferredInput(port) }
-        catch { NSLog("Failed to set preferred input: %@", error.localizedDescription) }
-        currentInput = port
-    }
-
-    private func isExternalOutput(_ port: AVAudioSessionPortDescription) -> Bool {
-        switch port.portType {
-        case .bluetoothA2DP, .bluetoothLE, .bluetoothHFP, .headphones, .airPlay, .carAudio, .usbAudio:
-            return true
-        default:
-            return false
-        }
-    }
-
-    private func iconForOutputPort(_ port: AVAudioSessionPortDescription) -> String {
-        switch port.portType {
-        case .bluetoothA2DP, .bluetoothLE, .bluetoothHFP:
-            return "wave.3.right"
-        case .headphones:
-            return "headphones"
-        case .airPlay:
-            return "airplayaudio"
-        case .carAudio:
-            return "car"
-        default:
-            return "speaker.wave.2"
-        }
-    }
-
-    private func iconForInputPort(_ port: AVAudioSessionPortDescription) -> String {
-        switch port.portType {
-        case .bluetoothHFP:
-            return "wave.3.right"
-        case .headsetMic:
-            return "headphones"
-        case .builtInMic:
-            return "iphone"
-        default:
-            return "mic"
-        }
+        .onAppear { snapshot = AudioDeviceSnapshot.current() }
     }
 }
 

--- a/ios/VisioMobile/Views/SettingsView.swift
+++ b/ios/VisioMobile/Views/SettingsView.swift
@@ -164,7 +164,7 @@ struct SettingsView: View {
 
                 Section {
                     Button(role: .destructive) {
-                        manager.client.clearRoomHistory()
+                        manager.client.clearVisioHistory()
                         historyCleared = true
                     } label: {
                         Text(Strings.t("settings.clearHistory", lang: lang))


### PR DESCRIPTION
## Summary

Extract shared device enumeration logic from 3 duplicate
sites into unified utilities on all platforms.

## Changes

### Desktop
- New `useDeviceEnumeration.ts` hook (lazy, preserves #161)
- ~220 lines removed from App.tsx

### Android
- New `AudioDeviceUtils.kt` with shared composable hook
- Superset of BLE device types (fixes InCall missing BLE)

### iOS
- New `AudioDeviceUtils.swift` with `AudioDeviceSnapshot`
- Shared between CallView and InCallSettingsSheet

## Test plan

- [ ] Lobby: devices listed correctly, defaults selected
- [ ] In-call picker: devices listed, fallback on disconnect
- [ ] Settings: no mic permission prompt (macOS)
- [ ] Verify on Android, iOS, Desktop