### PR TITLE
fix(desktop): apply lobby mic/camera overrides on join (#172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to
 
 ### Fixed
 
+- Lobby mic/camera overrides now correctly applied when
+  joining a visio on Desktop (#172)
 - Regenerate UniFFI bindings and fix build errors for
   friendly URLs feature (#156)
 - PiP only activates during an active call; no longer triggers

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -3978,7 +3978,12 @@ function PreJoinScreen({
   roomDisplayName?: string | null
   lang: string
   isDark: boolean
-  onJoin: (username: string | null) => void
+  onJoin: (
+    username: string | null,
+    micOn: boolean,
+    camOn: boolean,
+    audioMode: string
+  ) => void
   onCancel: () => void
   livekitUrl?: string | null
   livekitToken?: string | null
@@ -4185,7 +4190,7 @@ function PreJoinScreen({
     if (livekitUrl && livekitToken) {
       try {
         await invoke('connect_with_token', { livekitUrl, token: livekitToken })
-        onJoin(finalName)
+        onJoin(finalName, isMicOn, isCameraOn, audioMode)
       } catch (e) {
         console.error('connect_with_token failed:', e)
         setWaitingState('idle')
@@ -4225,7 +4230,7 @@ function PreJoinScreen({
     listen<string>('connection-state-changed', (event) => {
       if (event.payload === 'connected') {
         if (timeoutRef.current) clearTimeout(timeoutRef.current)
-        onJoin(finalName)
+        onJoin(finalName, isMicOn, isCameraOn, audioMode)
       }
     })
       .then((unlisten) => chainUnlisten(unlistenVideoRef, unlisten))
@@ -5408,7 +5413,27 @@ export default function App() {
             roomDisplayName={currentRoomDisplayName}
             lang={lang}
             isDark={theme === 'dark'}
-            onJoin={() => {
+            onJoin={async (_username, micOn, camOn, lobbyAudioMode) => {
+              // Apply lobby mic/camera overrides before showing the call view.
+              // Without this, micEnabled/camEnabled stay at their initial false
+              // values and the lobby toggles are silently ignored (#172).
+              const wantMic = micOn && lobbyAudioMode !== 'none'
+              if (wantMic) {
+                try {
+                  await invoke('toggle_mic', { enabled: true })
+                  setMicEnabled(true)
+                } catch (e) {
+                  console.error('Failed to enable mic on join:', e)
+                }
+              }
+              if (camOn) {
+                try {
+                  await invoke('toggle_camera', { enabled: true })
+                  setCamEnabled(true)
+                } catch (e) {
+                  console.error('Failed to enable camera on join:', e)
+                }
+              }
               setView('call')
             }}
             onCancel={() => setView('home')}


### PR DESCRIPTION
## Summary

Lobby mic/camera toggle state is now passed to the parent
and applied when joining the room, instead of being ignored.

## Root cause

`PreJoinScreen` saved lobby toggles but the parent `App`
never read them — `micEnabled`/`camEnabled` stayed `false`.

## Fix

Changed `onJoin` callback to pass `(username, micOn, camOn,
audioMode)`. Parent applies `toggle_mic`/`toggle_camera`
before rendering call view.

## Platforms

- Desktop only (Android/iOS not affected)

## Test plan

- [ ] Settings: disable camera on join
- [ ] Lobby: enable camera manually
- [ ] Join → camera should be ON
- [ ] Same test with mic