### PR TITLE
feat(ci): authenticate Play Store via WIF instead of SA JSON

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -39,6 +39,13 @@ jobs:
     # Tighter than default 6h so a hung step (Tauri DMG-style hang) fails
     # in minutes instead of burning runner hours.
     timeout-minutes: 45
+    # id-token: write is required for google-github-actions/auth to mint a
+    # GitHub OIDC token that GCP STS exchanges for a short-lived access
+    # token (WIF). contents: read overrides the workflow-level default
+    # which gets erased once we set a job-level permissions block.
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: .
@@ -110,14 +117,22 @@ jobs:
           printf '%s' "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" \
             | base64 -d > android/app/release.keystore
 
-      - name: Decode Play Store service account
-        # FIREBASE_SERVICE_ACCOUNT_BASE64 is a legacy secret name from when
-        # we also published via Firebase App Distribution. The JSON it
-        # decodes is now used exclusively for the Play Store Android
-        # Publisher API (supply / SUPPLY_JSON_KEY_PATH below).
-        run: |
-          printf '%s' "${{ secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 }}" \
-            | base64 -d > /tmp/play-sa.json
+      - name: Authenticate to Google Cloud via Workload Identity Federation
+        # Exchanges the job's GitHub OIDC token (id-token: write above) for a
+        # short-lived (~1h) GCP access token bound to the Play Store service
+        # account, then writes an "external account" credentials JSON to a
+        # temp path and exports GOOGLE_APPLICATION_CREDENTIALS pointing at it.
+        # No long-lived JSON private key lives in the secrets anymore.
+        # Gated by the same condition as the upload step below — there's no
+        # value in burning an STS exchange on builds that won't upload.
+        if: >-
+          (github.event_name == 'workflow_dispatch' && inputs.publish == true) ||
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc'))
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_PLAY_STORE_SA }}
+          create_credentials_file: true
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -146,7 +161,10 @@ jobs:
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-rc'))
         working-directory: android
         env:
-          SUPPLY_JSON_KEY_PATH: /tmp/play-sa.json
+          # google-github-actions/auth above sets GOOGLE_APPLICATION_CREDENTIALS
+          # to a temp external-account JSON. Fastlane supply accepts that
+          # path the same way it accepts a service-account JSON.
+          SUPPLY_JSON_KEY_PATH: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
         run: bundle exec fastlane release
 
       - name: Package native debug symbols

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to
 
 ### Added
 
+- CI: Android publish authenticates to Play Store via Google Cloud
+  Workload Identity Federation instead of a long-lived service-account
+  JSON. The job mints a GitHub OIDC token, GCP STS exchanges it for a
+  ~1h access token bound to the Play Store SA. No JSON private key is
+  stored in repo secrets. `FIREBASE_SERVICE_ACCOUNT_BASE64` is now
+  unused and will be removed once the next publish run confirms WIF
+  works end-to-end.
 - Desktop: the macOS `.app` and `.dmg` are now signed with a real
   Developer ID Application certificate (Linagora, KUT463DS29) and
   notarized via Apple's notarytool API. End users no longer see the


### PR DESCRIPTION
## Summary

Closes the long-standing audit item 5 (Workload Identity Federation for Play Store SA).

The Android workflow's `Upload AAB to Google Play (internal track)` step used to consume `FIREBASE_SERVICE_ACCOUNT_BASE64` — a base64-encoded service-account JSON containing a long-lived RSA private key. If that secret leaked, anyone could publish to our Play Store internal track until rotated.

This PR replaces that with Workload Identity Federation: GitHub Actions mints an OIDC token, GCP STS exchanges it for a ~1h access token bound to the same Play Store SA, and Fastlane uses the resulting external-account credentials. No private key in repo secrets anymore.

## Mechanism

```
GitHub OIDC token
  └─ assertion.repository = "mmaudet/visio-mobile"
     └─ GCP STS verifies via WIF Provider:
        - Issuer URL matches token.actions.githubusercontent.com
        - attribute-condition: assertion.repository == "mmaudet/visio-mobile"
     └─ Returns ~1h access token impersonating
        firebase-adminsdk-fbsvc@visio-mobile-android.iam.gserviceaccount.com
        └─ Fastlane supply uploads AAB to Play Store internal track
```

## GCP-side setup (already done in Cloud Shell, separate from this PR)

```bash
gcloud iam workload-identity-pools create "github-actions" --location=global
gcloud iam workload-identity-pools providers create-oidc "github" \
  --workload-identity-pool="github-actions" \
  --attribute-condition="assertion.repository == 'mmaudet/visio-mobile'" \
  --issuer-uri="https://token.actions.githubusercontent.com"
gcloud iam service-accounts add-iam-policy-binding \
  "firebase-adminsdk-fbsvc@visio-mobile-android.iam.gserviceaccount.com" \
  --role="roles/iam.workloadIdentityUser" \
  --member="principalSet://...attribute.repository/mmaudet/visio-mobile"
```

## Secrets changes

| Secret | Status | Why |
|---|---|---|
| `FIREBASE_SERVICE_ACCOUNT_BASE64` | **kept this PR, delete next** | Safety net during the WIF transition. Will be deleted after one successful `publish=true` run via WIF. |
| `GCP_WIF_PROVIDER` | **added** | Resource name of the WIF provider. Identifier, not a key. |
| `GCP_PLAY_STORE_SA` | **added** | Email of the SA to impersonate. Identifier, not a key. |

## What this does NOT change

- Same SA (`firebase-adminsdk-fbsvc@visio-mobile-android`) with the same Play Store roles — only the authentication mechanism changed. This SA is the legacy Firebase admin SA; switching to a least-privilege "Play Store Publisher only" SA is a follow-up worth doing.
- Same `publish` input gating. The auth step has the same `if:` as the upload step — dispatches without `publish=true` and RC tags don't burn an STS exchange.

## Test plan

The Android upload-key reset is still propagating Google-side (~16h elapsed, SLA up to 72h), so the actual Play Store upload is still blocked by that — unrelated to this PR. WIF can be tested in 3 layers:

- [ ] **Layer 1 — Branch dispatch without publish**: `gh workflow run build-android.yml --ref feat/android-wif-google-play` → builds AAB, the WIF auth step is skipped (gated), upload step is skipped. Should still pass.
- [ ] **Layer 2 — Branch dispatch with publish=true** → builds AAB, the WIF auth step actually runs and mints the GCP token, upload step starts but probably still fails on the upload-key validity error (Google-side). The point is to confirm the WIF step itself succeeds.
- [ ] **Layer 3 — After Google propagates** the upload key reset, full end-to-end: AAB uploaded to Play Store internal track via WIF. Then delete `FIREBASE_SERVICE_ACCOUNT_BASE64`.