### PR TITLE
fix(desktop): fix join flow race condition, room name, and camera on join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to
   adding a new instance (#169)
 - Desktop: hide optional room name field on home page when
   authenticated via OIDC (#171)
+- Desktop: fix race condition causing "waiting for authorization"
+  on public rooms (#180)
+- Desktop: remove room name field from join form (#180)
+- Desktop: fix camera not showing on join from lobby (#180)
 
 ### Added
 

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -1402,23 +1402,8 @@ function HomeView({
                 onKeyDown={handleKeyDown}
               />
             </div>
-            {!isAuthenticated && (
-              <div className="form-group">
-                <label htmlFor="roomDisplayName">
-                  {t('home.roomDisplayName')}
-                </label>
-                <input
-                  id="roomDisplayName"
-                  type="text"
-                  placeholder={t('home.roomDisplayNamePlaceholder')}
-                  autoComplete="off"
-                  data-testid="home-room-input"
-                  value={roomDisplayName}
-                  onChange={(e) => setRoomDisplayName(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                />
-              </div>
-            )}
+            {/* Room display name removed from join form — only relevant
+                when creating a room (CreateRoomView handles it). */}
             {roomStatus === 'auth_required' ? (
               <button className="btn btn-primary" onClick={handleAuth}>
                 {t('home.signIn')}
@@ -4054,6 +4039,10 @@ function PreJoinScreen({
   const micPollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const unlistenVideoRef = useRef<UnlistenFn | null>(null)
+  // When true, the component is transitioning to the call view — skip
+  // stopping camera/mic in the cleanup to avoid killing the capture that
+  // toggle_camera(true) just started in onJoin.
+  const joiningRef = useRef(false)
 
   // ---- Effect: load settings and device lists on mount --------------------
   useEffect(() => {
@@ -4086,9 +4075,12 @@ function PreJoinScreen({
       unlistenVideoRef.current?.()
       if (micPollRef.current) clearInterval(micPollRef.current)
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
-      // Stop previews on unmount
-      invoke('stop_camera_preview').catch(() => {})
-      invoke('stop_mic_preview').catch(() => {})
+      // Only stop previews if we're NOT transitioning to the call view.
+      // Otherwise this kills the camera/mic that onJoin just started.
+      if (!joiningRef.current) {
+        invoke('stop_camera_preview').catch(() => {})
+        invoke('stop_mic_preview').catch(() => {})
+      }
     }
   }, [])
 
@@ -4205,6 +4197,7 @@ function PreJoinScreen({
           url: roomUrl,
           displayName: roomDisplayName ?? null,
         }).catch(() => {})
+        joiningRef.current = true
         onJoin(finalName, isMicOn, isCameraOn, audioMode)
       } catch (e) {
         console.error('connect_with_token failed:', e)
@@ -4220,20 +4213,32 @@ function PreJoinScreen({
       setWaitingState((prev) => (prev === 'waiting' ? 'timeout' : prev))
     }, 60_000)
 
-    // Listen for lobby denied event
-    listen<string>('lobby-denied', () => {
+    // Register event listeners BEFORE calling connect() to avoid a race
+    // condition: for public rooms (no lobby), connect() obtains the token,
+    // connects to LiveKit, and emits "connected" synchronously before
+    // returning. If listeners are registered after await connect(), they miss
+    // the event and the UI stays stuck on "waiting for authorization".
+    const unlistenDenied = await listen<string>('lobby-denied', () => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
       setWaitingState('denied')
     })
-      .then((unlisten) => chainUnlisten(unlistenVideoRef, unlisten))
-      .catch(() => {})
+    chainUnlisten(unlistenVideoRef, unlistenDenied)
+
+    const unlistenState = await listen<string>(
+      'connection-state-changed',
+      (event) => {
+        if (event.payload === 'connected') {
+          if (timeoutRef.current) clearTimeout(timeoutRef.current)
+          joiningRef.current = true
+          onJoin(finalName, isMicOn, isCameraOn, audioMode)
+        }
+      }
+    )
+    chainUnlisten(unlistenVideoRef, unlistenState)
 
     // Connect to the room. For lobby-gated rooms, connect() returns Ok
-    // immediately while the user is still waiting_for_host. We listen for the
-    // connection-state-changed event and only call onJoin once the backend
-    // transitions to "connected", avoiding a duplicate connect call from the
-    // parent and preventing the blank-screen caused by setView("call") firing
-    // before admission.
+    // immediately while the user is still waiting_for_host. The listeners
+    // above will call onJoin once the backend transitions to "connected".
     try {
       await invoke('connect', { meetUrl: roomUrl, username: finalName })
     } catch {
@@ -4241,15 +4246,6 @@ function PreJoinScreen({
       setWaitingState('idle')
       return
     }
-
-    listen<string>('connection-state-changed', (event) => {
-      if (event.payload === 'connected') {
-        if (timeoutRef.current) clearTimeout(timeoutRef.current)
-        onJoin(finalName, isMicOn, isCameraOn, audioMode)
-      }
-    })
-      .then((unlisten) => chainUnlisten(unlistenVideoRef, unlisten))
-      .catch(() => {})
   }
 
   const handleBack = () => {

--- a/crates/visio-desktop/src/lib.rs
+++ b/crates/visio-desktop/src/lib.rs
@@ -603,11 +603,15 @@ async fn get_video_tracks(state: tauri::State<'_, VisioState>) -> Result<Vec<Str
 
 #[tauri::command]
 async fn toggle_mic(state: tauri::State<'_, VisioState>, enabled: bool) -> Result<(), String> {
+    tracing::info!("toggle_mic called with enabled={}", enabled);
     let controls = state.controls.lock().await;
     controls
         .set_microphone_enabled(enabled)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| {
+            tracing::error!("toggle_mic failed: {}", e);
+            e.to_string()
+        })?;
     if enabled {
         if let Some(source) = controls.audio_source().await {
             let mut engine = state.audio_engine.lock().unwrap_or_else(|e| e.into_inner());

--- a/crates/visio-desktop/tauri.conf.json
+++ b/crates/visio-desktop/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "frontend/dist",
-    "beforeDevCommand": "cd visio-desktop/frontend && npm run dev",
+    "beforeDevCommand": "",
     "beforeBuildCommand": ""
   },
   "app": {


### PR DESCRIPTION
## Summary
Fixes #180

- **Race condition on join**: Event listeners (`connection-state-changed`, `lobby-denied`) are now `await`ed before calling `invoke('connect')`, preventing the UI from getting stuck on "waiting for authorization" when joining public rooms
- **Room display name removed from join form**: The field only makes sense when creating a room — `CreateRoomView` already handles it
- **Camera preview on join**: Added a `joiningRef` flag so PreJoinView's cleanup does not call `stop_camera_preview` when transitioning to the call view, which was killing the camera capture just started by `toggle_camera(true)` in `onJoin`
- **Tracing**: Added `tracing::info`/`tracing::error` to `toggle_mic` for easier debugging

## Test plan
- [ ] Join a public room without OIDC auth → should go directly to call view (no "waiting for authorization" spinner)
- [ ] Verify "Nom de la visio" field is not shown on the join form
- [ ] Enable camera in pre-join lobby → join room → camera self-view should display immediately without needing to toggle off/on
- [ ] Enable mic in pre-join lobby → join room → mic should be active
- [ ] Cancel from pre-join lobby → camera/mic previews should stop properly
- [ ] Join a lobby-gated room → "waiting for authorization" should show until host approves