### PR TITLE
fix: v0.9.0 retrospective review fixes (security + correctness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ and this project adheres to
 
 ### Fixed
 
+- Security: derive chat encryption key from room name instead
+  of LiveKit URL to ensure per-room key isolation (#197)
+- Security: use VC1: prefix for encrypted messages to prevent
+  false positive detection on plain text (#197)
 - Android: restart AudioTrack/AudioRecord on Bluetooth device
   change for reliable routing mid-call (#203)
 - Android: debounce Bluetooth routing with SCO confirmation

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
@@ -1579,6 +1579,16 @@ private fun PaginatedGridLayout(
 
         val pagerState = rememberPagerState(pageCount = { pageCount })
 
+        // Wire page size to core LayoutEngine for smart subscriptions
+        LaunchedEffect(pageSize) {
+            VisioManager.client.setPageSize(pageSize.toUInt())
+        }
+
+        // Wire current page to core LayoutEngine for smart subscriptions
+        LaunchedEffect(pagerState.currentPage) {
+            VisioManager.client.setCurrentPage(pagerState.currentPage.toUInt())
+        }
+
         Column(modifier = Modifier.fillMaxSize()) {
             HorizontalPager(
                 state = pagerState,
@@ -1694,21 +1704,26 @@ private fun SpeakerLayout(
 ) {
     if (displayItems.isEmpty()) return
 
-    // Determine the main participant: pinned > active speaker > first
-    val mainItem =
-        when {
-            pinnedSpeakerSid != null -> displayItems.find { it.participant.sid == pinnedSpeakerSid }
-            else -> {
-                val speakerSid = activeSpeakers.firstOrNull()
-                if (speakerSid != null) {
-                    displayItems.find { it.participant.sid == speakerSid }
-                } else {
-                    null
-                }
-            }
-        } ?: displayItems.first()
+    // Wire pin state to core LayoutEngine for smart subscriptions
+    LaunchedEffect(pinnedSpeakerSid) {
+        VisioManager.client.pinParticipant(pinnedSpeakerSid)
+    }
 
-    val thumbnailItems = displayItems.filter { it.key != mainItem.key }
+    // Use core LayoutEngine to determine main and thumbnail participants
+    val mainSid = VisioManager.client.mainParticipant()
+    val thumbnailSids = VisioManager.client.thumbnailParticipants()
+
+    val mainItem = mainSid?.let { sid ->
+        displayItems.find { it.participant.sid == sid }
+    } ?: displayItems.first()
+
+    val thumbnailItems = if (thumbnailSids.isNotEmpty()) {
+        thumbnailSids.mapNotNull { sid ->
+            displayItems.find { it.participant.sid == sid }
+        }
+    } else {
+        displayItems.filter { it.key != mainItem.key }
+    }
 
     Column(modifier = Modifier.fillMaxSize()) {
         // Main tile (~70% height)

--- a/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
+++ b/android/app/src/main/kotlin/io/visio/mobile/ui/CallScreen.kt
@@ -1713,17 +1713,19 @@ private fun SpeakerLayout(
     val mainSid = VisioManager.client.mainParticipant()
     val thumbnailSids = VisioManager.client.thumbnailParticipants()
 
-    val mainItem = mainSid?.let { sid ->
-        displayItems.find { it.participant.sid == sid }
-    } ?: displayItems.first()
-
-    val thumbnailItems = if (thumbnailSids.isNotEmpty()) {
-        thumbnailSids.mapNotNull { sid ->
+    val mainItem =
+        mainSid?.let { sid ->
             displayItems.find { it.participant.sid == sid }
+        } ?: displayItems.first()
+
+    val thumbnailItems =
+        if (thumbnailSids.isNotEmpty()) {
+            thumbnailSids.mapNotNull { sid ->
+                displayItems.find { it.participant.sid == sid }
+            }
+        } else {
+            displayItems.filter { it.key != mainItem.key }
         }
-    } else {
-        displayItems.filter { it.key != mainItem.key }
-    }
 
     Column(modifier = Modifier.fillMaxSize()) {
         // Main tile (~70% height)

--- a/crates/visio-core/src/chat.rs
+++ b/crates/visio-core/src/chat.rs
@@ -31,7 +31,7 @@ const NONCE_SIZE: usize = 12;
 /// Shared chat encryption key, accessible from both ChatService and room event loop.
 pub type ChatKey = Arc<std::sync::Mutex<Option<[u8; 32]>>>;
 
-/// Derive a 256-bit AES-GCM key from a room token using HKDF-SHA256.
+/// Derive a 256-bit AES-GCM key from a room name using HKDF-SHA256.
 pub fn derive_chat_key(room_token: &str) -> [u8; 32] {
     let hk = Hkdf::<Sha256>::new(Some(b"visio-chat-v1"), room_token.as_bytes());
     let mut key = [0u8; 32];

--- a/crates/visio-core/src/chat.rs
+++ b/crates/visio-core/src/chat.rs
@@ -22,8 +22,8 @@ const CHAT_TOPIC: &str = "lk.chat";
 /// Maximum chat message length (matches Meet web client).
 const MAX_MESSAGE_LENGTH: usize = 2000;
 
-/// Wire format version byte for encrypted chat messages.
-const ENCRYPTION_VERSION: u8 = 0x01;
+/// ASCII prefix for encrypted chat messages ("Visio Chat v1").
+const ENCRYPTED_PREFIX: &str = "VC1:";
 
 /// AES-256-GCM nonce size in bytes.
 const NONCE_SIZE: usize = 12;
@@ -42,7 +42,7 @@ pub fn derive_chat_key(room_token: &str) -> [u8; 32] {
 
 /// Encrypt a plaintext message using AES-256-GCM.
 ///
-/// Wire format: `[version=0x01][12-byte nonce][ciphertext+tag]`, then base64 encoded.
+/// Wire format: `VC1:` prefix followed by base64-encoded `[12-byte nonce][ciphertext+tag]`.
 pub fn encrypt_message(plaintext: &str, key: &[u8; 32]) -> Result<String, VisioError> {
     use aes_gcm::AeadCore;
     use aes_gcm::aead::OsRng;
@@ -53,40 +53,32 @@ pub fn encrypt_message(plaintext: &str, key: &[u8; 32]) -> Result<String, VisioE
         .encrypt(&nonce, plaintext.as_bytes())
         .map_err(|e| VisioError::Room(format!("encrypt failed: {e}")))?;
 
-    let mut wire = Vec::with_capacity(1 + NONCE_SIZE + ciphertext.len());
-    wire.push(ENCRYPTION_VERSION);
+    let mut wire = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
     wire.extend_from_slice(&nonce);
     wire.extend_from_slice(&ciphertext);
 
-    Ok(BASE64.encode(&wire))
+    Ok(format!("{}{}", ENCRYPTED_PREFIX, BASE64.encode(&wire)))
 }
 
-/// Decrypt a base64-encoded encrypted message.
+/// Decrypt a `VC1:`-prefixed encrypted message.
 ///
-/// Returns the plaintext on success, or an error if the version is unknown,
+/// Returns the plaintext on success, or an error if the prefix is missing,
 /// the data is corrupt, or the key is wrong.
 pub fn decrypt_message(encoded: &str, key: &[u8; 32]) -> Result<String, VisioError> {
+    let payload = encoded
+        .strip_prefix(ENCRYPTED_PREFIX)
+        .ok_or_else(|| VisioError::Room("missing VC1: prefix".into()))?;
+
     let wire = BASE64
-        .decode(encoded)
+        .decode(payload)
         .map_err(|e| VisioError::Room(format!("base64 decode failed: {e}")))?;
 
-    if wire.is_empty() {
-        return Err(VisioError::Room("empty encrypted message".into()));
-    }
-
-    let version = wire[0];
-    if version != ENCRYPTION_VERSION {
-        return Err(VisioError::Room(format!(
-            "unknown encryption version: 0x{version:02x}"
-        )));
-    }
-
-    if wire.len() < 1 + NONCE_SIZE + 1 {
+    if wire.len() < NONCE_SIZE + 1 {
         return Err(VisioError::Room("encrypted message too short".into()));
     }
 
-    let nonce = Nonce::from_slice(&wire[1..1 + NONCE_SIZE]);
-    let ciphertext = &wire[1 + NONCE_SIZE..];
+    let nonce = Nonce::from_slice(&wire[..NONCE_SIZE]);
+    let ciphertext = &wire[NONCE_SIZE..];
 
     let cipher = Aes256Gcm::new(key.into());
     let plaintext = cipher
@@ -98,13 +90,9 @@ pub fn decrypt_message(encoded: &str, key: &[u8; 32]) -> Result<String, VisioErr
 
 /// Detect whether a message string is an encrypted chat message.
 ///
-/// Checks if it base64-decodes to bytes starting with the version byte 0x01.
+/// Checks for the `VC1:` ASCII prefix.
 pub fn is_encrypted_message(text: &str) -> bool {
-    BASE64
-        .decode(text)
-        .ok()
-        .map(|wire| !wire.is_empty() && wire[0] == ENCRYPTION_VERSION)
-        .unwrap_or(false)
+    text.starts_with(ENCRYPTED_PREFIX)
 }
 
 /// Manages chat messaging via LiveKit data channels.
@@ -356,11 +344,18 @@ mod tests {
     }
 
     #[test]
+    fn test_encrypted_has_vc1_prefix() {
+        let key = derive_chat_key("prefix-token");
+        let encrypted = encrypt_message("test prefix", &key).unwrap();
+        assert!(encrypted.starts_with("VC1:"));
+    }
+
+    #[test]
     fn test_long_message_roundtrip() {
         let key = derive_chat_key("long-msg-token");
         let plaintext = "x".repeat(2000);
         let encrypted = encrypt_message(&plaintext, &key).unwrap();
-        // Overhead check: base64 of (1 + 12 + 2000 + 16) = 2029 bytes → ~2706 base64 chars
+        // Overhead check: VC1: prefix (4) + base64 of (12 + 2000 + 16) = 2028 bytes → ~2708 base64 chars + 4
         assert!(
             encrypted.len() < 3000,
             "encrypted overhead too large: {} bytes",
@@ -371,14 +366,13 @@ mod tests {
     }
 
     #[test]
-    fn test_unknown_version_byte() {
-        // Craft a message with version 0x02 instead of 0x01
-        let mut wire = vec![0x02u8];
-        wire.extend_from_slice(&[0u8; NONCE_SIZE]); // dummy nonce
+    fn test_missing_prefix_fails() {
+        // A bare base64 string without VC1: prefix should fail
+        let mut wire = vec![0u8; NONCE_SIZE];
         wire.extend_from_slice(b"dummy ciphertext");
         let encoded = BASE64.encode(&wire);
         let key = derive_chat_key("any-token");
         let err = decrypt_message(&encoded, &key).unwrap_err();
-        assert!(err.to_string().contains("unknown encryption version"));
+        assert!(err.to_string().contains("missing VC1: prefix"));
     }
 }

--- a/crates/visio-core/src/features.rs
+++ b/crates/visio-core/src/features.rs
@@ -35,7 +35,12 @@ impl FeatureService {
     }
 
     pub fn is_enabled(&self, name: &str) -> bool {
-        if let Some(&val) = self.flags.read().unwrap_or_else(|p| p.into_inner()).get(name) {
+        if let Some(&val) = self
+            .flags
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .get(name)
+        {
             return val;
         }
         self.defaults.get(name).copied().unwrap_or(false)
@@ -46,7 +51,11 @@ impl FeatureService {
     }
 
     pub async fn refresh(&self) {
-        let url = self.proxy_url.read().unwrap_or_else(|p| p.into_inner()).clone();
+        let url = self
+            .proxy_url
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone();
         let Some(base_url) = url else { return };
         let client = match reqwest::Client::builder()
             .timeout(Duration::from_secs(3))

--- a/crates/visio-core/src/features.rs
+++ b/crates/visio-core/src/features.rs
@@ -35,18 +35,18 @@ impl FeatureService {
     }
 
     pub fn is_enabled(&self, name: &str) -> bool {
-        if let Some(&val) = self.flags.read().unwrap().get(name) {
+        if let Some(&val) = self.flags.read().unwrap_or_else(|p| p.into_inner()).get(name) {
             return val;
         }
         self.defaults.get(name).copied().unwrap_or(false)
     }
 
     pub fn set_proxy_url(&self, url: Option<String>) {
-        *self.proxy_url.write().unwrap() = url;
+        *self.proxy_url.write().unwrap_or_else(|p| p.into_inner()) = url;
     }
 
     pub async fn refresh(&self) {
-        let url = self.proxy_url.read().unwrap().clone();
+        let url = self.proxy_url.read().unwrap_or_else(|p| p.into_inner()).clone();
         let Some(base_url) = url else { return };
         let client = match reqwest::Client::builder()
             .timeout(Duration::from_secs(3))
@@ -77,7 +77,7 @@ impl FeatureService {
             }
         };
         if let Some(toggles) = body.get("toggles").and_then(|t| t.as_array()) {
-            let mut flags = self.flags.write().unwrap();
+            let mut flags = self.flags.write().unwrap_or_else(|p| p.into_inner());
             for toggle in toggles {
                 if let (Some(name), Some(enabled)) = (
                     toggle.get("name").and_then(|n| n.as_str()),

--- a/crates/visio-core/src/room.rs
+++ b/crates/visio-core/src/room.rs
@@ -137,9 +137,10 @@ async fn connect_after_lobby_acceptance(
                 ConnectionState::Connected,
             ));
 
-            // Derive chat key from LiveKit URL (shared by all participants)
+            // Derive chat key from room name (unique per room, shared by all participants)
             {
-                let key = crate::chat::derive_chat_key(&livekit_url);
+                let room_name = lk_room.name();
+                let key = crate::chat::derive_chat_key(&room_name);
                 *chat_key.lock().unwrap_or_else(|p| p.into_inner()) = Some(key);
             }
 
@@ -703,13 +704,6 @@ impl RoomManager {
     ) -> Result<(), VisioError> {
         self.set_connection_state(ConnectionState::Connecting).await;
 
-        // Derive and store the chat encryption key from the LiveKit URL
-        // (shared by all participants in the same room).
-        {
-            let key = crate::chat::derive_chat_key(livekit_url);
-            *self.chat_key.lock().unwrap_or_else(|p| p.into_inner()) = Some(key);
-        }
-
         let high_quality = self
             .high_quality_mode
             .load(std::sync::atomic::Ordering::Relaxed);
@@ -721,6 +715,13 @@ impl RoomManager {
             .map_err(|e| VisioError::Connection(e.to_string()))?;
 
         let room = Arc::new(room);
+
+        // Derive chat key from room name (unique per room, shared by all participants)
+        {
+            let room_name = room.name();
+            let key = crate::chat::derive_chat_key(&room_name);
+            *self.chat_key.lock().unwrap_or_else(|p| p.into_inner()) = Some(key);
+        }
 
         // Store local participant SID
         {

--- a/crates/visio-core/src/room.rs
+++ b/crates/visio-core/src/room.rs
@@ -407,7 +407,7 @@ impl RoomManager {
 
     /// Get a snapshot of current subscription stats.
     pub fn subscription_stats(&self) -> subscriptions::SubscriptionStats {
-        self.subscriptions.lock().unwrap().stats()
+        self.subscriptions.lock().unwrap_or_else(|p| p.into_inner()).stats()
     }
 
     // ── End layout engine delegation ────────────────────────────────
@@ -1959,7 +1959,7 @@ impl EventLoopContext {
 
         let participants = self.participants.lock().await;
         let all = participants.participants();
-        let mut sub_mgr = self.subscriptions.lock().unwrap();
+        let mut sub_mgr = self.subscriptions.lock().unwrap_or_else(|p| p.into_inner());
 
         for p in all {
             if let Some(ref track_sid) = p.video_track_sid {
@@ -1992,7 +1992,7 @@ impl EventLoopContext {
         }
 
         let actions = {
-            let mut sub_mgr = self.subscriptions.lock().unwrap();
+            let mut sub_mgr = self.subscriptions.lock().unwrap_or_else(|p| p.into_inner());
             sub_mgr.pending_actions(Instant::now())
         };
 

--- a/crates/visio-core/src/room.rs
+++ b/crates/visio-core/src/room.rs
@@ -410,7 +410,10 @@ impl RoomManager {
 
     /// Get a snapshot of current subscription stats.
     pub fn subscription_stats(&self) -> subscriptions::SubscriptionStats {
-        self.subscriptions.lock().unwrap_or_else(|p| p.into_inner()).stats()
+        self.subscriptions
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .stats()
     }
 
     // ── End layout engine delegation ────────────────────────────────

--- a/crates/visio-core/src/room.rs
+++ b/crates/visio-core/src/room.rs
@@ -389,6 +389,9 @@ impl RoomManager {
 
     pub fn pin_participant(&self, sid: Option<String>) {
         self.layout.pin_participant(sid);
+        if let Some(main) = self.layout.main_participant() {
+            self.emitter.emit(VisioEvent::MainParticipantChanged(main));
+        }
     }
 
     pub fn main_participant(&self) -> Option<String> {

--- a/ios/VisioMobile/Views/CallView.swift
+++ b/ios/VisioMobile/Views/CallView.swift
@@ -516,11 +516,16 @@ struct CallView: View {
             let pageSize = columnCount * maxRows
             let pageCount = max(1, (count + pageSize - 1) / pageSize)
 
+            // Wire page size to core LayoutEngine for smart subscriptions
+            let _ = manager.client.setPageSize(size: UInt32(pageSize))
+
             ZStack(alignment: .bottom) {
                 TabView(selection: Binding(
                     get: { currentPage },
                     set: { newValue in
                         currentPage = newValue
+                        // Wire current page to core LayoutEngine for smart subscriptions
+                        manager.client.setCurrentPage(page: UInt32(newValue))
                     }
                 )) {
                     ForEach(0..<pageCount, id: \.self) { pageIndex in
@@ -641,22 +646,26 @@ struct CallView: View {
 
     private var speakerLayout: some View {
         let displayItems = buildDisplayItems(manager.participants)
-        // Main participant: pinned, or first active speaker, or first remote, or first
-        let mainSid: String? = {
-            if userPinned, let fi = focusedItem {
-                return fi.participantSid
+
+        // Wire pin state to core LayoutEngine for smart subscriptions
+        let pinnedSid: String? = (userPinned ? focusedItem?.participantSid : nil)
+        let _ = manager.client.pinParticipant(sid: pinnedSid)
+
+        // Use core LayoutEngine to determine main and thumbnail participants
+        let mainSid = manager.client.mainParticipant()
+        let thumbnailSids = manager.client.thumbnailParticipants()
+
+        let mainItem = mainSid.flatMap { sid in
+            displayItems.first(where: { $0.participant.sid == sid && $0.source == .camera })
+        } ?? displayItems.first
+        let thumbnails: [DisplayItem] = {
+            if !thumbnailSids.isEmpty {
+                return thumbnailSids.compactMap { sid in
+                    displayItems.first(where: { $0.participant.sid == sid })
+                }
             }
-            if let speaker = manager.activeSpeakers.first {
-                return speaker
-            }
-            // First remote participant (skip local at index 0)
-            if displayItems.count > 1 {
-                return displayItems[1].participant.sid
-            }
-            return displayItems.first?.participant.sid
+            return displayItems.filter { $0.id != mainItem?.id }
         }()
-        let mainItem = displayItems.first(where: { $0.participant.sid == mainSid && $0.source == .camera }) ?? displayItems.first
-        let thumbnails = displayItems.filter { $0.id != mainItem?.id }
 
         return VStack(spacing: 8) {
             // Main tile


### PR DESCRIPTION
## Summary

Fixes for issues found during the v0.9.0 retrospective code review across all 5 phases.

### Critical fixes
- **Chat encryption key derivation** (security): was derived from LiveKit URL (shared across ALL rooms on a server). Now derived from room name (unique per room, shared by all participants).
- **Encrypted message detection**: single-byte `0x01` version marker replaced with `VC1:` ASCII prefix to eliminate false positives on plain text messages.

### Important fixes
- **Android/iOS LayoutEngine wiring**: pagination and speaker mode now call `setPageSize()`, `setCurrentPage()`, `mainParticipant()`, `thumbnailParticipants()` on the core. This was required for smart subscriptions (Phase 4) to function — without it, the core had no visibility into which page was displayed.
- **Mutex/RwLock poisoning**: `FeatureService` (3 sites) and `SubscriptionManager` (3 sites) now use `unwrap_or_else(|p| p.into_inner())` pattern consistently.
- **MainParticipantChanged on pin**: event now emitted when `pin_participant()` is called, not only on ActiveSpeakersChanged.

## Test plan

- [x] 247 Rust unit tests pass (1 new encryption test)
- [x] Clippy clean
- [x] Android debug build passes
- [ ] Integration: verify chat messages decrypt correctly between participants
- [ ] Integration: verify subscription stats update when swiping pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)