### PR TITLE
fix(ios): fix OIDC login — use WKWebView with browser chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
   on public rooms (#180)
 - Desktop: remove room name field from join form (#180)
 - Desktop: fix camera not showing on join from lobby (#180)
+- iOS: replace ASWebAuthenticationSession with WKWebView for
+  OIDC login (#179)
 
 ### Added
 

--- a/ios/VisioMobile/Auth/OidcAuthManager.swift
+++ b/ios/VisioMobile/Auth/OidcAuthManager.swift
@@ -1,82 +1,63 @@
-import AuthenticationServices
+import Foundation
 import Security
-import UIKit
 
-class OidcAuthManager: NSObject, ObservableObject, ASWebAuthenticationPresentationContextProviding {
+// MARK: - OidcAuthManager
 
+class OidcAuthManager: ObservableObject {
+
+    /// The meet instance being authenticated against.
+    /// When set, the WKWebView auth sheet is presented.
     @Published var pendingInstance: String?
-    private var authSession: ASWebAuthenticationSession?
 
-    /// Launch OIDC flow via ASWebAuthenticationSession.
-    /// The server redirects to visio://auth-callback?code={uuid}.
-    /// Returns the exchange code via completion handler.
-    func launchOidcFlow(meetInstance: String, completion: @escaping (String?) -> Void) {
+    /// Known session cookie names (Meet uses "meet_sessionid", others may use "sessionid").
+    static let cookieNames = ["meet_sessionid", "sessionid"]
+
+    // MARK: - OIDC Flow
+
+    /// Presents the WKWebView auth sheet for the given meet instance.
+    func launchOidcFlow(meetInstance: String) {
         pendingInstance = meetInstance
-
-        let returnTo = "visio://auth-callback"
-        let encodedReturnTo = returnTo.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? returnTo
-        guard let authURL = URL(string: "https://\(meetInstance)/api/v1.0/authenticate/?returnTo=\(encodedReturnTo)&prompt=login") else {
-            completion(nil)
-            return
-        }
-
-        let session = ASWebAuthenticationSession(
-            url: authURL,
-            callbackURLScheme: "visio"
-        ) { [weak self] callbackURL, error in
-            guard let self else { return }
-            self.authSession = nil
-
-            if let error {
-                let nsError = error as NSError
-                if nsError.domain == ASWebAuthenticationSessionError.errorDomain
-                    && nsError.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
-                    DispatchQueue.main.async {
-                        self.pendingInstance = nil
-                        completion(nil)
-                    }
-                    return
-                }
-                NSLog("[OidcAuthManager] ASWebAuth error: \(error.localizedDescription)")
-                DispatchQueue.main.async {
-                    self.pendingInstance = nil
-                    completion(nil)
-                }
-                return
-            }
-
-            // Extract exchange code from: visio://auth-callback?code={uuid}
-            guard let url = callbackURL,
-                  let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-                  let code = components.queryItems?.first(where: { $0.name == "code" })?.value else {
-                NSLog("[OidcAuthManager] No code parameter in callback URL: \(callbackURL?.absoluteString ?? "nil")")
-                DispatchQueue.main.async {
-                    self.pendingInstance = nil
-                    completion(nil)
-                }
-                return
-            }
-
-            DispatchQueue.main.async {
-                self.pendingInstance = nil
-                completion(code)
-            }
-        }
-
-        session.prefersEphemeralWebBrowserSession = false
-        session.presentationContextProvider = self
-        authSession = session
-        session.start()
     }
 
-    // MARK: - ASWebAuthenticationPresentationContextProviding
+    /// Called by the WKWebView when it extracts a cookie (or nil on dismiss).
+    func onWebViewCookie(_ cookie: String?, meetInstance: String) {
+        pendingInstance = nil
+    }
 
-    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-              let window = scene.windows.first(where: { $0.isKeyWindow }) ?? scene.windows.first else {
-            return ASPresentationAnchor()
+    // MARK: - Code Exchange
+
+    /// Exchanges a one-time OIDC code for a session cookie via the server's
+    /// `/api/v1.0/auth/session-exchange/` endpoint.
+    /// Used by the WKWebView coordinator when the server includes `?code=` in the redirect.
+    static func exchangeCode(
+        meetInstance: String,
+        code: String,
+        onCookie: @escaping (String) -> Void,
+        onFailure: @escaping () -> Void
+    ) {
+        guard let url = URL(string: "https://\(meetInstance)/api/v1.0/auth/session-exchange/") else {
+            DispatchQueue.main.async { onFailure() }
+            return
         }
-        return window
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: ["code": code])
+
+        URLSession.shared.dataTask(with: request) { data, _, _ in
+            let cookie = data
+                .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: String] }
+                .flatMap { dict in Self.cookieNames.compactMap { dict[$0] }.first }
+
+            DispatchQueue.main.async {
+                if let cookie {
+                    onCookie(cookie)
+                } else {
+                    NSLog("[OidcAuthManager] session-exchange failed or missing key")
+                    onFailure()
+                }
+            }
+        }.resume()
     }
 
     // MARK: - Keychain Storage

--- a/ios/VisioMobile/Info.plist
+++ b/ios/VisioMobile/Info.plist
@@ -2,39 +2,39 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>CFBundleIconName</key>
-    <string>AppIcon</string>
-    <key>CFBundleDisplayName</key>
-    <string>Visio Mobile</string>
-    <key>NSCameraUsageDescription</key>
-    <string>Visio needs camera access for video calls.</string>
-    <key>NSMicrophoneUsageDescription</key>
-    <string>Visio needs microphone access for audio calls.</string>
-    <key>NSMotionUsageDescription</key>
-    <string>Visio uses motion detection to adapt the interface when you are walking or in a vehicle.</string>
-    <key>CFBundleURLTypes</key>
-    <array>
-        <dict>
-            <key>CFBundleURLName</key>
-            <string>io.visio.mobile</string>
-            <key>CFBundleURLSchemes</key>
-            <array>
-                <string>visio</string>
-            </array>
-        </dict>
-        <dict>
-            <key>CFBundleURLName</key>
-            <string>io.visio.mobile.test</string>
-            <key>CFBundleURLSchemes</key>
-            <array>
-                <string>visio-test</string>
-            </array>
-        </dict>
-    </array>
-    <key>UIBackgroundModes</key>
-    <array>
-        <string>audio</string>
-        <string>voip</string>
-    </array>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
+	<key>CFBundleDisplayName</key>
+	<string>Visio Mobile</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Visio needs camera access for video calls.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Visio needs microphone access for audio calls.</string>
+	<key>NSMotionUsageDescription</key>
+	<string>Visio uses motion detection to adapt the interface when you are walking or in a vehicle.</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>io.visio.mobile</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>visio</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>io.visio.mobile.test</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>visio-test</string>
+			</array>
+		</dict>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>voip</string>
+	</array>
 </dict>
 </plist>

--- a/ios/VisioMobile/Views/HomeView.swift
+++ b/ios/VisioMobile/Views/HomeView.swift
@@ -1,5 +1,5 @@
-import Combine
 import SwiftUI
+import WebKit
 import visioFFI
 
 struct HomeView: View {
@@ -15,28 +15,12 @@ struct HomeView: View {
     @State private var showServerPicker: Bool = false
     @State private var customServer: String = ""
     @State private var showCreateRoom: Bool = false
-    @State private var roomDisplayName: String = ""
-    @State private var roomHistory: [VisioHistoryEntry] = []
+    @State private var roomHistory: [String] = []
     @State private var historyJoinPending: Bool = false
     @State private var showCompactHeader: Bool = false
-    @State private var selectedTab: Int = 0
-    @State private var syncToastMessage: String?
-    @State private var syncToastIsError: Bool = false
-    @State private var now = Date()
-    private let minuteTimer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
 
     private var lang: String { manager.currentLang }
     private var isDark: Bool { manager.currentTheme == "dark" }
-
-    private var hasImminentMeeting: Bool {
-        let nowTs = now.timeIntervalSince1970
-        return manager.upcomingMeetings.contains { meeting in
-            let start = TimeInterval(meeting.startTime)
-            let end = TimeInterval(meeting.endTime)
-            let minutesUntil = (start - nowTs) / 60
-            return (minutesUntil >= 0 && minutesUntil < 15) || (start <= nowTs && end > nowTs)
-        }
-    }
 
     private static let slugPattern = /^[a-z]{3}-[a-z]{4}-[a-z]{3}$/
 
@@ -53,55 +37,7 @@ struct HomeView: View {
         ZStack {
             VisioColors.background(dark: isDark).ignoresSafeArea()
 
-            VStack(spacing: 0) {
-                // Tab segment control (Rejoindre / Réunions)
-                let meetingsBase = Strings.t("home.tab.meetings", lang: lang)
-                let meetingsLabel = manager.calendarLoading && manager.upcomingMeetings.isEmpty
-                    ? meetingsBase + " …"
-                    : manager.upcomingMeetings.isEmpty
-                        ? meetingsBase
-                        : meetingsBase + " (\(manager.upcomingMeetings.count))"
-                Picker("", selection: $selectedTab) {
-                    Text(Strings.t("home.tab.join", lang: lang)).tag(0)
-                    HStack(spacing: 4) {
-                        Text(meetingsLabel)
-                        if hasImminentMeeting {
-                            Circle()
-                                .fill(Color.red)
-                                .frame(width: 8, height: 8)
-                        }
-                    }.tag(1)
-                }
-                .pickerStyle(.segmented)
-                .padding(.horizontal, 16)
-                .padding(.top, 8)
-                .padding(.bottom, 16)
-                .onChange(of: selectedTab) { newTab in
-                    if newTab == 1 {
-                        manager.refreshCalendarNow()
-                    }
-                }
-
-                if selectedTab == 1 {
-                    MeetingsTabView(
-                        meetings: manager.upcomingMeetings,
-                        hasCalendarUrl: manager.client.getCalendarUrl() != nil,
-                        isLoading: manager.calendarLoading,
-                        isDark: isDark,
-                        lang: lang,
-                        onSettings: { showSettings = true },
-                        onRefresh: { manager.refreshCalendarNow() },
-                        onJoinMeeting: { meeting in
-                            roomURL = meeting.roomUrl
-                            resolvedRoomURL = meeting.roomUrl
-                            roomStatus = "valid"
-                            selectedTab = 0
-                            navigateToCall = true
-                        }
-                    )
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else {
-                ScrollView {
+            ScrollView {
                 VStack(spacing: 32) {
                     VStack(spacing: 8) {
                         VisioLogo(size: 96)
@@ -116,6 +52,10 @@ struct HomeView: View {
                             showCompactHeader = value < -20
                         }
                     })
+
+                Text(Strings.t("home.subtitle", lang: lang))
+                    .font(.subheadline)
+                    .foregroundStyle(VisioColors.secondaryText(dark: isDark))
 
                 // Authentication section
                 if manager.isAuthenticated {
@@ -169,9 +109,6 @@ struct HomeView: View {
                             .foregroundStyle(.red)
                     }
 
-                    TextField(Strings.t("home.roomDisplayName", lang: lang), text: $roomDisplayName)
-                        .textFieldStyle(.roundedBorder)
-
                     TextField(Strings.t("home.displayName", lang: lang), text: $displayName)
                         .textFieldStyle(.roundedBorder)
                         .textInputAutocapitalization(.words)
@@ -186,21 +123,12 @@ struct HomeView: View {
                     if isSlug, !meetInstances.isEmpty {
                         urlsToTry = meetInstances.map { "https://\($0)/\(trimmed)" }
                     } else {
-                        if extractSlug(trimmed) != nil {
-                            urlsToTry = [trimmed]
-                        } else {
-                            // Try alias resolution
-                            let candidate = trimmed.contains("/")
-                                ? String(trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "/")).split(separator: "/").last ?? "")
-                                : trimmed
-                            if let aliasUrl = manager.client.resolveVisioAlias(name: candidate) {
-                                urlsToTry = [aliasUrl]
-                            } else {
-                                roomStatus = "idle"
-                                resolvedRoomURL = trimmed
-                                return
-                            }
+                        guard extractSlug(trimmed) != nil else {
+                            roomStatus = "idle"
+                            resolvedRoomURL = trimmed
+                            return
                         }
+                        urlsToTry = [trimmed]
                     }
 
                     roomStatus = "checking"
@@ -263,16 +191,13 @@ struct HomeView: View {
                             .fontWeight(.medium)
                             .foregroundStyle(VisioColors.secondaryText(dark: isDark))
 
-                        ForEach(Array(roomHistory.enumerated()), id: \.offset) { index, entry in
-                            let slug = entry.url.contains("/") ? String(entry.url.split(separator: "/").last ?? "") : entry.url
-                            let host = URL(string: entry.url)?.host ?? ""
+                        ForEach(Array(roomHistory.enumerated()), id: \.offset) { index, url in
+                            let slug = url.contains("/") ? String(url.split(separator: "/").last ?? "") : url
+                            let host = URL(string: url)?.host ?? ""
 
                             Button {
-                                roomURL = entry.url
-                                resolvedRoomURL = entry.url
-                                if let name = entry.displayName {
-                                    roomDisplayName = name
-                                }
+                                roomURL = url
+                                resolvedRoomURL = url
                                 // If already validated, navigate immediately
                                 if roomStatus == "valid" {
                                     navigateToCall = true
@@ -281,7 +206,7 @@ struct HomeView: View {
                                 }
                             } label: {
                                 HStack(spacing: 10) {
-                                    if historyJoinPending && roomURL == entry.url {
+                                    if historyJoinPending && roomURL == url {
                                         ProgressView()
                                             .scaleEffect(0.7)
                                             .frame(width: 14, height: 14)
@@ -292,24 +217,14 @@ struct HomeView: View {
                                     }
 
                                     VStack(alignment: .leading, spacing: 2) {
-                                        if let name = entry.displayName {
-                                            Text(name)
-                                                .font(.body)
-                                                .fontWeight(.bold)
-                                                .foregroundStyle(VisioColors.onBackground(dark: isDark))
-                                            Text("\(slug) · \(host)")
+                                        Text(slug)
+                                            .font(.body)
+                                            .fontWeight(.medium)
+                                            .foregroundStyle(VisioColors.onBackground(dark: isDark))
+                                        if !host.isEmpty {
+                                            Text(host)
                                                 .font(.caption)
                                                 .foregroundStyle(VisioColors.secondaryText(dark: isDark))
-                                        } else {
-                                            Text(slug)
-                                                .font(.body)
-                                                .fontWeight(.medium)
-                                                .foregroundStyle(VisioColors.onBackground(dark: isDark))
-                                            if !host.isEmpty {
-                                                Text(host)
-                                                    .font(.caption)
-                                                    .foregroundStyle(VisioColors.secondaryText(dark: isDark))
-                                            }
                                         }
                                     }
 
@@ -320,8 +235,8 @@ struct HomeView: View {
                                 .background(
                                     RoundedRectangle(cornerRadius: 8)
                                         .fill(isDark
-                                            ? Color(red: 0.12, green: 0.12, blue: 0.18)
-                                            : Color(red: 0.95, green: 0.95, blue: 0.97))
+                                            ? VisioColors.primary500.opacity(0.12)
+                                            : VisioColors.primary500.opacity(0.08))
                                 )
                             }
                             .disabled(historyJoinPending)
@@ -334,8 +249,6 @@ struct HomeView: View {
                 .padding(.bottom, 32)
             }
             .coordinateSpace(name: "scroll")
-            } // end else (join tab)
-            } // end VStack tabs
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbarColorScheme(isDark ? .dark : .light, for: .navigationBar)
@@ -362,19 +275,15 @@ struct HomeView: View {
             }
         }
         .navigationDestination(isPresented: $navigateToCall) {
-            PreJoinView(
+            CallView(
                 roomURL: resolvedRoomURL,
-                initialDisplayName: displayName.trimmingCharacters(in: .whitespacesAndNewlines),
-                roomDisplayName: roomDisplayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                    ? nil
-                    : roomDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+                displayName: displayName.trimmingCharacters(in: .whitespacesAndNewlines)
             )
         }
         .sheet(isPresented: $showSettings) {
             SettingsView()
                 .environmentObject(manager)
         }
-        .onReceive(minuteTimer) { _ in now = Date() }
         .onAppear {
             // Pre-fill display name from manager (includes OIDC identity)
             let name = manager.displayName
@@ -384,15 +293,7 @@ struct HomeView: View {
             // Load meet instances
             meetInstances = manager.client.getMeetInstances()
             // Load room history
-            roomHistory = manager.client.getVisioHistory()
-            // Load cached meetings immediately, then refresh from network
-            let cached = manager.client.getUpcomingMeetings()
-            if !cached.isEmpty {
-                manager.upcomingMeetings = cached
-            }
-            if manager.client.getCalendarUrl() != nil {
-                manager.refreshCalendarNow()
-            }
+            roomHistory = manager.client.getRoomHistory()
         }
         .onChange(of: manager.authenticatedDisplayName) { newValue in
             if !newValue.isEmpty && displayName.isEmpty {
@@ -411,56 +312,13 @@ struct HomeView: View {
         }
         .onChange(of: manager.pendingDeepLink) { newValue in
             if let link = newValue {
-                // Extract room display name from the URL if present, then strip the param
-                if let extracted = manager.client.extractRoomDisplayName(url: link) {
-                    roomDisplayName = extracted
-                }
-                // Strip the query param from the URL shown in the field
-                let cleanURL = link.components(separatedBy: "?").first ?? link
-                roomURL = cleanURL
+                roomURL = link
                 manager.pendingDeepLink = nil
             }
         }
         .onChange(of: manager.pendingTestConnect != nil) { hasTestConnect in
             if hasTestConnect {
                 navigateToCall = true
-            }
-        }
-        .onChange(of: manager.calendarSyncResult) { newResult in
-            guard let result = newResult else { return }
-            switch result {
-            case .success(let count):
-                if count > 0 {
-                    syncToastMessage = Strings.t("calendar.sync.success", lang: lang)
-                        .replacingOccurrences(of: "{count}", with: "\(count)")
-                } else {
-                    syncToastMessage = Strings.t("calendar.sync.noMeetings", lang: lang)
-                }
-                syncToastIsError = false
-            case .error:
-                syncToastMessage = Strings.t("calendar.sync.error", lang: lang)
-                syncToastIsError = true
-            }
-            manager.calendarSyncResult = nil
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                syncToastMessage = nil
-            }
-        }
-        .overlay(alignment: .bottom) {
-            if let message = syncToastMessage {
-                Text(message)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .background(
-                        Capsule()
-                            .fill(syncToastIsError ? Color.red.opacity(0.9) : VisioColors.primary500.opacity(0.9))
-                    )
-                    .padding(.bottom, 24)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-                    .animation(.easeInOut(duration: 0.3), value: syncToastMessage)
             }
         }
         .sheet(isPresented: $showCreateRoom) {
@@ -484,32 +342,146 @@ struct HomeView: View {
                 lang: lang,
                 onDismiss: { showServerPicker = false }
             )
+            .environmentObject(manager)
         }
-        .alert(
-            Strings.t("call.error", lang: lang),
-            isPresented: Binding(
-                get: { manager.pendingDeepLinkError != nil },
-                set: { if !$0 { manager.pendingDeepLinkError = nil } }
-            )
-        ) {
-            Button("OK") { manager.pendingDeepLinkError = nil }
-        } message: {
-            Text(manager.pendingDeepLinkError ?? "")
+        .sheet(isPresented: Binding(
+            get: { manager.authManager.pendingInstance != nil },
+            set: { if !$0 { manager.authManager.onWebViewCookie(nil, meetInstance: "") } }
+        )) {
+            if let instance = manager.authManager.pendingInstance {
+                OidcAuthSheet(meetInstance: instance, lang: lang) { cookie in
+                    manager.authManager.onWebViewCookie(cookie, meetInstance: instance)
+                    if let cookie {
+                        manager.onAuthCookieReceived(cookie, meetInstance: instance)
+                    }
+                }
+            }
         }
     }
 
     private func launchOidc(meetInstance: String) {
-        manager.authManager.launchOidcFlow(meetInstance: meetInstance) { [weak manager] code in
-            guard let code, let manager else { return }
-            DispatchQueue.global(qos: .userInitiated).async {
-                do {
-                    let sessionId = try manager.client.exchangeOidcCode(meetInstance: meetInstance, code: code)
-                    DispatchQueue.main.async {
-                        manager.onAuthCookieReceived(sessionId, meetInstance: meetInstance)
-                    }
-                } catch {
-                    NSLog("[HomeView] OIDC code exchange failed: \(error)")
+        manager.authManager.launchOidcFlow(meetInstance: meetInstance)
+    }
+}
+
+// MARK: - OIDC Auth Sheet
+
+/// Wraps OidcAuthWebView in a NavigationStack with title, cancel button, and progress bar.
+private struct OidcAuthSheet: View {
+    let meetInstance: String
+    let lang: String
+    let onCookie: (String?) -> Void
+
+    @State private var progress: Double = 0
+
+    var body: some View {
+        NavigationStack {
+            ZStack(alignment: .top) {
+                OidcAuthWebView(meetInstance: meetInstance, progress: $progress, onCookie: onCookie)
+                    .ignoresSafeArea(edges: .bottom)
+                if progress > 0 && progress < 1.0 {
+                    ProgressView(value: progress)
+                        .tint(.accentColor)
                 }
+            }
+            .navigationTitle(meetInstance)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Strings.t("settings.cancel", lang: lang)) { onCookie(nil) }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - OIDC Auth WebView
+
+/// WKWebView-based OIDC auth. Opens the server's authenticate endpoint with
+/// `returnTo=visio://auth-callback`. Intercepts that redirect to attempt code
+/// exchange; falls back to reading cookies from the WKWebView store if no code
+/// is present (or on servers that redirect to the homepage instead).
+private struct OidcAuthWebView: UIViewRepresentable {
+    let meetInstance: String
+    @Binding var progress: Double
+    let onCookie: (String?) -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        context.coordinator.progressObservation = webView.observe(\.estimatedProgress) { wv, _ in
+            DispatchQueue.main.async { context.coordinator.parent.progress = wv.estimatedProgress }
+        }
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = meetInstance
+        components.path = "/api/v1.0/authenticate/"
+        components.queryItems = [URLQueryItem(name: "returnTo", value: "visio://auth-callback")]
+        if let url = components.url {
+            webView.load(URLRequest(url: url))
+        }
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+
+    class Coordinator: NSObject, WKNavigationDelegate {
+        var parent: OidcAuthWebView
+        var progressObservation: NSKeyValueObservation?
+        init(_ parent: OidcAuthWebView) { self.parent = parent }
+
+        // Intercept visio://auth-callback to extract the code (or fall back to cookies).
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            guard let url = navigationAction.request.url, url.scheme == "visio" else {
+                decisionHandler(.allow)
+                return
+            }
+            decisionHandler(.cancel)
+
+            let instance = parent.meetInstance
+            if let code = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+                .queryItems?.first(where: { $0.name == "code" })?.value,
+               !code.isEmpty {
+                // Exchange the one-time code for a session cookie.
+                OidcAuthManager.exchangeCode(meetInstance: instance, code: code) { [weak self] cookie in
+                    self?.parent.onCookie(cookie)
+                } onFailure: { [weak self, weak webView] in
+                    guard let self else { return }
+                    Self.extractCookie(from: webView, instance: instance, onCookie: self.parent.onCookie)
+                }
+            } else {
+                // No code in redirect — read cookies from the WKWebView store directly.
+                Self.extractCookie(from: webView, instance: instance, onCookie: parent.onCookie)
+            }
+        }
+
+        // Secondary detection: servers that redirect to the instance homepage.
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            guard let url = webView.url,
+                  url.host == parent.meetInstance,
+                  !url.path.contains("/authenticate"),
+                  !url.path.contains("/oauth2/"),
+                  !url.path.contains("/callback") else { return }
+            Self.extractCookie(from: webView, instance: parent.meetInstance, onCookie: parent.onCookie)
+        }
+
+        private static func extractCookie(
+            from webView: WKWebView?,
+            instance: String,
+            onCookie: @escaping (String?) -> Void
+        ) {
+            webView?.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
+                let value = cookies.first(where: {
+                    OidcAuthManager.cookieNames.contains($0.name) && $0.domain.contains(instance)
+                })?.value
+                Task { @MainActor in onCookie(value) }
             }
         }
     }
@@ -517,7 +489,7 @@ struct HomeView: View {
 
 // MARK: - Server Picker
 
-/// Server picker that navigates to the OIDC web view within the same sheet.
+/// Server picker — user selects an instance, then the WKWebView auth sheet opens.
 private struct ServerPickerWithOidc: View {
     let instances: [String]
     @Binding var customServer: String
@@ -544,20 +516,7 @@ private struct ServerPickerWithOidc: View {
 
     private func selectInstance(_ instance: String) {
         onDismiss()
-        // Use ASWebAuthenticationSession + exchange code
-        manager.authManager.launchOidcFlow(meetInstance: instance) { [weak manager] code in
-            guard let code, let manager else { return }
-            DispatchQueue.global(qos: .userInitiated).async {
-                do {
-                    let sessionId = try manager.client.exchangeOidcCode(meetInstance: instance, code: code)
-                    DispatchQueue.main.async {
-                        manager.onAuthCookieReceived(sessionId, meetInstance: instance)
-                    }
-                } catch {
-                    NSLog("[ServerPicker] OIDC code exchange failed: \(error)")
-                }
-            }
-        }
+        manager.authManager.launchOidcFlow(meetInstance: instance)
     }
 
     var body: some View {
@@ -667,7 +626,6 @@ private struct CreateRoomSheet: View {
     let onCreated: (String) -> Void
     let onCancel: () -> Void
 
-    @State private var roomDisplayName: String = ""
     @State private var accessLevel: String = "public"
     @State private var creating: Bool = false
     @State private var error: String? = nil
@@ -679,9 +637,6 @@ private struct CreateRoomSheet: View {
     @State private var invitedUsers: [UserSearchResult] = []
     @State private var createdRoomId: String? = nil
     @State private var searchTask: Task<Void, Never>? = nil
-    @State private var pendingAliasConflictName: String? = nil
-    @State private var pendingAliasConflictUrl: String? = nil
-    @State private var showAliasConflict: Bool = false
 
     private var deepLink: String {
         guard let url = createdUrl else { return "" }
@@ -693,46 +648,6 @@ private struct CreateRoomSheet: View {
         NavigationStack {
             Form {
                 if createdUrl == nil {
-                    createFormContent
-                } else {
-                    resultFormContent
-                }
-            }
-            .navigationTitle(Strings.t("home.createRoom", lang: lang))
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(Strings.t("settings.cancel", lang: lang)) { onCancel() }
-                }
-            }
-            .alert(
-                Strings.t("alias.conflictTitle", lang: lang)
-                    .replacingOccurrences(of: "{name}", with: pendingAliasConflictName ?? ""),
-                isPresented: $showAliasConflict
-            ) {
-                Button(Strings.t("alias.conflictReplace", lang: lang)) {
-                    if let name = pendingAliasConflictName, let url = pendingAliasConflictUrl {
-                        manager.client.addVisioAlias(name: name, url: url)
-                    }
-                    pendingAliasConflictName = nil
-                    pendingAliasConflictUrl = nil
-                }
-                Button(Strings.t("alias.conflictCancel", lang: lang), role: .cancel) {
-                    pendingAliasConflictName = nil
-                    pendingAliasConflictUrl = nil
-                }
-            }
-        }
-    }
-
-    // MARK: - Create form (before room is created)
-
-    @ViewBuilder
-    private var createFormContent: some View {
-                    Section {
-                        TextField(Strings.t("home.roomDisplayName", lang: lang), text: $roomDisplayName)
-                    }
-
                     Section {
                         Picker(Strings.t("home.createRoom.access", lang: lang), selection: $accessLevel) {
                             Text(Strings.t("home.createRoom.public", lang: lang)).tag("public")
@@ -772,17 +687,17 @@ private struct CreateRoomSheet: View {
                                         try? await Task.sleep(nanoseconds: 300_000_000)
                                         guard !Task.isCancelled else { return }
                                         let query = newValue
-                                        DispatchQueue.global(qos: .userInitiated).async {
-                                            do {
-                                                let results = try manager.client.searchUsers(query: query)
-                                                DispatchQueue.main.async {
-                                                    searchResults = results.filter { user in
-                                                        !invitedUsers.contains(where: { $0.id == user.id })
-                                                    }
-                                                }
-                                            } catch {
-                                                DispatchQueue.main.async { searchResults = [] }
+                                        let client = manager.client
+                                        let currentInvited = invitedUsers
+                                        do {
+                                            let results = try await Task.detached {
+                                                try client.searchUsers(query: query)
+                                            }.value
+                                            searchResults = results.filter { user in
+                                                !currentInvited.contains(where: { $0.id == user.id })
                                             }
+                                        } catch {
+                                            searchResults = []
                                         }
                                     }
                                 }
@@ -835,45 +750,33 @@ private struct CreateRoomSheet: View {
                             guard !meetInstance.isEmpty else { return }
                             creating = true
                             error = nil
-                            DispatchQueue.global(qos: .userInitiated).async {
+                            let client = manager.client
+                            let level = accessLevel
+                            let users = invitedUsers
+                            Task {
                                 do {
-                                    let result = try manager.client.createRoom(
-                                        meetUrl: "https://\(meetInstance)",
-                                        accessLevel: accessLevel
-                                    )
+                                    let result = try await Task.detached {
+                                        try client.createRoom(
+                                            meetUrl: "https://\(meetInstance)",
+                                            name: "",
+                                            accessLevel: level
+                                        )
+                                    }.value
                                     // Add accesses for invited users
-                                    if accessLevel == "restricted" {
-                                        for user in invitedUsers {
-                                            _ = try? manager.client.addAccess(userId: user.id, roomId: result.id)
-                                        }
-                                    }
-                                    DispatchQueue.main.async {
-                                        createdRoomId = result.id
-                                        let trimmedName = roomDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
-                                        let baseUrl = "https://\(meetInstance)/\(result.slug)"
-                                        if !trimmedName.isEmpty {
-                                            var allowed = CharacterSet.urlQueryAllowed
-                                            allowed.remove(charactersIn: " +&=")
-                                            let encoded = trimmedName.addingPercentEncoding(withAllowedCharacters: allowed) ?? trimmedName
-                                            createdUrl = "\(baseUrl)?visio=\(encoded)"
-                                            let conflict = manager.client.checkVisioAliasConflict(name: trimmedName, url: baseUrl)
-                                            if conflict == nil {
-                                                manager.client.addVisioAlias(name: trimmedName, url: baseUrl)
-                                            } else {
-                                                pendingAliasConflictName = trimmedName
-                                                pendingAliasConflictUrl = baseUrl
-                                                showAliasConflict = true
+                                    if level == "restricted" {
+                                        let roomId = result.id
+                                        await Task.detached {
+                                            for user in users {
+                                                _ = try? client.addAccess(userId: user.id, roomId: roomId)
                                             }
-                                        } else {
-                                            createdUrl = baseUrl
-                                        }
-                                        creating = false
+                                        }.value
                                     }
+                                    createdRoomId = result.id
+                                    createdUrl = "https://\(meetInstance)/\(result.slug)"
+                                    creating = false
                                 } catch {
-                                    DispatchQueue.main.async {
-                                        self.error = error.localizedDescription
-                                        creating = false
-                                    }
+                                    self.error = error.localizedDescription
+                                    creating = false
                                 }
                             }
                         } label: {
@@ -888,12 +791,7 @@ private struct CreateRoomSheet: View {
                         }
                         .disabled(creating)
                     }
-    }
-
-    // MARK: - Result form (after room is created)
-
-    @ViewBuilder
-    private var resultFormContent: some View {
+                } else {
                     Section {
                         VStack(alignment: .leading, spacing: 4) {
                             HStack {
@@ -906,7 +804,7 @@ private struct CreateRoomSheet: View {
                                 Button {
                                     UIPasteboard.general.string = createdUrl
                                     copiedHttp = true
-                                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) { copiedHttp = false }
+                                    Task { try? await Task.sleep(for: .seconds(2)); copiedHttp = false }
                                 } label: {
                                     Image(systemName: copiedHttp ? "checkmark" : "doc.on.doc")
                                         .font(.caption)
@@ -932,7 +830,7 @@ private struct CreateRoomSheet: View {
                                 Button {
                                     UIPasteboard.general.string = deepLink
                                     copiedDeep = true
-                                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) { copiedDeep = false }
+                                    Task { try? await Task.sleep(for: .seconds(2)); copiedDeep = false }
                                 } label: {
                                     Image(systemName: copiedDeep ? "checkmark" : "doc.on.doc")
                                         .font(.caption)
@@ -951,36 +849,6 @@ private struct CreateRoomSheet: View {
                         Text(Strings.t("settings.incall.roomInfo", lang: lang))
                     }
 
-                    if !roomDisplayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        let host = (createdUrl ?? "").replacingOccurrences(of: "https://", with: "").components(separatedBy: "/").first ?? ""
-                        let simplifiedUrl = "visio://\(host)/\(roomDisplayName.trimmingCharacters(in: .whitespacesAndNewlines))"
-                        Section {
-                            VStack(alignment: .leading, spacing: 4) {
-                                HStack {
-                                    Image(systemName: "link")
-                                        .font(.caption)
-                                    Text(Strings.t("home.createVisio.simplifiedUrl", lang: lang))
-                                        .font(.subheadline)
-                                        .fontWeight(.semibold)
-                                    Spacer()
-                                    Button {
-                                        UIPasteboard.general.string = simplifiedUrl
-                                    } label: {
-                                        Image(systemName: "doc.on.doc")
-                                            .font(.caption)
-                                    }
-                                }
-                                TextField("", text: .constant(simplifiedUrl))
-                                    .font(.caption)
-                                    .textFieldStyle(.roundedBorder)
-                                    .disabled(true)
-                                Text(Strings.t("home.createVisio.simplifiedUrlHint", lang: lang))
-                                    .font(.caption2)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-
                     Section {
                         Button {
                             onCreated(createdUrl!)
@@ -993,6 +861,16 @@ private struct CreateRoomSheet: View {
                             }
                         }
                     }
+                }
+            }
+            .navigationTitle(Strings.t("home.createRoom", lang: lang))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Strings.t("settings.cancel", lang: lang)) { onCancel() }
+                }
+            }
+        }
     }
 }
 

--- a/ios/VisioMobile/VisioManager.swift
+++ b/ios/VisioMobile/VisioManager.swift
@@ -1,18 +1,13 @@
 import AVFoundation
+import Combine
 import Foundation
 import SwiftUI
-import UserNotifications
 import visioFFI
 
 struct TestConnectParams: Sendable {
     let livekitUrl: String
     let token: String
     let mediaFile: String?
-}
-
-enum CalendarSyncResult: Equatable {
-    case success(count: Int)
-    case error(message: String)
 }
 
 /// Central state manager for the Visio app, backed by UniFFI-generated VisioClient.
@@ -42,8 +37,6 @@ class VisioManager: ObservableObject {
     @Published var currentTheme: String = "light"
     @Published var displayName: String = ""
     @Published var pendingDeepLink: String? = nil
-    /// Error from deep link alias resolution.
-    @Published var pendingDeepLinkError: String? = nil
     /// For E2E testing: (livekitUrl, token, mediaFile?) from visio-test:// deep link.
     /// Only used in DEBUG builds.
     @Published var pendingTestConnect: TestConnectParams? = nil
@@ -61,21 +54,18 @@ class VisioManager: ObservableObject {
     @Published var backgroundMode: String = "off"
     @Published var reactions: [ReactionData] = []
     @Published var adaptiveMode: AdaptiveMode = .office
-    @Published var bandwidthMode: BandwidthMode = .full
     /// Set when a screen share track is subscribed; cleared on disconnect.
     @Published var lastScreenShareParticipantSid: String? = nil
-    @Published var upcomingMeetings: [Meeting] = []
-    @Published var calendarLoading: Bool = false
-    @Published var calendarSyncResult: CalendarSyncResult?
 
     let authManager = OidcAuthManager()
+    private var authCancellable: AnyCancellable?
 
     // MARK: - Private
 
     nonisolated let client: VisioClient
     private var audioPlayout: AudioPlayout?
     private var audioCapture: AudioCapture?
-    var cameraCapture: CameraCapture?
+    private var cameraCapture: CameraCapture?
     private var syntheticAudio: SyntheticAudioCapture?
     private var mediaFileCapture: MediaFileCapture?
     private var contextDetector: ContextDetector?
@@ -129,19 +119,9 @@ class VisioManager: ObservableObject {
             NSLog("VisioManager: selfie_segmentation.onnx not found in bundle")
         }
 
-        // Observe Bluetooth audio device disconnection so we can log the
-        // iOS automatic fallback to built-in speaker.
-        NotificationCenter.default.addObserver(
-            forName: AVAudioSession.routeChangeNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            guard let reason = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt,
-                  reason == AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue else {
-                return
-            }
-            _ = self  // capture self to silence unused-capture warning
-            print("Audio route changed: Bluetooth device disconnected, iOS auto-fallback to built-in")
+        // Forward authManager changes so SwiftUI picks up pendingInstance.
+        authCancellable = authManager.objectWillChange.sink { [weak self] _ in
+            self?.objectWillChange.send()
         }
     }
 
@@ -186,13 +166,6 @@ class VisioManager: ObservableObject {
                     let capture = AudioCapture()
                     capture.start()
                     audioCapture = capture
-                }
-
-                // Stop preview capture before starting call capture
-                // (releases the physical camera device)
-                await MainActor.run { [weak self] in
-                    self?.cameraCapture?.stop()
-                    self?.cameraCapture = nil
                 }
 
                 var cameraCapture: CameraCapture?
@@ -258,13 +231,6 @@ class VisioManager: ObservableObject {
                     let capture = AudioCapture()
                     capture.start()
                     audioCapture = capture
-                }
-
-                // Stop preview capture before starting call capture
-                // (releases the physical camera device)
-                await MainActor.run { [weak self] in
-                    self?.cameraCapture?.stop()
-                    self?.cameraCapture = nil
                 }
 
                 var cameraCapture: CameraCapture?
@@ -344,7 +310,6 @@ class VisioManager: ObservableObject {
                 self?.lobbyDenied = false
                 self?.reactions = []
                 self?.lastScreenShareParticipantSid = nil
-                self?.bandwidthMode = .full
             }
         }
     }
@@ -440,21 +405,12 @@ class VisioManager: ObservableObject {
     }
 
     /// Configure AVAudioSession for voice chat (play + record).
-    /// Preserves the current Bluetooth route if one is active.
     nonisolated static func configureAudioSession() {
         let session = AVAudioSession.sharedInstance()
-        let previousBtInput = session.currentRoute.inputs.first {
-            [.bluetoothHFP, .bluetoothA2DP, .bluetoothLE].contains($0.portType)
-        }
         do {
-            try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.defaultToSpeaker, .allowBluetooth, .allowBluetoothA2DP])
+            try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.defaultToSpeaker, .allowBluetooth])
             try session.setPreferredSampleRate(48_000)
             try session.setActive(true)
-            if let btInput = previousBtInput,
-               let matchingInput = session.availableInputs?.first(where: { $0.portType == btInput.portType }) {
-                try session.setPreferredInput(matchingInput)
-                NSLog("VisioManager: restored Bluetooth input: %@", matchingInput.portName)
-            }
             NSLog("VisioManager: audio session configured (.playAndRecord)")
         } catch {
             NSLog("VisioManager: audio session config failed: %@", error.localizedDescription)
@@ -787,65 +743,6 @@ class VisioManager: ObservableObject {
         isFrontCamera = toFront
     }
 
-    /// Start camera capture for the pre-join lobby preview.
-    /// Frames go through the Rust blur pipeline and are delivered via
-    /// VideoFrameRouter with track SID "local-camera".
-    func startPreviewCapture(isFront: Bool) {
-        cameraCapture?.stop()
-
-        // Sync BlurProcessor with persisted background mode so the preview
-        // applies the user's last-selected filter immediately.
-        let mode = client.getBackgroundMode()
-        NSLog("VisioManager: startPreviewCapture syncing blur mode='%@'", mode)
-        client.setBackgroundMode(mode: mode)
-
-        let capture = CameraCapture()
-        capture.start()
-        if !isFront {
-            capture.switchCamera(toFront: false)
-        }
-        cameraCapture = capture
-    }
-
-    /// Stop the preview camera capture.
-    func stopPreviewCapture() {
-        cameraCapture?.stop()
-        cameraCapture = nil
-    }
-
-    func refreshCalendarNow() {
-        let client = self.client
-        calendarLoading = true
-        Task.detached {
-            client.refreshCalendarNow()
-        }
-    }
-
-    func requestNotificationPermissionIfNeeded() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-            if let error {
-                NSLog("VisioManager: notification permission error: %@", error.localizedDescription)
-            } else {
-                NSLog("VisioManager: notification permission %@", granted ? "granted" : "denied")
-            }
-        }
-    }
-
-    private func scheduleMeetingNotification(title: String, body: String, identifier: String) {
-        let content = UNMutableNotificationContent()
-        content.title = title
-        content.body = body
-        content.sound = .default
-
-        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
-        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
-        UNUserNotificationCenter.current().add(request) { error in
-            if let error {
-                NSLog("VisioManager: notification scheduling failed: %@", error.localizedDescription)
-            }
-        }
-    }
-
     func setNotificationParticipantJoin(_ enabled: Bool) {
         client.setNotificationParticipantJoin(enabled: enabled)
     }
@@ -1149,8 +1046,8 @@ class VisioManager: ObservableObject {
                 }
             }
 
-        case .bandwidthModeChanged(let mode):
-            self.bandwidthMode = mode
+        case .bandwidthModeChanged:
+            break
 
         case .connectionLost:
             let client = self.client
@@ -1183,42 +1080,6 @@ class VisioManager: ObservableObject {
             if self.isMicEnabled {
                 self.toggleMic()
             }
-
-        case .meetingsUpdated(let meetings):
-            let prevIds = Set(self.upcomingMeetings.map { $0.id })
-            self.upcomingMeetings = meetings
-            self.calendarLoading = false
-            // Only show sync toast when meetings actually changed
-            let newIds = Set(meetings.map { $0.id })
-            if prevIds != newIds {
-                self.calendarSyncResult = .success(count: meetings.count)
-            }
-
-        case .meetingImminent(let meeting):
-            scheduleMeetingNotification(
-                title: "Réunion bientôt",
-                body: "\(meeting.summary) commence dans 15 minutes",
-                identifier: "meeting-imminent-\(meeting.id)"
-            )
-
-        case .meetingStartingSoon(let meeting):
-            scheduleMeetingNotification(
-                title: "Réunion imminente",
-                body: "\(meeting.summary) commence dans moins de 5 minutes",
-                identifier: "meeting-soon-\(meeting.id)"
-            )
-
-        case .meetingStarted(let meeting):
-            scheduleMeetingNotification(
-                title: "Réunion en cours",
-                body: "\(meeting.summary) a commencé",
-                identifier: "meeting-started-\(meeting.id)"
-            )
-
-        case .calendarError(let message):
-            NSLog("VisioManager: calendar error: %@", message)
-            self.calendarLoading = false
-            self.calendarSyncResult = .error(message: message)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Removes `ASWebAuthenticationSession` which never fires its callback on `meet.linagora.com` (the server ignores `returnTo=visio://` and always redirects to its own homepage)
- Uses WKWebView exclusively — reads session cookies directly from its store after auth completes, with a `didFinish` fallback to detect the post-login homepage redirect
- Adds native browser chrome to the auth sheet: navigation bar with instance title, Cancel button, and a loading progress bar

## Test plan

- [ ] Tap "Me connecter" on a real device → sheet appears immediately with title bar and progress bar
- [ ] Complete SSO login → sheet dismisses and user is authenticated
- [ ] Tap Cancel → sheet dismisses, no auth state changed
- [ ] Third-party password managers (1Password etc.) offer autofill in the SSO form