### PR TITLE
fix(ios): fix compilation errors on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
   OIDC login (#179)
 - iOS: fix 5 compilation errors (private access, missing API,
   type-checker timeouts, missing bandwidthMode property)
+- iOS: migrate onChange(of:) to iOS 17+ no-param syntax
 
 ### Added
 

--- a/ios/VisioMobile/Views/CallView.swift
+++ b/ios/VisioMobile/Views/CallView.swift
@@ -312,33 +312,33 @@ struct CallView: View {
             UIApplication.shared.isIdleTimerDisabled = false
             PiPManager.shared.tearDown()
         }
-        .onChange(of: scenePhase) { phase in
-            if phase == .background {
+        .onChange(of: scenePhase) {
+            if scenePhase == .background {
                 if case .connected = manager.connectionState {
                     PiPManager.shared.startIfNeeded()
                 }
-            } else if phase == .active {
+            } else if scenePhase == .active {
                 PiPManager.shared.stop()
             }
         }
-        .onChange(of: manager.lobbyDenied) { denied in
-            if denied {
+        .onChange(of: manager.lobbyDenied) {
+            if manager.lobbyDenied {
                 manager.lobbyDenied = false
                 manager.disconnect()
                 CallKitManager.shared.reportCallEnded()
                 dismiss()
             }
         }
-        .onChange(of: manager.lastScreenShareParticipantSid) { newSid in
-            if let sid = newSid {
+        .onChange(of: manager.lastScreenShareParticipantSid) {
+            if let sid = manager.lastScreenShareParticipantSid {
                 withAnimation(.easeInOut(duration: 0.2)) {
                     focusedItem = FocusItem(participantSid: sid, source: .screenShare)
                 }
             }
         }
-        .onChange(of: manager.participants) { newParticipants in
+        .onChange(of: manager.participants) {
             if let fi = focusedItem, fi.source == .screenShare {
-                let p = newParticipants.first(where: { $0.sid == fi.participantSid })
+                let p = manager.participants.first(where: { $0.sid == fi.participantSid })
                 if p?.hasScreenShare != true {
                     withAnimation(.easeInOut(duration: 0.2)) {
                         userPinned = false
@@ -348,7 +348,7 @@ struct CallView: View {
             }
             // Clear pin if the focused participant left the room
             if let fi = focusedItem {
-                let stillPresent = newParticipants.contains(where: { $0.sid == fi.participantSid })
+                let stillPresent = manager.participants.contains(where: { $0.sid == fi.participantSid })
                 if !stillPresent {
                     withAnimation(.easeInOut(duration: 0.2)) {
                         userPinned = false
@@ -357,10 +357,10 @@ struct CallView: View {
                 }
             }
         }
-        .onChange(of: manager.activeSpeakers) { _ in
+        .onChange(of: manager.activeSpeakers) {
             updateLayout()
         }
-        .onChange(of: manager.participants.count) { _ in
+        .onChange(of: manager.participants.count) {
             updateLayout()
         }
         .task {

--- a/ios/VisioMobile/Views/ChatView.swift
+++ b/ios/VisioMobile/Views/ChatView.swift
@@ -39,7 +39,7 @@ struct ChatView: View {
                             }
                             .padding()
                         }
-                        .onChange(of: manager.chatMessages.count) { _ in
+                        .onChange(of: manager.chatMessages.count) {
                             if let last = manager.chatMessages.last {
                                 withAnimation {
                                     proxy.scrollTo(last.id, anchor: .bottom)

--- a/ios/VisioMobile/Views/HomeView.swift
+++ b/ios/VisioMobile/Views/HomeView.swift
@@ -48,8 +48,8 @@ struct HomeView: View {
                     }
                     .padding(.top, 16)
                     .background(GeometryReader { geo in
-                        Color.clear.onChange(of: geo.frame(in: .named("scroll")).minY) { value in
-                            showCompactHeader = value < -20
+                        Color.clear.onChange(of: geo.frame(in: .named("scroll")).minY) {
+                            showCompactHeader = geo.frame(in: .named("scroll")).minY < -20
                         }
                     })
 
@@ -296,29 +296,28 @@ struct HomeView: View {
             // Load room history
             roomHistory = manager.client.getVisioHistory()
         }
-        .onChange(of: manager.authenticatedDisplayName) { newValue in
-            if !newValue.isEmpty && displayName.isEmpty {
-                displayName = newValue
+        .onChange(of: manager.authenticatedDisplayName) {
+            if !manager.authenticatedDisplayName.isEmpty && displayName.isEmpty {
+                displayName = manager.authenticatedDisplayName
             }
         }
-        .onChange(of: roomStatus) { newStatus in
+        .onChange(of: roomStatus) {
             guard historyJoinPending else { return }
-            if newStatus == "valid" {
+            if roomStatus == "valid" {
                 historyJoinPending = false
                 navigateToCall = true
-            } else if newStatus == "not_found" || newStatus == "idle" {
-                // Validation failed — fall back to just showing the URL in the field
+            } else if roomStatus == "not_found" || roomStatus == "idle" {
                 historyJoinPending = false
             }
         }
-        .onChange(of: manager.pendingDeepLink) { newValue in
-            if let link = newValue {
+        .onChange(of: manager.pendingDeepLink) {
+            if let link = manager.pendingDeepLink {
                 roomURL = link
                 manager.pendingDeepLink = nil
             }
         }
-        .onChange(of: manager.pendingTestConnect != nil) { hasTestConnect in
-            if hasTestConnect {
+        .onChange(of: manager.pendingTestConnect) {
+            if manager.pendingTestConnect != nil {
                 navigateToCall = true
             }
         }
@@ -706,16 +705,16 @@ private struct CreateRoomSheet: View {
         if accessLevel == "restricted" {
             Section(header: Text(Strings.t("restricted.invite", lang: lang))) {
                 TextField(Strings.t("restricted.searchUsers", lang: lang), text: $searchQuery)
-                    .onChange(of: searchQuery) { newValue in
+                    .onChange(of: searchQuery) {
                         searchTask?.cancel()
-                        guard newValue.count >= 3 else {
+                        guard searchQuery.count >= 3 else {
                             searchResults = []
                             return
                         }
                         searchTask = Task {
                             try? await Task.sleep(nanoseconds: 300_000_000)
                             guard !Task.isCancelled else { return }
-                            let query = newValue
+                            let query = searchQuery
                             let client = manager.client
                             let currentInvited = invitedUsers
                             do {
@@ -793,7 +792,6 @@ private struct CreateRoomSheet: View {
                         let result = try await Task.detached {
                             try client.createRoom(
                                 meetUrl: "https://\(meetInstance)",
-                                name: "",
                                 accessLevel: level
                             )
                         }.value

--- a/ios/VisioMobile/Views/InCallSettingsSheet.swift
+++ b/ios/VisioMobile/Views/InCallSettingsSheet.swift
@@ -410,8 +410,8 @@ private struct NotificationsTabContent: View {
                         .foregroundStyle(VisioColors.onSurface(dark: isDark))
                 }
                 .tint(VisioColors.primary500)
-                .onChange(of: notifParticipant) { value in
-                    manager.setNotificationParticipantJoin(value)
+                .onChange(of: notifParticipant) {
+                    manager.setNotificationParticipantJoin(notifParticipant)
                 }
 
                 Toggle(isOn: $notifHandRaised) {
@@ -419,8 +419,8 @@ private struct NotificationsTabContent: View {
                         .foregroundStyle(VisioColors.onSurface(dark: isDark))
                 }
                 .tint(VisioColors.primary500)
-                .onChange(of: notifHandRaised) { value in
-                    manager.setNotificationHandRaised(value)
+                .onChange(of: notifHandRaised) {
+                    manager.setNotificationHandRaised(notifHandRaised)
                 }
 
                 Toggle(isOn: $notifMessage) {
@@ -428,8 +428,8 @@ private struct NotificationsTabContent: View {
                         .foregroundStyle(VisioColors.onSurface(dark: isDark))
                 }
                 .tint(VisioColors.primary500)
-                .onChange(of: notifMessage) { value in
-                    manager.setNotificationMessageReceived(value)
+                .onChange(of: notifMessage) {
+                    manager.setNotificationMessageReceived(notifMessage)
                 }
             }
         }
@@ -462,16 +462,16 @@ private struct MembersTabContent: View {
                 TextField(Strings.t("restricted.searchUsers", lang: lang), text: $searchQuery)
                     .textFieldStyle(.roundedBorder)
                     .padding(.horizontal)
-                    .onChange(of: searchQuery) { newValue in
+                    .onChange(of: searchQuery) {
                         searchTask?.cancel()
-                        guard newValue.count >= 3 else {
+                        guard searchQuery.count >= 3 else {
                             searchResults = []
                             return
                         }
                         searchTask = Task {
                             try? await Task.sleep(nanoseconds: 300_000_000)
                             guard !Task.isCancelled else { return }
-                            let query = newValue
+                            let query = searchQuery
                             let client = manager.client
                             let currentAccesses = manager.roomAccesses
                             do {

--- a/ios/VisioMobile/Views/PreJoinView.swift
+++ b/ios/VisioMobile/Views/PreJoinView.swift
@@ -237,8 +237,8 @@ struct PreJoinView: View {
             isCameraOn = settings.cameraEnabledOnJoin
             isMicOn = settings.micEnabledOnJoin
         }
-        .onChange(of: manager.connectionState) { newState in
-            if case .connected = newState {
+        .onChange(of: manager.connectionState) {
+            if case .connected = manager.connectionState {
                 waitingState = .idle
                 navigateToCall = true
             }

--- a/ios/VisioMobile/Views/SettingsView.swift
+++ b/ios/VisioMobile/Views/SettingsView.swift
@@ -145,8 +145,8 @@ struct SettingsView: View {
             .pickerStyle(.menu)
             .foregroundStyle(VisioColors.onSurface(dark: isDark))
             .listRowBackground(VisioColors.surface(dark: isDark))
-            .onChange(of: language) { newLang in
-                manager.setLanguage(newLang)
+            .onChange(of: language) {
+                manager.setLanguage(language)
             }
         }
     }
@@ -199,8 +199,8 @@ struct SettingsView: View {
                 .keyboardType(.URL)
                 .foregroundStyle(VisioColors.onSurface(dark: isDark))
                 .listRowBackground(VisioColors.surface(dark: isDark))
-                .onChange(of: calendarUrl) { newUrl in
-                    let trimmed = newUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+                .onChange(of: calendarUrl) {
+                    let trimmed = calendarUrl.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
                     manager.client.setCalendarUrl(url: trimmed.isEmpty ? nil : trimmed)
                     if !trimmed.isEmpty {
                         manager.requestNotificationPermissionIfNeeded()
@@ -216,8 +216,8 @@ struct SettingsView: View {
             }
             .foregroundStyle(VisioColors.onSurface(dark: isDark))
             .listRowBackground(VisioColors.surface(dark: isDark))
-            .onChange(of: calendarRefreshInterval) { newInterval in
-                manager.client.setCalendarRefreshInterval(interval: newInterval)
+            .onChange(of: calendarRefreshInterval) {
+                manager.client.setCalendarRefreshInterval(interval: calendarRefreshInterval)
             }
 
             if !calendarUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {

--- a/ios/VisioMobile/VisioManager.swift
+++ b/ios/VisioMobile/VisioManager.swift
@@ -37,6 +37,7 @@ class VisioManager: ObservableObject {
     @Published var currentTheme: String = "light"
     @Published var displayName: String = ""
     @Published var pendingDeepLink: String? = nil
+    @Published var pendingDeepLinkError: String? = nil
     /// For E2E testing: (livekitUrl, token, mediaFile?) from visio-test:// deep link.
     /// Only used in DEBUG builds.
     @Published var pendingTestConnect: TestConnectParams? = nil
@@ -739,6 +740,19 @@ class VisioManager: ObservableObject {
         displayName = name
     }
 
+    /// Start camera capture in preview mode (lobby / blur preview).
+    func startPreviewCapture(isFront: Bool) {
+        if cameraCapture == nil {
+            let capture = CameraCapture()
+            capture.start()
+            if isFront != isFrontCamera {
+                capture.switchCamera(toFront: isFront)
+            }
+            cameraCapture = capture
+            isFrontCamera = isFront
+        }
+    }
+
     func switchCamera(toFront: Bool) {
         cameraCapture?.switchCamera(toFront: toFront)
         isFrontCamera = toFront
@@ -1083,6 +1097,11 @@ class VisioManager: ObservableObject {
             if self.isMicEnabled {
                 self.toggleMic()
             }
+
+        case .meetingsUpdated, .meetingImminent, .meetingStartingSoon,
+             .meetingStarted, .calendarError:
+            // Calendar events are handled by the calendar service; no UI action needed here.
+            break
         }
     }
 }

--- a/ios/VisioMobile/VisioMobileApp.swift
+++ b/ios/VisioMobile/VisioMobileApp.swift
@@ -68,8 +68,8 @@ struct VisioMobileApp: App {
                         .replacingOccurrences(of: "{name}", with: pathSegment)
                 }
             }
-            .onChange(of: scenePhase) { phase in
-                switch phase {
+            .onChange(of: scenePhase) {
+                switch scenePhase {
                 case .background:
                     manager.onAppBackgrounded()
                 case .active:


### PR DESCRIPTION
## Summary
Supersedes and extends #182. Fixes all iOS compilation errors on main.

- BlurredCameraPreviewView: use public `switchCamera()` / add `startPreviewCapture()`
- HomeView: `getVisioHistory()` instead of removed `getRoomHistory()`, remove extra `name` param from `createRoom`
- HomeView/SettingsView: extract `@ViewBuilder` sub-views to fix Swift type-checker timeouts
- VisioManager: add `bandwidthMode`, `pendingDeepLinkError`, `startPreviewCapture`; handle missing event cases
- All Swift files: migrate `onChange(of:)` to iOS 17+ no-param closure syntax

## Test plan
- [ ] iOS build succeeds