### PR TITLE
fix(ios): fix 5 compilation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to
 - Desktop: fix camera not showing on join from lobby (#180)
 - iOS: replace ASWebAuthenticationSession with WKWebView for
   OIDC login (#179)
+- iOS: fix 5 compilation errors (private access, missing API,
+  type-checker timeouts, missing bandwidthMode property)
 
 ### Added
 

--- a/ios/VisioMobile/Views/BlurredCameraPreviewView.swift
+++ b/ios/VisioMobile/Views/BlurredCameraPreviewView.swift
@@ -16,7 +16,7 @@ struct BlurredCameraPreviewView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: VideoDisplayView, context: Context) {
-        manager.cameraCapture?.switchCamera(toFront: isFront)
+        manager.switchCamera(toFront: isFront)
     }
 
     static func dismantleUIView(_ uiView: VideoDisplayView, coordinator: ()) {

--- a/ios/VisioMobile/Views/HomeView.swift
+++ b/ios/VisioMobile/Views/HomeView.swift
@@ -15,7 +15,7 @@ struct HomeView: View {
     @State private var showServerPicker: Bool = false
     @State private var customServer: String = ""
     @State private var showCreateRoom: Bool = false
-    @State private var roomHistory: [String] = []
+    @State private var roomHistory: [VisioHistoryEntry] = []
     @State private var historyJoinPending: Bool = false
     @State private var showCompactHeader: Bool = false
 
@@ -191,8 +191,9 @@ struct HomeView: View {
                             .fontWeight(.medium)
                             .foregroundStyle(VisioColors.secondaryText(dark: isDark))
 
-                        ForEach(Array(roomHistory.enumerated()), id: \.offset) { index, url in
-                            let slug = url.contains("/") ? String(url.split(separator: "/").last ?? "") : url
+                        ForEach(Array(roomHistory.enumerated()), id: \.offset) { index, entry in
+                            let url = entry.url
+                            let slug = entry.displayName ?? (url.contains("/") ? String(url.split(separator: "/").last ?? "") : url)
                             let host = URL(string: url)?.host ?? ""
 
                             Button {
@@ -293,7 +294,7 @@ struct HomeView: View {
             // Load meet instances
             meetInstances = manager.client.getMeetInstances()
             // Load room history
-            roomHistory = manager.client.getRoomHistory()
+            roomHistory = manager.client.getVisioHistory()
         }
         .onChange(of: manager.authenticatedDisplayName) { newValue in
             if !newValue.isEmpty && displayName.isEmpty {
@@ -648,219 +649,13 @@ private struct CreateRoomSheet: View {
         NavigationStack {
             Form {
                 if createdUrl == nil {
-                    Section {
-                        Picker(Strings.t("home.createRoom.access", lang: lang), selection: $accessLevel) {
-                            Text(Strings.t("home.createRoom.public", lang: lang)).tag("public")
-                            Text(Strings.t("home.createRoom.trusted", lang: lang)).tag("trusted")
-                            Text(Strings.t("home.createRoom.restricted", lang: lang)).tag("restricted")
-                        }
-                        .pickerStyle(.inline)
-                        .labelsHidden()
-
-                        if accessLevel == "public" {
-                            Text(Strings.t("home.createRoom.publicDesc", lang: lang))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        } else if accessLevel == "trusted" {
-                            Text(Strings.t("home.createRoom.trustedDesc", lang: lang))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        } else {
-                            Text(Strings.t("home.createRoom.restrictedDesc", lang: lang))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    } header: {
-                        Text(Strings.t("home.createRoom.access", lang: lang))
-                    }
-
-                    if accessLevel == "restricted" {
-                        Section(header: Text(Strings.t("restricted.invite", lang: lang))) {
-                            TextField(Strings.t("restricted.searchUsers", lang: lang), text: $searchQuery)
-                                .onChange(of: searchQuery) { newValue in
-                                    searchTask?.cancel()
-                                    guard newValue.count >= 3 else {
-                                        searchResults = []
-                                        return
-                                    }
-                                    searchTask = Task {
-                                        try? await Task.sleep(nanoseconds: 300_000_000)
-                                        guard !Task.isCancelled else { return }
-                                        let query = newValue
-                                        let client = manager.client
-                                        let currentInvited = invitedUsers
-                                        do {
-                                            let results = try await Task.detached {
-                                                try client.searchUsers(query: query)
-                                            }.value
-                                            searchResults = results.filter { user in
-                                                !currentInvited.contains(where: { $0.id == user.id })
-                                            }
-                                        } catch {
-                                            searchResults = []
-                                        }
-                                    }
-                                }
-
-                            ForEach(searchResults, id: \.id) { user in
-                                Button {
-                                    invitedUsers.append(user)
-                                    searchQuery = ""
-                                    searchResults = []
-                                } label: {
-                                    VStack(alignment: .leading) {
-                                        Text(user.fullName ?? user.email)
-                                        Text(user.email)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                    }
-                                }
-                            }
-                        }
-
-                        if !invitedUsers.isEmpty {
-                            Section(header: Text(Strings.t("restricted.members", lang: lang))) {
-                                ForEach(invitedUsers, id: \.id) { user in
-                                    HStack {
-                                        Text(user.fullName ?? user.email)
-                                        Spacer()
-                                        Button {
-                                            invitedUsers.removeAll { $0.id == user.id }
-                                        } label: {
-                                            Image(systemName: "xmark.circle.fill")
-                                                .foregroundStyle(.secondary)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    if let error {
-                        Section {
-                            Text(error)
-                                .foregroundStyle(.red)
-                                .font(.caption)
-                        }
-                    }
-
-                    Section {
-                        Button {
-                            let meetInstance = manager.authenticatedMeetInstance
-                            guard !meetInstance.isEmpty else { return }
-                            creating = true
-                            error = nil
-                            let client = manager.client
-                            let level = accessLevel
-                            let users = invitedUsers
-                            Task {
-                                do {
-                                    let result = try await Task.detached {
-                                        try client.createRoom(
-                                            meetUrl: "https://\(meetInstance)",
-                                            name: "",
-                                            accessLevel: level
-                                        )
-                                    }.value
-                                    // Add accesses for invited users
-                                    if level == "restricted" {
-                                        let roomId = result.id
-                                        await Task.detached {
-                                            for user in users {
-                                                _ = try? client.addAccess(userId: user.id, roomId: roomId)
-                                            }
-                                        }.value
-                                    }
-                                    createdRoomId = result.id
-                                    createdUrl = "https://\(meetInstance)/\(result.slug)"
-                                    creating = false
-                                } catch {
-                                    self.error = error.localizedDescription
-                                    creating = false
-                                }
-                            }
-                        } label: {
-                            HStack {
-                                Spacer()
-                                Text(creating
-                                    ? Strings.t("home.createRoom.creating", lang: lang)
-                                    : Strings.t("home.createRoom.create", lang: lang))
-                                    .fontWeight(.semibold)
-                                Spacer()
-                            }
-                        }
-                        .disabled(creating)
-                    }
+                    accessLevelSection
+                    restrictedUsersSection
+                    errorSection
+                    createButtonSection
                 } else {
-                    Section {
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack {
-                                Image(systemName: "globe")
-                                    .font(.caption)
-                                Text(Strings.t("settings.incall.roomLink", lang: lang))
-                                    .font(.subheadline)
-                                    .fontWeight(.semibold)
-                                Spacer()
-                                Button {
-                                    UIPasteboard.general.string = createdUrl
-                                    copiedHttp = true
-                                    Task { try? await Task.sleep(for: .seconds(2)); copiedHttp = false }
-                                } label: {
-                                    Image(systemName: copiedHttp ? "checkmark" : "doc.on.doc")
-                                        .font(.caption)
-                                }
-                                ShareLink(item: createdUrl!) {
-                                    Image(systemName: "square.and.arrow.up")
-                                        .font(.caption)
-                                }
-                            }
-                            TextField("", text: .constant(createdUrl!))
-                                .font(.caption)
-                                .textFieldStyle(.roundedBorder)
-                                .disabled(true)
-                        }
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack {
-                                Image(systemName: "iphone")
-                                    .font(.caption)
-                                Text(Strings.t("settings.incall.deepLink", lang: lang))
-                                    .font(.subheadline)
-                                    .fontWeight(.semibold)
-                                Spacer()
-                                Button {
-                                    UIPasteboard.general.string = deepLink
-                                    copiedDeep = true
-                                    Task { try? await Task.sleep(for: .seconds(2)); copiedDeep = false }
-                                } label: {
-                                    Image(systemName: copiedDeep ? "checkmark" : "doc.on.doc")
-                                        .font(.caption)
-                                }
-                                ShareLink(item: createdUrl!) {
-                                    Image(systemName: "square.and.arrow.up")
-                                        .font(.caption)
-                                }
-                            }
-                            TextField("", text: .constant(deepLink))
-                                .font(.caption)
-                                .textFieldStyle(.roundedBorder)
-                                .disabled(true)
-                        }
-                    } header: {
-                        Text(Strings.t("settings.incall.roomInfo", lang: lang))
-                    }
-
-                    Section {
-                        Button {
-                            onCreated(createdUrl!)
-                        } label: {
-                            HStack {
-                                Spacer()
-                                Label(Strings.t("home.join", lang: lang), systemImage: "phone.fill")
-                                    .fontWeight(.semibold)
-                                Spacer()
-                            }
-                        }
-                    }
+                    createdRoomSection
+                    joinButtonSection
                 }
             }
             .navigationTitle(Strings.t("home.createRoom", lang: lang))
@@ -868,6 +663,229 @@ private struct CreateRoomSheet: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(Strings.t("settings.cancel", lang: lang)) { onCancel() }
+                }
+            }
+        }
+    }
+
+    // MARK: - Sub-views (broken out to help the Swift type-checker)
+
+    @ViewBuilder
+    private var accessLevelSection: some View {
+        Section {
+            Picker(Strings.t("home.createRoom.access", lang: lang), selection: $accessLevel) {
+                Text(Strings.t("home.createRoom.public", lang: lang)).tag("public")
+                Text(Strings.t("home.createRoom.trusted", lang: lang)).tag("trusted")
+                Text(Strings.t("home.createRoom.restricted", lang: lang)).tag("restricted")
+            }
+            .pickerStyle(.inline)
+            .labelsHidden()
+
+            accessLevelDescription
+        } header: {
+            Text(Strings.t("home.createRoom.access", lang: lang))
+        }
+    }
+
+    @ViewBuilder
+    private var accessLevelDescription: some View {
+        if accessLevel == "public" {
+            Text(Strings.t("home.createRoom.publicDesc", lang: lang))
+                .font(.caption).foregroundStyle(.secondary)
+        } else if accessLevel == "trusted" {
+            Text(Strings.t("home.createRoom.trustedDesc", lang: lang))
+                .font(.caption).foregroundStyle(.secondary)
+        } else {
+            Text(Strings.t("home.createRoom.restrictedDesc", lang: lang))
+                .font(.caption).foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var restrictedUsersSection: some View {
+        if accessLevel == "restricted" {
+            Section(header: Text(Strings.t("restricted.invite", lang: lang))) {
+                TextField(Strings.t("restricted.searchUsers", lang: lang), text: $searchQuery)
+                    .onChange(of: searchQuery) { newValue in
+                        searchTask?.cancel()
+                        guard newValue.count >= 3 else {
+                            searchResults = []
+                            return
+                        }
+                        searchTask = Task {
+                            try? await Task.sleep(nanoseconds: 300_000_000)
+                            guard !Task.isCancelled else { return }
+                            let query = newValue
+                            let client = manager.client
+                            let currentInvited = invitedUsers
+                            do {
+                                let results = try await Task.detached {
+                                    try client.searchUsers(query: query)
+                                }.value
+                                searchResults = results.filter { user in
+                                    !currentInvited.contains(where: { $0.id == user.id })
+                                }
+                            } catch {
+                                searchResults = []
+                            }
+                        }
+                    }
+
+                ForEach(searchResults, id: \.id) { user in
+                    Button {
+                        invitedUsers.append(user)
+                        searchQuery = ""
+                        searchResults = []
+                    } label: {
+                        VStack(alignment: .leading) {
+                            Text(user.fullName ?? user.email)
+                            Text(user.email)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+
+            if !invitedUsers.isEmpty {
+                Section(header: Text(Strings.t("restricted.members", lang: lang))) {
+                    ForEach(invitedUsers, id: \.id) { user in
+                        HStack {
+                            Text(user.fullName ?? user.email)
+                            Spacer()
+                            Button {
+                                invitedUsers.removeAll { $0.id == user.id }
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var errorSection: some View {
+        if let error {
+            Section {
+                Text(error)
+                    .foregroundStyle(.red)
+                    .font(.caption)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var createButtonSection: some View {
+        Section {
+            Button {
+                let meetInstance = manager.authenticatedMeetInstance
+                guard !meetInstance.isEmpty else { return }
+                creating = true
+                error = nil
+                let client = manager.client
+                let level = accessLevel
+                let users = invitedUsers
+                Task {
+                    do {
+                        let result = try await Task.detached {
+                            try client.createRoom(
+                                meetUrl: "https://\(meetInstance)",
+                                name: "",
+                                accessLevel: level
+                            )
+                        }.value
+                        if level == "restricted" {
+                            let roomId = result.id
+                            await Task.detached {
+                                for user in users {
+                                    _ = try? client.addAccess(userId: user.id, roomId: roomId)
+                                }
+                            }.value
+                        }
+                        createdRoomId = result.id
+                        createdUrl = "https://\(meetInstance)/\(result.slug)"
+                        creating = false
+                    } catch {
+                        self.error = error.localizedDescription
+                        creating = false
+                    }
+                }
+            } label: {
+                HStack {
+                    Spacer()
+                    Text(creating
+                        ? Strings.t("home.createRoom.creating", lang: lang)
+                        : Strings.t("home.createRoom.create", lang: lang))
+                        .fontWeight(.semibold)
+                    Spacer()
+                }
+            }
+            .disabled(creating)
+        }
+    }
+
+    @ViewBuilder
+    private var createdRoomSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Image(systemName: "globe").font(.caption)
+                    Text(Strings.t("settings.incall.roomLink", lang: lang))
+                        .font(.subheadline).fontWeight(.semibold)
+                    Spacer()
+                    Button {
+                        UIPasteboard.general.string = createdUrl
+                        copiedHttp = true
+                        Task { try? await Task.sleep(for: .seconds(2)); copiedHttp = false }
+                    } label: {
+                        Image(systemName: copiedHttp ? "checkmark" : "doc.on.doc").font(.caption)
+                    }
+                    ShareLink(item: createdUrl!) {
+                        Image(systemName: "square.and.arrow.up").font(.caption)
+                    }
+                }
+                TextField("", text: .constant(createdUrl!))
+                    .font(.caption).textFieldStyle(.roundedBorder).disabled(true)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Image(systemName: "iphone").font(.caption)
+                    Text(Strings.t("settings.incall.deepLink", lang: lang))
+                        .font(.subheadline).fontWeight(.semibold)
+                    Spacer()
+                    Button {
+                        UIPasteboard.general.string = deepLink
+                        copiedDeep = true
+                        Task { try? await Task.sleep(for: .seconds(2)); copiedDeep = false }
+                    } label: {
+                        Image(systemName: copiedDeep ? "checkmark" : "doc.on.doc").font(.caption)
+                    }
+                    ShareLink(item: createdUrl!) {
+                        Image(systemName: "square.and.arrow.up").font(.caption)
+                    }
+                }
+                TextField("", text: .constant(deepLink))
+                    .font(.caption).textFieldStyle(.roundedBorder).disabled(true)
+            }
+        } header: {
+            Text(Strings.t("settings.incall.roomInfo", lang: lang))
+        }
+    }
+
+    @ViewBuilder
+    private var joinButtonSection: some View {
+        Section {
+            Button {
+                onCreated(createdUrl!)
+            } label: {
+                HStack {
+                    Spacer()
+                    Label(Strings.t("home.join", lang: lang), systemImage: "phone.fill")
+                        .fontWeight(.semibold)
+                    Spacer()
                 }
             }
         }

--- a/ios/VisioMobile/Views/SettingsView.swift
+++ b/ios/VisioMobile/Views/SettingsView.swift
@@ -41,136 +41,13 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section(Strings.t("settings.profile", lang: lang)) {
-                    TextField(Strings.t("settings.displayName", lang: lang), text: $displayName)
-                        .autocorrectionDisabled()
-                        .foregroundStyle(VisioColors.onSurface(dark: isDark))
-                        .listRowBackground(VisioColors.surface(dark: isDark))
-                }
-
-                Section(Strings.t("settings.joinMeeting", lang: lang)) {
-                    Toggle(Strings.t("settings.micOnJoin", lang: lang), isOn: $micOnJoin)
-                        .foregroundStyle(VisioColors.onSurface(dark: isDark))
-                        .listRowBackground(VisioColors.surface(dark: isDark))
-                    Toggle(Strings.t("settings.camOnJoin", lang: lang), isOn: $cameraOnJoin)
-                        .foregroundStyle(VisioColors.onSurface(dark: isDark))
-                        .listRowBackground(VisioColors.surface(dark: isDark))
-                    Toggle(Strings.t("settings.adaptiveMode", lang: lang), isOn: $adaptiveModeEnabled)
-                        .foregroundStyle(VisioColors.onSurface(dark: isDark))
-                        .listRowBackground(VisioColors.surface(dark: isDark))
-                }
-
-                Section(Strings.t("settings.theme", lang: lang)) {
-                    ForEach(["light", "dark"], id: \.self) { option in
-                        ThemeOptionRow(
-                            label: Strings.t("settings.theme.\(option)", lang: lang),
-                            isSelected: theme == option,
-                            isDark: isDark,
-                            onTap: {
-                                theme = option
-                                manager.setTheme(option)
-                            }
-                        )
-                    }
-                }
-
-                Section(Strings.t("settings.language", lang: lang)) {
-                    Picker(Strings.t("settings.language", lang: lang), selection: $language) {
-                        ForEach(Strings.supportedLangs, id: \.self) { code in
-                            Text(Strings.t("lang.\(code)", lang: code)).tag(code)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                    .foregroundStyle(VisioColors.onSurface(dark: isDark))
-                    .listRowBackground(VisioColors.surface(dark: isDark))
-                    .onChange(of: language) { newLang in
-                        manager.setLanguage(newLang)
-                    }
-                }
-
-                Section(Strings.t("settings.meetInstances", lang: lang)) {
-                    ForEach(meetInstances, id: \.self) { instance in
-                        HStack {
-                            Text(instance)
-                                .foregroundStyle(VisioColors.onSurface(dark: isDark))
-                            Spacer()
-                            Button {
-                                meetInstances.removeAll { $0 == instance }
-                            } label: {
-                                Image(systemName: "minus.circle.fill")
-                                    .foregroundStyle(.red)
-                            }
-                        }
-                        .listRowBackground(VisioColors.surface(dark: isDark))
-                    }
-                    HStack {
-                        TextField(Strings.t("settings.instancePlaceholder", lang: lang), text: $newInstance)
-                            .textInputAutocapitalization(.never)
-                            .autocorrectionDisabled()
-                            .keyboardType(.URL)
-                            .foregroundStyle(VisioColors.onSurface(dark: isDark))
-                        Button {
-                            let normalized = normalizeInstance(newInstance)
-                            if !normalized.isEmpty && !meetInstances.contains(normalized) {
-                                meetInstances.append(normalized)
-                                newInstance = ""
-                            }
-                        } label: {
-                            Image(systemName: "plus.circle.fill")
-                                .foregroundStyle(VisioColors.primary500)
-                        }
-                        .disabled(newInstance.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                    }
-                    .listRowBackground(VisioColors.surface(dark: isDark))
-                }
-                Section(Strings.t("settings.calendar", lang: lang)) {
-                    TextField(Strings.t("settings.calendarUrl", lang: lang), text: $calendarUrl)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                        .keyboardType(.URL)
-                        .foregroundStyle(VisioColors.onSurface(dark: isDark))
-                        .listRowBackground(VisioColors.surface(dark: isDark))
-                        .onChange(of: calendarUrl) { newUrl in
-                            let trimmed = newUrl.trimmingCharacters(in: .whitespacesAndNewlines)
-                            manager.client.setCalendarUrl(url: trimmed.isEmpty ? nil : trimmed)
-                            if !trimmed.isEmpty {
-                                manager.requestNotificationPermissionIfNeeded()
-                            }
-                        }
-
-                    Picker(Strings.t("settings.calendarRefresh", lang: lang), selection: $calendarRefreshInterval) {
-                        Text(Strings.t("settings.calendarRefresh.5min", lang: lang)).tag(CalendarRefreshInterval.minutes5)
-                        Text(Strings.t("settings.calendarRefresh.15min", lang: lang)).tag(CalendarRefreshInterval.minutes15)
-                        Text(Strings.t("settings.calendarRefresh.1h", lang: lang)).tag(CalendarRefreshInterval.hour1)
-                        Text(Strings.t("settings.calendarRefresh.4h", lang: lang)).tag(CalendarRefreshInterval.hours4)
-                        Text(Strings.t("settings.calendarRefresh.manual", lang: lang)).tag(CalendarRefreshInterval.manual)
-                    }
-                    .foregroundStyle(VisioColors.onSurface(dark: isDark))
-                    .listRowBackground(VisioColors.surface(dark: isDark))
-                    .onChange(of: calendarRefreshInterval) { newInterval in
-                        manager.client.setCalendarRefreshInterval(interval: newInterval)
-                    }
-
-                    if !calendarUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        Button(role: .destructive) {
-                            calendarUrl = ""
-                            manager.client.setCalendarUrl(url: nil)
-                        } label: {
-                            Text(Strings.t("settings.calendarRemove", lang: lang))
-                        }
-                        .listRowBackground(VisioColors.surface(dark: isDark))
-                    }
-                }
-
-                Section {
-                    Button(role: .destructive) {
-                        manager.client.clearVisioHistory()
-                        historyCleared = true
-                    } label: {
-                        Text(Strings.t("settings.clearHistory", lang: lang))
-                    }
-                    .listRowBackground(VisioColors.surface(dark: isDark))
-                }
+                profileSection
+                joinMeetingSection
+                themeSection
+                languageSection
+                meetInstancesSection
+                calendarSection
+                historySection
             }
             .scrollContentBackground(.hidden)
             .background(VisioColors.background(dark: isDark))
@@ -211,6 +88,161 @@ struct SettingsView: View {
         .animation(.easeInOut(duration: 0.3), value: historyCleared)
         .onDisappear { save() }
         .onAppear { load() }
+    }
+
+    // MARK: - Sub-views (broken out to help the Swift type-checker)
+
+    @ViewBuilder
+    private var profileSection: some View {
+        Section(Strings.t("settings.profile", lang: lang)) {
+            TextField(Strings.t("settings.displayName", lang: lang), text: $displayName)
+                .autocorrectionDisabled()
+                .foregroundStyle(VisioColors.onSurface(dark: isDark))
+                .listRowBackground(VisioColors.surface(dark: isDark))
+        }
+    }
+
+    @ViewBuilder
+    private var joinMeetingSection: some View {
+        Section(Strings.t("settings.joinMeeting", lang: lang)) {
+            Toggle(Strings.t("settings.micOnJoin", lang: lang), isOn: $micOnJoin)
+                .foregroundStyle(VisioColors.onSurface(dark: isDark))
+                .listRowBackground(VisioColors.surface(dark: isDark))
+            Toggle(Strings.t("settings.camOnJoin", lang: lang), isOn: $cameraOnJoin)
+                .foregroundStyle(VisioColors.onSurface(dark: isDark))
+                .listRowBackground(VisioColors.surface(dark: isDark))
+            Toggle(Strings.t("settings.adaptiveMode", lang: lang), isOn: $adaptiveModeEnabled)
+                .foregroundStyle(VisioColors.onSurface(dark: isDark))
+                .listRowBackground(VisioColors.surface(dark: isDark))
+        }
+    }
+
+    @ViewBuilder
+    private var themeSection: some View {
+        Section(Strings.t("settings.theme", lang: lang)) {
+            ForEach(["light", "dark"], id: \.self) { option in
+                ThemeOptionRow(
+                    label: Strings.t("settings.theme.\(option)", lang: lang),
+                    isSelected: theme == option,
+                    isDark: isDark,
+                    onTap: {
+                        theme = option
+                        manager.setTheme(option)
+                    }
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var languageSection: some View {
+        Section(Strings.t("settings.language", lang: lang)) {
+            Picker(Strings.t("settings.language", lang: lang), selection: $language) {
+                ForEach(Strings.supportedLangs, id: \.self) { code in
+                    Text(Strings.t("lang.\(code)", lang: code)).tag(code)
+                }
+            }
+            .pickerStyle(.menu)
+            .foregroundStyle(VisioColors.onSurface(dark: isDark))
+            .listRowBackground(VisioColors.surface(dark: isDark))
+            .onChange(of: language) { newLang in
+                manager.setLanguage(newLang)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var meetInstancesSection: some View {
+        Section(Strings.t("settings.meetInstances", lang: lang)) {
+            ForEach(meetInstances, id: \.self) { instance in
+                HStack {
+                    Text(instance)
+                        .foregroundStyle(VisioColors.onSurface(dark: isDark))
+                    Spacer()
+                    Button {
+                        meetInstances.removeAll { $0 == instance }
+                    } label: {
+                        Image(systemName: "minus.circle.fill")
+                            .foregroundStyle(.red)
+                    }
+                }
+                .listRowBackground(VisioColors.surface(dark: isDark))
+            }
+            HStack {
+                TextField(Strings.t("settings.instancePlaceholder", lang: lang), text: $newInstance)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .keyboardType(.URL)
+                    .foregroundStyle(VisioColors.onSurface(dark: isDark))
+                Button {
+                    let normalized = normalizeInstance(newInstance)
+                    if !normalized.isEmpty && !meetInstances.contains(normalized) {
+                        meetInstances.append(normalized)
+                        newInstance = ""
+                    }
+                } label: {
+                    Image(systemName: "plus.circle.fill")
+                        .foregroundStyle(VisioColors.primary500)
+                }
+                .disabled(newInstance.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            .listRowBackground(VisioColors.surface(dark: isDark))
+        }
+    }
+
+    @ViewBuilder
+    private var calendarSection: some View {
+        Section(Strings.t("settings.calendar", lang: lang)) {
+            TextField(Strings.t("settings.calendarUrl", lang: lang), text: $calendarUrl)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.URL)
+                .foregroundStyle(VisioColors.onSurface(dark: isDark))
+                .listRowBackground(VisioColors.surface(dark: isDark))
+                .onChange(of: calendarUrl) { newUrl in
+                    let trimmed = newUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+                    manager.client.setCalendarUrl(url: trimmed.isEmpty ? nil : trimmed)
+                    if !trimmed.isEmpty {
+                        manager.requestNotificationPermissionIfNeeded()
+                    }
+                }
+
+            Picker(Strings.t("settings.calendarRefresh", lang: lang), selection: $calendarRefreshInterval) {
+                Text(Strings.t("settings.calendarRefresh.5min", lang: lang)).tag(CalendarRefreshInterval.minutes5)
+                Text(Strings.t("settings.calendarRefresh.15min", lang: lang)).tag(CalendarRefreshInterval.minutes15)
+                Text(Strings.t("settings.calendarRefresh.1h", lang: lang)).tag(CalendarRefreshInterval.hour1)
+                Text(Strings.t("settings.calendarRefresh.4h", lang: lang)).tag(CalendarRefreshInterval.hours4)
+                Text(Strings.t("settings.calendarRefresh.manual", lang: lang)).tag(CalendarRefreshInterval.manual)
+            }
+            .foregroundStyle(VisioColors.onSurface(dark: isDark))
+            .listRowBackground(VisioColors.surface(dark: isDark))
+            .onChange(of: calendarRefreshInterval) { newInterval in
+                manager.client.setCalendarRefreshInterval(interval: newInterval)
+            }
+
+            if !calendarUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Button(role: .destructive) {
+                    calendarUrl = ""
+                    manager.client.setCalendarUrl(url: nil)
+                } label: {
+                    Text(Strings.t("settings.calendarRemove", lang: lang))
+                }
+                .listRowBackground(VisioColors.surface(dark: isDark))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var historySection: some View {
+        Section {
+            Button(role: .destructive) {
+                manager.client.clearVisioHistory()
+                historyCleared = true
+            } label: {
+                Text(Strings.t("settings.clearHistory", lang: lang))
+            }
+            .listRowBackground(VisioColors.surface(dark: isDark))
+        }
     }
 
     private func load() {

--- a/ios/VisioMobile/VisioManager.swift
+++ b/ios/VisioMobile/VisioManager.swift
@@ -55,6 +55,7 @@ class VisioManager: ObservableObject {
     @Published var reactions: [ReactionData] = []
     @Published var adaptiveMode: AdaptiveMode = .office
     /// Set when a screen share track is subscribed; cleared on disconnect.
+    @Published var bandwidthMode: BandwidthMode = .full
     @Published var lastScreenShareParticipantSid: String? = nil
 
     let authManager = OidcAuthManager()
@@ -1046,8 +1047,10 @@ class VisioManager: ObservableObject {
                 }
             }
 
-        case .bandwidthModeChanged:
-            break
+        case .bandwidthModeChanged(let mode):
+            DispatchQueue.main.async { [weak self] in
+                self?.bandwidthMode = mode
+            }
 
         case .connectionLost:
             let client = self.client


### PR DESCRIPTION
## Summary

Fixes iOS build failures on main caused by accumulated mismatches between Swift code and UniFFI bindings/VisioManager API.

1. **BlurredCameraPreviewView** — accessed `private` `cameraCapture` directly; now uses the public `switchCamera(toFront:)` method
2. **HomeView** — called `getRoomHistory()` which no longer exists; replaced with `getVisioHistory()` returning `[VisioHistoryEntry]`
3. **HomeView CreateRoomSheet** — Swift type-checker timeout on complex `body`; extracted into `@ViewBuilder` sub-views
4. **CallView** — referenced `manager.bandwidthMode` which didn't exist; added `@Published var bandwidthMode` to VisioManager and wired the `bandwidthModeChanged` event
5. **SettingsView** — Swift type-checker timeout; extracted into `@ViewBuilder` sub-views

## Test plan
- [ ] iOS build succeeds (`Build & Distribute iOS` workflow)
- [ ] Settings view renders correctly
- [ ] Create room flow works
- [ ] Room history displays with display names
- [ ] Bandwidth mode banner shows in call view