### PR TITLE
fix(desktop): record visio in recent history (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
 
 - Lobby mic/camera overrides now correctly applied when
   joining a visio on Desktop (#172)
+- Desktop: record visio in recent history when
+  connecting via `connect_with_token` path (#173)
 - Regenerate UniFFI bindings and fix build errors for
   friendly URLs feature (#156)
 - PiP only activates during an active call; no longer triggers

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -4190,6 +4190,12 @@ function PreJoinScreen({
     if (livekitUrl && livekitToken) {
       try {
         await invoke('connect_with_token', { livekitUrl, token: livekitToken })
+        // Record in history (connect_with_token bypasses the event-based
+        // history recording since last_meet_url is not set).
+        invoke('add_visio_to_history', {
+          url: roomUrl,
+          displayName: roomDisplayName ?? null,
+        }).catch(() => {})
         onJoin(finalName, isMicOn, isCameraOn, audioMode)
       } catch (e) {
         console.error('connect_with_token failed:', e)

--- a/crates/visio-desktop/src/lib.rs
+++ b/crates/visio-desktop/src/lib.rs
@@ -958,6 +958,21 @@ fn validate_room_display_name_cmd(name: String) -> Option<String> {
 }
 
 #[tauri::command]
+fn add_visio_to_history(
+    state: tauri::State<'_, VisioState>,
+    url: String,
+    display_name: Option<String>,
+) {
+    let clean_url = visio_core::strip_room_display_name_param(&url);
+    let extracted_name = visio_core::extract_room_display_name(&url);
+    let name = display_name.or(extracted_name);
+    state.settings.add_visio_to_history(clean_url.clone(), name.clone());
+    if let Some(n) = name {
+        state.settings.add_visio_alias(n, clean_url);
+    }
+}
+
+#[tauri::command]
 fn clear_visio_history(state: tauri::State<'_, VisioState>) {
     state.settings.clear_visio_history();
 }
@@ -2183,6 +2198,7 @@ pub fn run() {
             set_adaptive_mode_enabled,
             check_media_permissions,
             get_visio_history,
+            add_visio_to_history,
             clear_visio_history,
             add_visio_alias,
             resolve_visio_alias,


### PR DESCRIPTION
## Summary

Visios created via room creation (connect_with_token path)
are now recorded in the recent history.

## Root cause

`connect_with_token` does not set `last_meet_url` in
RoomManager, so `last_connection_info()` returns None and
history recording is skipped.

## Fix

- Added `add_visio_to_history` Tauri command
- Call it explicitly after `connect_with_token` in
  PreJoinScreen

## Platforms

- Desktop only (Android/iOS not affected)

## Test plan

- [ ] Create a visio → join → disconnect
- [ ] Home screen: visio appears in recent list
- [ ] Join via URL → disconnect → appears in list