### PR TITLE
chore(ci): uniformise dispatch input + artifact + workflow names

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -7,8 +7,8 @@ on:
         description: "Release notes for testers"
         required: false
         default: ""
-      publish_to_play_store:
-        description: "Upload AAB to Google Play (internal track)"
+      publish:
+        description: "Upload AAB to Play Store internal track"
         required: false
         type: boolean
         default: false
@@ -142,7 +142,7 @@ jobs:
         # Publish when explicitly requested via workflow_dispatch input OR
         # when triggered by a non-RC semver tag push (vX.Y.Z, not -rcN).
         if: >-
-          (github.event_name == 'workflow_dispatch' && inputs.publish_to_play_store == true) ||
+          (github.event_name == 'workflow_dispatch' && inputs.publish == true) ||
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc'))
         working-directory: android
         env:
@@ -159,7 +159,7 @@ jobs:
               cp "$UNSTRIPPED" "$SYMBOLS_DIR/lib/arm64-v8a/"
             fi
           done
-          cd "$SYMBOLS_DIR" && zip -r "$GITHUB_WORKSPACE/native-debug-symbols.zip" lib/
+          cd "$SYMBOLS_DIR" && zip -r "$GITHUB_WORKSPACE/android-debug-symbols.zip" lib/
 
       - name: Find built AAB
         id: find-aab
@@ -185,7 +185,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: always()
         with:
-          name: native-debug-symbols
-          path: native-debug-symbols.zip
+          name: android-debug-symbols
+          path: android-debug-symbols.zip
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,4 +1,4 @@
-name: Build Desktop
+name: Build & Distribute Desktop
 
 on:
   workflow_dispatch:
@@ -7,6 +7,11 @@ on:
         description: "Release notes"
         required: false
         default: ""
+      publish:
+        description: "Publish a desktop-build-N GitHub prerelease for this dispatch"
+        required: false
+        type: boolean
+        default: false
   push:
     # Pushing a semver tag triggers a Desktop build and a GitHub Release
     # attached to that tag (assets: .dmg, .msi, .exe, .deb, .AppImage,
@@ -216,6 +221,14 @@ jobs:
   # --- GitHub Release with all artifacts ---
   release:
     needs: build
+    # Publish when a semver tag is pushed, OR on workflow_dispatch with
+    # publish=true. Default dispatch (publish=false) builds artifacts and
+    # uploads them to the run page but creates no GitHub Release —
+    # symmetric with Android (`publish` gates Play Store upload) and iOS
+    # (`publish` gates App Store Connect upload).
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish == true)
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -7,8 +7,8 @@ on:
         description: "Release notes for testers"
         required: false
         default: ""
-      publish_to_app_store:
-        description: "Upload to App Store Connect (metadata + binary)"
+      publish:
+        description: "Upload metadata to App Store Connect"
         required: false
         type: boolean
         default: false
@@ -90,7 +90,7 @@ jobs:
         # Publish when explicitly requested via workflow_dispatch input OR
         # when triggered by a non-RC semver tag push (vX.Y.Z, not -rcN).
         if: >-
-          (github.event_name == 'workflow_dispatch' && inputs.publish_to_app_store == true) ||
+          (github.event_name == 'workflow_dispatch' && inputs.publish == true) ||
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc'))
         timeout-minutes: 20
         working-directory: ios

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ and this project adheres to
 - CI: pin `ubuntu-latest` -> `ubuntu-24.04` and `windows-latest` ->
   `windows-2022` so a GitHub-side image bump doesn't break a release
   the day it ships
+- CI: dispatch input names are now uniform across the three workflows.
+  Android `publish_to_play_store` and iOS `publish_to_app_store` are
+  renamed to `publish`. Desktop gets a new `publish` input (default
+  false) — a default dispatch builds artifacts without creating a
+  `desktop-build-N` GitHub Release. Tag-triggered runs ignore the
+  input and always publish.
+- CI: Android `native-debug-symbols` artifact renamed to
+  `android-debug-symbols` so the platform prefix matches the other
+  artifacts (`android-aab`, `ios-ipa`, `desktop-*`)
+- CI: Desktop workflow display name aligned with the others:
+  "Build Desktop" -> "Build & Distribute Desktop"
 
 ## [0.10.0] - 2026-06-04
 


### PR DESCRIPTION
## Summary

Four pre-existing asymmetries between the three build workflows, fixed in one go. None caused incidents, but each was one more rule to remember when re-triggering or scripting.

| | Before | After |
|---|---|---|
| Workflow display | "Build & Distribute Android", "Build & Distribute iOS", **"Build Desktop"** | All three: "Build & Distribute X" |
| Dispatch input | `publish_to_play_store`, `publish_to_app_store`, _(missing on Desktop)_ | All three: `publish` (bool, default `false`) |
| Per-dispatch release | Android: none. **Desktop: always emits `desktop-build-N`** | Both gated by `publish=true` |
| Artifact name | `android-aab`, `ios-ipa`, `desktop-*`, **`native-debug-symbols`** | All `<platform>-<kind>`: `android-debug-symbols` |

## Behavioural changes

- `gh workflow run build-desktop.yml --ref main` without `-f publish=true` → builds the bundles and uploads them as workflow artifacts, but creates **no** GitHub Release. Previously emitted `desktop-build-N` every time. Add `-f publish=true` to get the legacy behaviour.
- Anyone with a script using `-f publish_to_play_store=true` or `-f publish_to_app_store=true` needs to update to `-f publish=true`. There's only one such caller (me, manual), no external automation.
- Tag-triggered runs (`vX.Y.Z` / `vX.Y.Z-rcN`) ignore the input entirely — they always publish to the canonical channel, same as today.

## Naming convention going forward

- **Dispatch input `publish`** = "push to the canonical distribution channel for this platform". Description string carries the platform-specific phrasing. Default `false` everywhere → dispatch never accidentally promotes.
- **Artifact name `<platform>-<kind>`**: `android-aab`, `android-debug-symbols`, `ios-ipa`, `desktop-macos-arm64`, `desktop-windows-x64`, `desktop-linux-x64`. Greppable by platform in the run page.
- **Workflow display `Build & Distribute <Platform>`**: consistent across the three.

The internal directory `android/app/build/outputs/native-debug-symbols/release/` inside the Android build step is the gradle `bundleRelease` output convention — not a name we control, left as-is.

## Test plan

- [ ] `gh workflow run build-desktop.yml --ref main` → builds, no Release created.
- [ ] `gh workflow run build-desktop.yml --ref main -f publish=true` → builds + `desktop-build-N` GitHub Release.
- [ ] `gh workflow run build-android.yml --ref main` → builds AAB, no Play Store upload.
- [ ] `gh workflow run build-android.yml --ref main -f publish=true` → builds + uploads to Play Store internal track.
- [ ] `gh workflow run build-ios.yml --ref main` → builds + TestFlight push (TestFlight is part of the build, always-on by design).
- [ ] `gh workflow run build-ios.yml --ref main -f publish=true` → above + App Store Connect metadata push.
- [ ] Push tag `v0.99.0-rc1` → 3 workflows fire, no store upload, Desktop release marked `--prerelease`.
- [ ] Push tag `v0.99.0` → 3 workflows fire, Play Store + ASC metadata + Desktop Release.