### PR TITLE
feat(ci): sign and notarize macOS desktop app

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -156,15 +156,25 @@ jobs:
       - name: Write App Store Connect API key to file (macOS)
         # Tauri's notarize step uses xcrun notarytool with --key (file path),
         # so we materialize APP_STORE_CONNECT_API_KEY_CONTENT (already used
-        # by iOS) into a temp .p8 file.
+        # by iOS via fastlane) into a temp .p8 file.
+        #
+        # The secret is stored base64-encoded — ios/Fastfile passes it with
+        # is_key_content_base64: true. We decode it here before writing so
+        # the file is real PKCS#8 PEM that notarytool / openssl accept.
+        # Writing the raw base64 produces "invalidAsn1" at notarize time.
         if: matrix.platform == 'macos'
         shell: bash
         env:
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
         run: |
           mkdir -p "$RUNNER_TEMP/asc"
-          printf '%s' "$APP_STORE_CONNECT_API_KEY_CONTENT" > "$RUNNER_TEMP/asc/AuthKey.p8"
+          printf '%s' "$APP_STORE_CONNECT_API_KEY_CONTENT" \
+            | base64 -d > "$RUNNER_TEMP/asc/AuthKey.p8"
           chmod 600 "$RUNNER_TEMP/asc/AuthKey.p8"
+          # Sanity check — fail early with a clear message if the .p8 is
+          # malformed, instead of a cryptic "invalidAsn1" inside Tauri.
+          openssl pkcs8 -in "$RUNNER_TEMP/asc/AuthKey.p8" -inform PEM -nocrypt -noout
+          echo "ASC API key .p8 is valid PKCS#8 PEM"
 
       - name: Build Tauri app (Linux with PipeWire)
         if: matrix.platform == 'linux'

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -205,6 +205,34 @@ jobs:
         shell: bash
         run: cargo tauri build
 
+      - name: Notarize and staple .dmg (macOS)
+        # Tauri notarizes and staples the .app inside the .dmg, but the
+        # .dmg itself is only signed (with the same Developer ID cert) —
+        # not notarized. End users don't actually hit a Gatekeeper prompt
+        # on the .dmg in practice (they open it, drag the .app, run the
+        # .app which carries its own stapled ticket), but Apple's
+        # documented best practice is to notarize the .dmg as well so
+        # online-stapling caches and any Gatekeeper edge case on the .dmg
+        # see a valid ticket.
+        if: matrix.platform == 'macos'
+        shell: bash
+        env:
+          APPLE_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/asc/AuthKey.p8
+        run: |
+          DMG=$(find target/release/bundle/dmg -name "*.dmg" -type f | head -1)
+          if [ -z "$DMG" ]; then
+            echo "::error::No .dmg found to notarize"
+            exit 1
+          fi
+          xcrun notarytool submit "$DMG" \
+            --key "$APPLE_API_KEY_PATH" \
+            --key-id "$APPLE_API_KEY" \
+            --issuer "$APPLE_API_ISSUER" \
+            --wait
+          xcrun stapler staple "$DMG"
+
       - name: Verify macOS signature and Gatekeeper acceptance
         # Fails the build if the .app or .dmg is unsigned, signature is
         # broken, or Gatekeeper rejects it. Catches a regression *before*

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -173,8 +173,10 @@ jobs:
           chmod 600 "$RUNNER_TEMP/asc/AuthKey.p8"
           # Sanity check — fail early with a clear message if the .p8 is
           # malformed, instead of a cryptic "invalidAsn1" inside Tauri.
-          openssl pkcs8 -in "$RUNNER_TEMP/asc/AuthKey.p8" -inform PEM -nocrypt -noout
-          echo "ASC API key .p8 is valid PKCS#8 PEM"
+          # macos-15 runner ships LibreSSL: pkcs8 does not support -noout,
+          # so use pkey which does (and parses PKCS#8 PEM the same way).
+          openssl pkey -in "$RUNNER_TEMP/asc/AuthKey.p8" -noout
+          echo "ASC API key .p8 is valid PEM private key"
 
       - name: Build Tauri app (Linux with PipeWire)
         if: matrix.platform == 'linux'

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -122,18 +122,70 @@ jobs:
         if: matrix.platform == 'macos'
         run: brew install create-dmg
 
+      - name: Import Developer ID Application certificate (macOS)
+        # Imports the .p12 from secrets into a fresh, isolated keychain so
+        # codesign can find the identity without us touching the runner's
+        # login keychain. The keychain disappears with the ephemeral runner;
+        # no explicit cleanup needed.
+        if: matrix.platform == 'macos'
+        shell: bash
+        env:
+          APPLE_DEVELOPER_ID_CERT_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_BASE64 }}
+          APPLE_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
+          APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+        run: |
+          CERT_PATH="$RUNNER_TEMP/DeveloperID.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
+          echo "$APPLE_DEVELOPER_ID_CERT_BASE64" | base64 -d > "$CERT_PATH"
+          security create-keychain -p "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" \
+            -P "$APPLE_DEVELOPER_ID_CERT_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          # Allow codesign / productsign to use the key without a UI prompt.
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # Prepend our keychain to the user search list so codesign finds it.
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '" ')
+          # Sanity check — must show our Developer ID Application identity.
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+          rm -f "$CERT_PATH"
+
+      - name: Write App Store Connect API key to file (macOS)
+        # Tauri's notarize step uses xcrun notarytool with --key (file path),
+        # so we materialize APP_STORE_CONNECT_API_KEY_CONTENT (already used
+        # by iOS) into a temp .p8 file.
+        if: matrix.platform == 'macos'
+        shell: bash
+        env:
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/asc"
+          printf '%s' "$APP_STORE_CONNECT_API_KEY_CONTENT" > "$RUNNER_TEMP/asc/AuthKey.p8"
+          chmod 600 "$RUNNER_TEMP/asc/AuthKey.p8"
+
       - name: Build Tauri app (Linux with PipeWire)
         if: matrix.platform == 'linux'
         working-directory: crates/visio-desktop
         run: cargo tauri build --features pipewire-camera
 
-      - name: Build Tauri app (macOS)
+      - name: Build, sign and notarize Tauri app (macOS)
+        # APPLE_SIGNING_IDENTITY makes Tauri sign with the real Developer ID
+        # cert imported above (instead of the previous "-" ad-hoc identity
+        # that Gatekeeper rejects). APPLE_API_* trigger Tauri's notarytool
+        # submit + staple step automatically — no extra build call needed.
         if: matrix.platform == 'macos'
         working-directory: crates/visio-desktop
         shell: bash
         run: cargo tauri build
         env:
-          APPLE_SIGNING_IDENTITY: "-"
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_SIGNING_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APPLE_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/asc/AuthKey.p8
 
       - name: Build Tauri app (Windows)
         if: matrix.platform == 'windows'
@@ -141,15 +193,30 @@ jobs:
         shell: bash
         run: cargo tauri build
 
-      - name: Inject macOS privacy permissions into Info.plist
+      - name: Verify macOS signature and Gatekeeper acceptance
+        # Fails the build if the .app or .dmg is unsigned, signature is
+        # broken, or Gatekeeper rejects it. Catches a regression *before*
+        # a broken artifact lands in a GitHub Release.
         if: matrix.platform == 'macos'
         shell: bash
         run: |
-          APP_BUNDLE=$(find target/release/bundle -name "*.app" -type d | head -1)
-          if [ -n "$APP_BUNDLE" ]; then
-            /usr/libexec/PlistBuddy -c "Add :NSMicrophoneUsageDescription string 'Visio Mobile needs microphone access for video calls'" "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null || true
-            /usr/libexec/PlistBuddy -c "Add :NSCameraUsageDescription string 'Visio Mobile needs camera access for video calls'" "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null || true
-            echo "Injected privacy descriptions into $APP_BUNDLE/Contents/Info.plist"
+          APP_BUNDLE=$(find target/release/bundle/macos -name "*.app" -type d | head -1)
+          DMG=$(find target/release/bundle/dmg -name "*.dmg" -type f | head -1)
+          if [ -z "$APP_BUNDLE" ]; then
+            echo "::error::No .app bundle found"
+            exit 1
+          fi
+          echo "=== codesign --verify .app ==="
+          codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
+          echo "=== codesign --display .app ==="
+          codesign --display --verbose=4 "$APP_BUNDLE" | head -20
+          echo "=== Gatekeeper assessment (.app) ==="
+          spctl --assess --type execute --verbose=4 "$APP_BUNDLE"
+          if [ -n "$DMG" ]; then
+            echo "=== codesign --verify .dmg ==="
+            codesign --verify --verbose=2 "$DMG"
+            echo "=== Gatekeeper assessment (.dmg) ==="
+            spctl --assess --type install --verbose=4 "$DMG"
           fi
 
       # --- Flatpak build (Linux only, from source in GNOME SDK) ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to
 
 ### Added
 
+- Desktop: the macOS `.app` and `.dmg` are now signed with a real
+  Developer ID Application certificate (Linagora, KUT463DS29) and
+  notarized via Apple's notarytool API. End users no longer see the
+  "unidentified developer" Gatekeeper warning; the app launches by
+  double-click. Hardened runtime is on; the existing camera / mic
+  entitlements (`com.apple.security.device.camera`,
+  `com.apple.security.device.audio-input`) carry the privacy
+  authorizations the app needs.
 - CI: pushing a semver tag (`vX.Y.Z` or `vX.Y.Z-rcN`) now triggers
   the three build workflows automatically. Non-RC tags publish to
   Play Store internal / App Store Connect; RC tags build only.


### PR DESCRIPTION
## Summary

Closes the long-standing audit item 4 (macOS code signing + notarization).

The Desktop `.dmg` / `.app` shipped from CI has been **ad-hoc-signed** (`APPLE_SIGNING_IDENTITY: "-"`) since the workflow was first added. Gatekeeper rejects ad-hoc signatures — end users have to right-click → Open or run `xattr -dr com.apple.quarantine`, which nobody actually does. This PR fixes the chain end-to-end.

## What changes

### Three new pre-build steps (macOS leg only)

1. **Import Developer ID Application certificate** into a fresh, isolated keychain. The `.p12` (cert + private key for Linagora KUT463DS29) is stored as `APPLE_DEVELOPER_ID_CERT_BASE64` + `APPLE_DEVELOPER_ID_CERT_PASSWORD` secrets. Creates the keychain, imports, allows `codesign` access without UI prompt, prepends to user search list. Ephemeral runner → no cleanup.

2. **Write App Store Connect API key to file**. The `.p8` content was already in `APP_STORE_CONNECT_API_KEY_CONTENT` (used by iOS); materialized here so `notarytool` can read it via `--key <path>`.

3. **Build + sign + notarize** in one `cargo tauri build` invocation. `APPLE_SIGNING_IDENTITY` triggers signing with the cert imported above; the four `APPLE_API_*` env vars trigger Tauri's automatic notarytool submit + staple.

### Step removed

- "Inject macOS privacy permissions into Info.plist" — mutated the bundle's `Info.plist` **after** the build, which would now break the signature. Also redundant: the same `NSCameraUsageDescription` / `NSMicrophoneUsageDescription` are already in `crates/visio-desktop/Info.plist` source and bundled by Tauri.

### Step added at the end

- **"Verify macOS signature and Gatekeeper acceptance"** — runs `codesign --verify --deep --strict`, `codesign --display`, and `spctl --assess --type execute` on the `.app` plus `--type install` on the `.dmg`. Fails the build if Gatekeeper would reject the artifact → prevents a broken signing chain from landing in a Release.

## 4 new secrets (already pushed)

| Secret | Source |
|---|---|
| `APPLE_DEVELOPER_ID_CERT_BASE64` | `base64 -i DeveloperID.p12` (locally generated via openssl + Developer ID Application cert from Apple Developer portal) |
| `APPLE_DEVELOPER_ID_CERT_PASSWORD` | `.p12` export password |
| `APPLE_DEVELOPER_ID_SIGNING_IDENTITY` | `Developer ID Application: Linagora (KUT463DS29)` |
| `APPLE_KEYCHAIN_PASSWORD` | `openssl rand -hex 32`, used only for the ephemeral CI keychain |

The existing `APP_STORE_CONNECT_*` secrets (already used by iOS) drive the notarization step.

## What this does NOT change

- Windows signing — separate follow-up (Azure Trusted Signing or DigiCert/SSL.com cert, ~€10/month or ~€500/year).
- Linux artifacts — Flatpak/AppImage/Deb don't need code signing in the same sense.

## Test plan

- [ ] First push to `feat/macos-signing-notarization` triggers Desktop build (no publish flag, so no GitHub Release).
- [ ] macOS leg: "Import Developer ID Application certificate" step succeeds → `security find-identity` shows our cert.
- [ ] macOS leg: "Build, sign and notarize Tauri app" succeeds without env var errors.
- [ ] macOS leg: "Verify macOS signature and Gatekeeper acceptance" — `codesign --verify` passes, `spctl --assess` passes (means Gatekeeper would accept the app without warnings).
- [ ] Linux + Windows legs are unchanged and still pass.
- [ ] Locally: download the `desktop-macos-arm64` artifact from the workflow run, mount the `.dmg`, double-click the `.app` — should open without the "unidentified developer" warning.