### PR TITLE
chore(ci): cleanup post-0.10.0 release pipeline

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -83,61 +83,27 @@ jobs:
           fi
 
       - name: Decode keystore
-        # echo adds a trailing newline that can corrupt the decoded binary.
+        # echo adds a trailing newline that can corrupt the decoded binary;
         # printf '%s' emits the secret verbatim and base64 -d ignores
-        # whitespace, so we get byte-identical output to the source file.
+        # whitespace, so the decoded keystore is byte-identical to the source.
         run: |
           printf '%s' "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" \
             | base64 -d > android/app/release.keystore
-          ls -la android/app/release.keystore
-          sha256sum android/app/release.keystore
-          # The keytool check below catches password-vs-keystore drift early
-          # (vs. discovering it 4 minutes later at signReleaseBundle time).
-          # 'keytool -list' rejects with a clear message if the storepass is
-          # wrong for the embedded PKCS12.
-          # Test the storepass only first (opens the keystore).
-          keytool -list -keystore android/app/release.keystore \
-            -storepass "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" \
-            -v | head -10
-          # Now test the alias + keypass — this is what gradle's
-          # signReleaseBundle does internally and will fail with the same
-          # 'password was incorrect' message if either is wrong.
-          echo "--- alias+keypass check ---"
-          keytool -keypasswd -list \
-            -keystore android/app/release.keystore \
-            -storepass "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" \
-            -alias "${{ secrets.ANDROID_KEY_ALIAS }}" \
-            -keypass "${{ secrets.ANDROID_KEY_PASSWORD }}" 2>&1 | head -5 || true
-          # And a non-destructive way: keytool -certreq probes the key.
-          keytool -certreq \
-            -keystore android/app/release.keystore \
-            -storepass "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" \
-            -alias "${{ secrets.ANDROID_KEY_ALIAS }}" \
-            -keypass "${{ secrets.ANDROID_KEY_PASSWORD }}" 2>&1 | head -3
 
-      - name: Decode Firebase service account
+      - name: Decode Play Store service account
+        # FIREBASE_SERVICE_ACCOUNT_BASE64 is a legacy secret name from when
+        # we also published via Firebase App Distribution. The JSON it
+        # decodes is now used exclusively for the Play Store Android
+        # Publisher API (supply / SUPPLY_JSON_KEY_PATH below).
         run: |
           printf '%s' "${{ secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 }}" \
-            | base64 -d > /tmp/firebase-sa.json
+            | base64 -d > /tmp/play-sa.json
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
           bundler-cache: true
-
-      - name: Build & distribute via Fastlane
-        working-directory: android
-        env:
-          KEYSTORE_PATH: release.keystore
-          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
-          GOOGLE_APPLICATION_CREDENTIALS: /tmp/firebase-sa.json
-          VERSION_CODE: ${{ github.run_number }}
-          RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
-        run: bundle exec fastlane distribute
 
       - name: Build AAB for Google Play
         working-directory: android
@@ -146,9 +112,9 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-          # Same monotonic versionCode as the APK step. Without this the
-          # build.gradle.kts fallback (`?: 1`) ships a version_code=1 AAB
-          # to Play Store — which rejects it as already-used by 0.8.0.
+          # Monotonic versionCode from the run number. Without it the
+          # build.gradle.kts fallback (`?: 1`) ships version_code=1 — which
+          # Play Store rejects as already-used by an earlier release.
           VERSION_CODE: ${{ github.run_number }}
         run: ./gradlew bundleRelease
 
@@ -156,35 +122,20 @@ jobs:
         if: inputs.publish_to_play_store == true
         working-directory: android
         env:
-          SUPPLY_JSON_KEY_PATH: /tmp/firebase-sa.json
+          SUPPLY_JSON_KEY_PATH: /tmp/play-sa.json
         run: bundle exec fastlane release
 
       - name: Package native debug symbols
         run: |
           SYMBOLS_DIR="android/app/build/outputs/native-debug-symbols/release"
           mkdir -p "$SYMBOLS_DIR/lib/arm64-v8a"
-          # Copy unstripped .so files with debug symbols
           for lib in libvisio_ffi.so libvisio_video.so; do
             UNSTRIPPED=$(find target/aarch64-linux-android/release -name "$lib" -not -path "*/stripped/*" | head -1)
             if [ -n "$UNSTRIPPED" ]; then
               cp "$UNSTRIPPED" "$SYMBOLS_DIR/lib/arm64-v8a/"
             fi
           done
-          # Create native-debug-symbols.zip for Google Play upload
           cd "$SYMBOLS_DIR" && zip -r "$GITHUB_WORKSPACE/native-debug-symbols.zip" lib/
-
-      - name: Find built APK
-        id: find-apk
-        if: always()
-        run: |
-          APK=$(find android/app/build/outputs -name "*.apk" -type f | head -1)
-          if [ -n "$APK" ]; then
-            echo "apk_path=$APK" >> $GITHUB_OUTPUT
-            echo "apk_name=$(basename $APK)" >> $GITHUB_OUTPUT
-            echo "Found APK: $APK"
-          else
-            echo "No APK found"
-          fi
 
       - name: Find built AAB
         id: find-aab
@@ -198,19 +149,13 @@ jobs:
             echo "No AAB found"
           fi
 
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        if: steps.find-apk.outputs.apk_path != ''
-        with:
-          name: android-apk
-          path: ${{ steps.find-apk.outputs.apk_path }}
-
       - name: Upload AAB artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: steps.find-aab.outputs.aab_path != ''
         with:
           name: android-aab
           path: ${{ steps.find-aab.outputs.aab_path }}
+          retention-days: 14
 
       - name: Upload native debug symbols
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
@@ -219,26 +164,4 @@ jobs:
           name: native-debug-symbols
           path: native-debug-symbols.zip
           if-no-files-found: warn
-
-      - name: Create GitHub Release
-        if: steps.find-apk.outputs.apk_path != '' || steps.find-aab.outputs.aab_path != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="build-${{ github.run_number }}"
-          NOTES="${{ github.event.inputs.release_notes }}"
-          if [ -z "$NOTES" ]; then
-            NOTES="Build #${{ github.run_number }} from $(date -u +%Y-%m-%d)"
-          fi
-          FILES=()
-          if [ -n "${{ steps.find-apk.outputs.apk_path }}" ]; then
-            FILES+=("${{ steps.find-apk.outputs.apk_path }}")
-          fi
-          if [ -n "${{ steps.find-aab.outputs.aab_path }}" ]; then
-            FILES+=("${{ steps.find-aab.outputs.aab_path }}")
-          fi
-          gh release create "$TAG" \
-            "${FILES[@]}" \
-            --title "Android Build #${{ github.run_number }}" \
-            --notes "$NOTES" \
-            --prerelease
+          retention-days: 30

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -173,6 +173,7 @@ jobs:
             target/release/bundle/dmg/*.dmg
             target/release/bundle/macos/*.app.tar.gz
             target/release/bundle/macos/*.app.tar.gz.sig
+          retention-days: 14
 
       - name: Upload Windows artifacts
         if: matrix.platform == 'windows'
@@ -182,6 +183,7 @@ jobs:
           path: |
             target/release/bundle/msi/*.msi
             target/release/bundle/nsis/*.exe
+          retention-days: 14
 
       - name: Upload Linux artifacts
         if: matrix.platform == 'linux'
@@ -192,6 +194,7 @@ jobs:
             target/release/bundle/appimage/*.AppImage
             target/release/bundle/deb/*.deb
             target/release/bundle/flatpak/*.flatpak
+          retention-days: 14
 
   # --- GitHub Release with all artifacts ---
   release:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -91,3 +91,4 @@ jobs:
         with:
           name: ios-ipa
           path: ios/build/VisioMobile.ipa
+          retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- CI: Android publish now goes through Play Store internal track only;
+  the Firebase App Distribution channel and the per-run
+  `build-N` GitHub prereleases are dropped
+- CI: artifact retention reduced to 14 days across all build workflows
+
 ## [0.10.0] - 2026-06-04
 
 ### Added

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -1,21 +1,6 @@
 default_platform(:android)
 
 platform :android do
-  desc "Build release APK and distribute via Firebase App Distribution"
-  lane :distribute do
-    gradle(
-      task: "assembleRelease",
-      project_dir: "."
-    )
-
-    firebase_app_distribution(
-      app: ENV["FIREBASE_APP_ID"],
-      service_credentials_file: ENV["GOOGLE_APPLICATION_CREDENTIALS"],
-      groups: "testers",
-      release_notes: ENV["RELEASE_NOTES"].to_s.empty? ? "Build #{ENV['GITHUB_RUN_NUMBER'] || 'local'} — #{`git log -1 --pretty=%s`.strip}" : ENV["RELEASE_NOTES"]
-    )
-  end
-
   desc "Upload an already-built AAB to Google Play (internal track)"
   lane :release do
     # The AAB is produced and signed by the previous workflow step


### PR DESCRIPTION
## Summary

Trim the build pipeline to match the canonical channels chosen for 0.10.0 and after. Three behavioural changes + one CHANGELOG note, no app code touched.

### What changes

- **Android: drop Firebase App Distribution** (`android/fastlane/Fastfile`, `.github/workflows/build-android.yml`).
  - The `distribute` lane was building an APK and pushing it to Firebase as a parallel testing channel. With Play Store internal track now functional and no remaining testers on the Firebase side, the channel is dropped.
  - The APK is no longer produced (the upstream `gradle assembleRelease` came with the distribute lane). Internal testers consume the AAB via Play Store directly; sideload remains possible via a local `./gradlew assembleRelease` for the rare case it's needed.
  - The per-run `Android Build #N` GitHub prerelease (~80 of these were created since v0.9.0) is also dropped. AAB stays as a 14-day workflow artifact for archival.

- **Android: drop the keystore diagnostics from the CI** (`.github/workflows/build-android.yml`).
  - The `sha256sum`, `keytool -list`, `keytool -keypasswd`, `keytool -certreq` steps were temporary scaffolding added today while we hunted the `keystore password was incorrect` failure. Root cause turned out to be a missing `VERSION_CODE` env in the AAB step and an empty env block on the supply step; both are fixed elsewhere. The diagnostic steps now just waste ~45 s per run and dump cert metadata into the logs.

- **Rename `/tmp/firebase-sa.json` → `/tmp/play-sa.json`** to reflect actual usage. The `FIREBASE_SERVICE_ACCOUNT_BASE64` secret name itself stays as-is — renaming it requires re-pushing the secret and we can do that in a separate ops step if we want.

- **Cap workflow artifact retention at 14 days** (Android AAB, Desktop bundles, iOS IPA). Default is 90 days; on a workflow that produces ~270 MB of Desktop artefacts per run, the previous cadence ate >20 GB of artifact storage. Shipped binaries live in their respective stores / `desktop-build-N` GitHub Releases which keep assets indefinitely. Native debug symbols stay at 30 days (useful for crash triage).

### Operational cleanup done outside this PR

- Deleted ~60 stale `build-N` and `desktop-build-N` GitHub releases (everything older than `desktop-build-80` which carries v0.10.0 with `oidc_auth=true` ON).
- Deleted the orphan draft GitHub release for `v0.10.0` (created early in the day before the tag started moving around).

## Test plan

- [ ] Trigger `build-android.yml` manually with `publish_to_play_store: false`. Should build the AAB and stop — no Firebase upload, no APK, no GitHub Release.
- [ ] Trigger `build-android.yml` manually with `publish_to_play_store: true`. Should build the AAB and upload to Play Store internal (assuming the Google upload-key reset has propagated by then).
- [ ] Trigger `build-desktop.yml` manually. Existing behaviour — artefacts attached to `desktop-build-N` GitHub Release as before. Just shorter retention on the per-run workflow artifacts (the release assets are unaffected).
- [ ] Trigger `build-ios.yml` manually with `publish_to_app_store: false`. Existing behaviour, just shorter IPA retention.

## Follow-ups intentionally not in this PR

- macOS Developer ID signing + notarization (planned, gated on creating the cert + pushing the new secrets).
- Windows code signing (Trusted Signing or OV cert, ~120 €/year).
- Renaming `FIREBASE_SERVICE_ACCOUNT_BASE64` → `PLAY_STORE_SERVICE_ACCOUNT_BASE64`.
- Tag-management discipline: stop moving `vX.Y.Z` once shipped; use `vX.Y.Z-rcN` for in-flight iterations.