### PR TITLE
fix(desktop): hide room name field on home when authenticated (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - Desktop: prevent meet instances list from being overwritten when
   adding a new instance (#169)
+- Desktop: hide optional room name field on home page when
+  authenticated via OIDC (#171)
 
 ### Added
 

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -1402,21 +1402,23 @@ function HomeView({
                 onKeyDown={handleKeyDown}
               />
             </div>
-            <div className="form-group">
-              <label htmlFor="roomDisplayName">
-                {t('home.roomDisplayName')}
-              </label>
-              <input
-                id="roomDisplayName"
-                type="text"
-                placeholder={t('home.roomDisplayNamePlaceholder')}
-                autoComplete="off"
-                data-testid="home-room-input"
-                value={roomDisplayName}
-                onChange={(e) => setRoomDisplayName(e.target.value)}
-                onKeyDown={handleKeyDown}
-              />
-            </div>
+            {!isAuthenticated && (
+              <div className="form-group">
+                <label htmlFor="roomDisplayName">
+                  {t('home.roomDisplayName')}
+                </label>
+                <input
+                  id="roomDisplayName"
+                  type="text"
+                  placeholder={t('home.roomDisplayNamePlaceholder')}
+                  autoComplete="off"
+                  data-testid="home-room-input"
+                  value={roomDisplayName}
+                  onChange={(e) => setRoomDisplayName(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                />
+              </div>
+            )}
             {roomStatus === 'auth_required' ? (
               <button className="btn btn-primary" onClick={handleAuth}>
                 {t('home.signIn')}


### PR DESCRIPTION
## Summary
- Hide "Nom de la visio (optionnel)" field on home page when user is authenticated via OIDC
- Room name is only relevant on the room creation screen, not the home page join form

Fixes #171

## Test plan
- [ ] Open desktop app without OIDC login → room name field should be visible
- [ ] Log in via OIDC → room name field should be hidden on home page
- [ ] Click "Créer une visio" → room name field should appear on creation screen