### PR TITLE
feat(ci): attest SLSA build provenance on shipping artifacts

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -39,13 +39,22 @@ jobs:
     # Tighter than default 6h so a hung step (Tauri DMG-style hang) fails
     # in minutes instead of burning runner hours.
     timeout-minutes: 45
-    # id-token: write is required for google-github-actions/auth to mint a
-    # GitHub OIDC token that GCP STS exchanges for a short-lived access
-    # token (WIF). contents: read overrides the workflow-level default
-    # which gets erased once we set a job-level permissions block.
+    # Three job-level permission needs cumulated here:
+    # - contents: read       — restore the workflow-level default that
+    #   gets erased once we set a job-level permissions block.
+    # - id-token: write      — google-github-actions/auth mints a GitHub
+    #   OIDC token; GCP STS exchanges it for a ~1h access token bound
+    #   to the Play Store service account (WIF). The same token is
+    #   also used by attest-build-provenance below as the Sigstore
+    #   subject.
+    # - attestations: write  — actions/attest-build-provenance pushes
+    #   a signed SLSA build provenance attestation to the repo's
+    #   attestations endpoint, so anyone can verify a published AAB
+    #   really came from this commit via `gh attestation verify`.
     permissions:
       contents: read
       id-token: write
+      attestations: write
     defaults:
       run:
         working-directory: .
@@ -194,6 +203,16 @@ jobs:
           name: android-aab
           path: ${{ steps.find-aab.outputs.aab_path }}
           retention-days: 14
+
+      - name: Attest AAB build provenance
+        # SLSA build provenance: signs an attestation that this AAB came
+        # from this commit on this workflow. Stored against the repo;
+        # verifiable with `gh attestation verify <file> --repo <repo>`.
+        # Skipped if the AAB build failed (no point attesting a missing file).
+        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
+        if: steps.find-aab.outputs.aab_path != ''
+        with:
+          subject-path: ${{ steps.find-aab.outputs.aab_path }}
 
       - name: Upload native debug symbols
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -54,6 +54,15 @@ jobs:
     # Linux Tauri (webrtc-sys + flatpak) is the long pole at ~20-30 min;
     # cap at 60 so a hung step fails in minutes.
     timeout-minutes: 60
+    # id-token + attestations enable SLSA build provenance: the runner
+    # mints an OIDC token, Sigstore signs an attestation over each
+    # artifact hash, and the result is stored against the repo so
+    # anyone can verify "this .dmg / .msi / .deb really came from this
+    # commit on this workflow" via `gh attestation verify`.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     defaults:
       run:
         working-directory: .
@@ -300,6 +309,15 @@ jobs:
             target/release/bundle/macos/*.app.tar.gz.sig
           retention-days: 14
 
+      - name: Attest macOS build provenance
+        # SLSA build provenance for the shipping .dmg. The .app.tar.gz
+        # and .sig are the Tauri updater bundle — internal mechanism,
+        # not directly distributed, so left out of the attestation.
+        if: matrix.platform == 'macos'
+        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
+        with:
+          subject-path: target/release/bundle/dmg/*.dmg
+
       - name: Upload Windows artifacts
         if: matrix.platform == 'windows'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
@@ -309,6 +327,17 @@ jobs:
             target/release/bundle/msi/*.msi
             target/release/bundle/nsis/*.exe
           retention-days: 14
+
+      - name: Attest Windows build provenance
+        # SLSA build provenance for both Windows distribution formats:
+        # the WiX .msi (preferred for admin install) and the NSIS .exe
+        # (preferred for user-mode install).
+        if: matrix.platform == 'windows'
+        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
+        with:
+          subject-path: |
+            target/release/bundle/msi/*.msi
+            target/release/bundle/nsis/*.exe
 
       - name: Upload Linux artifacts
         if: matrix.platform == 'linux'
@@ -320,6 +349,18 @@ jobs:
             target/release/bundle/deb/*.deb
             target/release/bundle/flatpak/*.flatpak
           retention-days: 14
+
+      - name: Attest Linux build provenance
+        # SLSA build provenance for the three Linux distribution
+        # formats we ship: AppImage (portable), .deb (Debian/Ubuntu),
+        # .flatpak (Flathub-ready).
+        if: matrix.platform == 'linux'
+        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
+        with:
+          subject-path: |
+            target/release/bundle/appimage/*.AppImage
+            target/release/bundle/deb/*.deb
+            target/release/bundle/flatpak/*.flatpak
 
   # --- GitHub Release with all artifacts ---
   release:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -31,6 +31,15 @@ jobs:
     # ~15-25 min healthy. Cap at 60 to absorb a slow ASC upload retry
     # without ever burning the default 6h.
     timeout-minutes: 60
+    # id-token + attestations enable SLSA build provenance: the runner
+    # mints an OIDC token, Sigstore signs an attestation over the
+    # artifact hash, and the result is stored against the repo so
+    # anyone can verify "this IPA really came from this commit on
+    # this workflow" via `gh attestation verify`.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     defaults:
       run:
         working-directory: .
@@ -107,3 +116,13 @@ jobs:
           name: ios-ipa
           path: ios/build/VisioMobile.ipa
           retention-days: 14
+
+      - name: Attest IPA build provenance
+        # SLSA build provenance: signs an attestation that this IPA came
+        # from this commit on this workflow. Stored against the repo;
+        # verifiable with `gh attestation verify <file> --repo <repo>`.
+        # No `if: always()` — there's no point attesting a missing IPA
+        # if the build failed.
+        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
+        with:
+          subject-path: ios/build/VisioMobile.ipa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to
   stored in repo secrets. `FIREBASE_SERVICE_ACCOUNT_BASE64` is now
   unused and will be removed once the next publish run confirms WIF
   works end-to-end.
+- CI: every shipping artifact (`.aab`, `.ipa`, `.dmg`, `.msi`, `.exe`,
+  `.AppImage`, `.deb`, `.flatpak`) now ships with a signed SLSA build
+  provenance attestation. Anyone can verify a binary really came from
+  this repo at a given commit with `gh attestation verify <file>
+  --repo mmaudet/visio-mobile`. The attestations live in the GitHub
+  attestations store (also pushed to Sigstore Rekor public ledger),
+  no extra files in releases. This puts the build at SLSA Level 3.
 - Desktop: the macOS `.app` and `.dmg` are now signed with a real
   Developer ID Application certificate (Linagora, KUT463DS29) and
   notarized via Apple's notarytool API. End users no longer see the


### PR DESCRIPTION
## Summary

Closes the long-standing audit follow-up: SLSA provenance.

Add `actions/attest-build-provenance@v4` (SHA-pinned) after each upload step in the three build workflows. Every shipping binary now ships with a cryptographic attestation that proves:

- **What commit** the artifact was built from
- **What workflow + run ID** produced it
- **When** (signed timestamp)
- **By the GitHub-hosted runner** (not by a maintainer's laptop)

End-user verification, once they have the file:

```bash
gh attestation verify Visio_Mobile_0.10.0_aarch64.dmg --repo mmaudet/visio-mobile
# Loaded digest sha256:abc...123 for file:///Users/.../Visio_Mobile_0.10.0_aarch64.dmg
# Loaded 1 attestation from GitHub API
# ✓ Verification succeeded!
# Issuer: https://token.actions.githubusercontent.com
# Predicate type: https://slsa.dev/provenance/v1
# Source: commit cbb14797 on mmaudet/visio-mobile via .github/workflows/build-desktop.yml
```

No secret is required to verify — the signature chains to Sigstore's public root.

## Coverage

| Workflow | Artifact attested |
|---|---|
| `build-android.yml` | `app-release.aab` |
| `build-ios.yml` | `VisioMobile.ipa` |
| `build-desktop.yml` (macOS leg) | `*.dmg` |
| `build-desktop.yml` (Windows leg) | `*.msi`, `*.exe` (NSIS) |
| `build-desktop.yml` (Linux leg) | `*.AppImage`, `*.deb`, `*.flatpak` |

**Intentionally not attested**: `android-debug-symbols.zip` (debugging only, not shipping) and `*.app.tar.gz` / `*.sig` (Tauri updater bundle, internal mechanism).

## Permissions changes

Per-job permissions added to each build job:

```yaml
permissions:
  contents: read       # was workflow-level, restored here since job-level overrides
  id-token: write      # mint a GitHub OIDC token Sigstore can verify
  attestations: write  # push the resulting attestation to the repo's attestations API
```

Same model the WIF PR (#215) uses for GCP auth on Android — once a job needs `id-token: write`, it's job-level.

## SLSA level achieved

Combined with PR #214 (macOS Developer ID signing + notarization), this places the build at **SLSA Build Level 3**:

| Level | Requirement | How we meet it |
|---|---|---|
| L1 | Build process is documented | Workflows in `.github/workflows/` |
| L1 | Provenance is generated | `attest-build-provenance` |
| L2 | Provenance is signed | Sigstore Fulcio cert (OIDC, short-lived) |
| L2 | Hosted build service | GitHub-hosted runners |
| L3 | Build runs hermetically | GitHub-hosted runners are ephemeral |
| L3 | Workflow is immutable during the build | We pin `actions/checkout` to `${{ github.sha }}` (PR earlier) |
| L4 | Two-person review for trusted lane | Out of scope; would need branch protection rule with required reviewers |

## Test plan

- [ ] PR's CI passes (Linux + Windows builds will exercise the attest step on every dispatch; macOS needs a successful sign + notarize chain too).
- [ ] After merge, dispatch the desktop workflow and download a `.dmg`. Run `gh attestation verify <dmg> --repo mmaudet/visio-mobile` → expect "✓ Verification succeeded".
- [ ] Same for Android `.aab`.
- [ ] Same for iOS `.ipa`.