### PR TITLE
chore(ci): quick wins — concurrency, timeouts, pinned runners, tag-triggered releases

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -12,6 +12,14 @@ on:
         required: false
         type: boolean
         default: false
+  push:
+    # Pushing a semver tag triggers a build + automatic Play Store
+    # upload. Use vX.Y.Z for prod-ready releases (Play Store internal
+    # track, ready to promote to production from the console) and
+    # vX.Y.Z-rcN for release candidates (build only, no upload).
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
 
 permissions:
   contents: read
@@ -131,7 +139,11 @@ jobs:
         run: ./gradlew bundleRelease
 
       - name: Upload AAB to Google Play (internal track)
-        if: inputs.publish_to_play_store == true
+        # Publish when explicitly requested via workflow_dispatch input OR
+        # when triggered by a non-RC semver tag push (vX.Y.Z, not -rcN).
+        if: >-
+          (github.event_name == 'workflow_dispatch' && inputs.publish_to_play_store == true) ||
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc'))
         working-directory: android
         env:
           SUPPLY_JSON_KEY_PATH: /tmp/play-sa.json

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -14,11 +14,23 @@ on:
         default: false
 
 permissions:
-  contents: write
+  contents: read
+
+# A new dispatch of this workflow on the same ref cancels the in-progress
+# one. Keeps the iteration loop from racking up 5 parallel Android builds
+# fighting for the Play Store upload slot when we re-trigger during a
+# debug session.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-android:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    # Android build path: ~10-15 min healthy, 25 min with cold cargo cache.
+    # Tighter than default 6h so a hung step (Tauri DMG-style hang) fails
+    # in minutes instead of burning runner hours.
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: .

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -7,6 +7,13 @@ on:
         description: "Release notes"
         required: false
         default: ""
+  push:
+    # Pushing a semver tag triggers a Desktop build and a GitHub Release
+    # attached to that tag (assets: .dmg, .msi, .exe, .deb, .AppImage,
+    # .flatpak). RC tags (-rcN) are marked prerelease.
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -234,10 +241,30 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="desktop-build-${{ github.run_number }}"
+          # Two trigger paths:
+          # - push: tags -> use the semver tag itself as the release tag
+          #   (so v0.10.0 publishes a `v0.10.0` GitHub release with the
+          #   .dmg / .msi / .deb / .AppImage / .flatpak attached).
+          # - workflow_dispatch -> per-run desktop-build-N prerelease,
+          #   useful for testing without burning a real semver tag.
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            TITLE="Visio Mobile $TAG"
+            # Mark RC tags as prerelease.
+            if [[ "$TAG" == *-rc* ]]; then
+              PRERELEASE="--prerelease"
+            else
+              PRERELEASE=""
+            fi
+          else
+            TAG="desktop-build-${{ github.run_number }}"
+            TITLE="Desktop Build #${{ github.run_number }}"
+            PRERELEASE="--prerelease"
+          fi
+
           NOTES="${{ github.event.inputs.release_notes }}"
           if [ -z "$NOTES" ]; then
-            NOTES="Desktop Build #${{ github.run_number }} from $(date -u +%Y-%m-%d)"
+            NOTES="$TITLE from $(date -u +%Y-%m-%d)"
           fi
 
           # Collect all release files (use NUL-delimited to handle spaces in names)
@@ -249,9 +276,9 @@ jobs:
           if [ ${#FILES[@]} -gt 0 ]; then
             gh release create "$TAG" \
               "${FILES[@]}" \
-              --title "Desktop Build #${{ github.run_number }}" \
+              --title "$TITLE" \
               --notes "$NOTES" \
-              --prerelease
+              $PRERELEASE
           else
             echo "::warning::No artifacts found for release"
           fi

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: ""
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:
@@ -23,7 +27,10 @@ jobs:
             rust-targets: aarch64-apple-darwin
             label: macos-arm64
           - platform: windows
-            runner: windows-latest
+            # windows-2022 instead of windows-latest: GitHub rolls the
+            # 'latest' label forward to new images on its own schedule,
+            # which has broken Tauri/webrtc-sys builds in the past.
+            runner: windows-2022
             rust-targets: x86_64-pc-windows-msvc
             label: windows-x64
           - platform: linux
@@ -32,6 +39,9 @@ jobs:
             label: linux-x64
 
     runs-on: ${{ matrix.runner }}
+    # Linux Tauri (webrtc-sys + flatpak) is the long pole at ~20-30 min;
+    # cap at 60 so a hung step fails in minutes.
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: .
@@ -199,7 +209,8 @@ jobs:
   # --- GitHub Release with all artifacts ---
   release:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -12,6 +12,14 @@ on:
         required: false
         type: boolean
         default: false
+  push:
+    # Pushing a semver tag triggers build + TestFlight + ASC metadata.
+    # Use vX.Y.Z for prod-ready releases (App Store metadata pushed,
+    # ready for the manual 'Add for review' click) and vX.Y.Z-rcN for
+    # build-only (TestFlight stays the canonical channel for RCs).
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -79,7 +87,11 @@ jobs:
         run: bundle exec fastlane distribute
 
       - name: Upload to App Store Connect
-        if: inputs.publish_to_app_store == true
+        # Publish when explicitly requested via workflow_dispatch input OR
+        # when triggered by a non-RC semver tag push (vX.Y.Z, not -rcN).
+        if: >-
+          (github.event_name == 'workflow_dispatch' && inputs.publish_to_app_store == true) ||
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc'))
         timeout-minutes: 20
         working-directory: ios
         env:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -13,9 +13,16 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-ios:
     runs-on: macos-15
+    # ~15-25 min healthy. Cap at 60 to absorb a slow ASC upload retry
+    # without ever burning the default 6h.
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,24 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- CI: pushing a semver tag (`vX.Y.Z` or `vX.Y.Z-rcN`) now triggers
+  the three build workflows automatically. Non-RC tags publish to
+  Play Store internal / App Store Connect; RC tags build only.
+  Desktop releases use the semver tag as the GitHub Release tag.
+
 ### Changed
 
 - CI: Android publish now goes through Play Store internal track only;
   the Firebase App Distribution channel and the per-run
   `build-N` GitHub prereleases are dropped
 - CI: artifact retention reduced to 14 days across all build workflows
+- CI: every build workflow has explicit `concurrency: cancel-in-progress`
+  and `timeout-minutes` instead of relying on the GitHub defaults
+- CI: pin `ubuntu-latest` -> `ubuntu-24.04` and `windows-latest` ->
+  `windows-2022` so a GitHub-side image bump doesn't break a release
+  the day it ships
 
 ## [0.10.0] - 2026-06-04
 


### PR DESCRIPTION
## Summary

Three CI quick wins from the post-0.10.0 audit, batched in one PR. No app code touched; only `.github/workflows/*.yml` + a CHANGELOG entry.

### 1. Concurrency + timeouts

- Every build workflow declares `concurrency: group: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`. Re-dispatching during a debug iteration cancels the in-flight run instead of stacking them.
- `timeout-minutes` is set per job: Android 45, iOS 60, Desktop matrix 60, Desktop release 15. Replaces the GitHub default of 6 h, so a hung step (yesterday's `bundle_dmg.sh` Sequoia stall is the canonical example) fails in minutes.

### 2. Pin runner versions

- Android: `ubuntu-latest` → `ubuntu-24.04`
- Desktop Windows: `windows-latest` → `windows-2022`
- Desktop release job: `ubuntu-latest` → `ubuntu-24.04`

`*-latest` rolls forward to new images on GitHub's schedule. We hit that twice in the last 24 h (`macos-15` libc++ C++20 regression). Explicit pins protect releases against the upstream image bump cadence.

### 3. Tag-triggered releases

Each workflow now reacts to:

- `vX.Y.Z` → stable release. Build runs; publish step gated by `&& !contains(github.ref, '-rc')` → uploads to Play Store internal / App Store Connect / GitHub Release.
- `vX.Y.Z-rcN` → release candidate. Build runs; publish step skipped. Desktop release is marked `--prerelease`.

The legacy `workflow_dispatch` paths are unchanged. The dispatch inputs (`publish_to_play_store`, `publish_to_app_store`, `release_notes`) still work the same way for manual runs.

For Desktop specifically, the GitHub Release tag now matches the semver tag instead of `desktop-build-N` when triggered via tag push. Dispatch path keeps the `desktop-build-N` convention for ad-hoc test builds.

### Bonus

- Android workflow-level `permissions: contents: write` → `contents: read` (the per-run `Android Build #N` GitHub Release was dropped in the previous cleanup PR, so the write scope is no longer needed at the workflow level).

## Test plan

- [ ] `gh workflow run build-android.yml --ref main -f publish_to_play_store=false` → builds AAB, no upload. Same as today.
- [ ] `gh workflow run build-android.yml --ref main -f publish_to_play_store=true` → builds + uploads to Play Store internal. Same as today.
- [ ] Push a fake tag `v0.99.0-rc1` from a feature branch → all 3 workflows fire automatically; no Play Store / ASC upload; Desktop Release marked prerelease.
- [ ] Push a fake tag `v0.99.0` → all 3 workflows fire automatically; Play Store upload runs; ASC deliver runs; Desktop Release marked stable.
- [ ] Re-dispatch Android while a previous Android run is still in progress → the previous one is cancelled.

## Follow-ups not in this PR

- macOS Developer ID signing + notarization (audit item 4).
- Windows Trusted Signing (audit item 6).
- Workload Identity Federation for Play Store SA (audit item 5).
- Reusable workflow for the shared Rust/cargo setup steps.