### PR TITLE
fix(metadata): rewrite iOS release notes for 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,14 @@ and this project adheres to
   Future SHA bumps for `dtolnay/rust-toolchain` or
   `Swatinem/rust-cache` are a one-file edit.
 
+### Fixed
+
+- iOS: App Store metadata. Release notes for all 6 locales now
+  describe 0.10.0 (OAuth 2.0 + PKCE, encrypted Keychain storage,
+  hardened HTTPS, security audits) instead of carrying the stale
+  0.9.0 changelog. Unblocks the Apple submission that was rejected
+  under Guideline 2.3.10 on 2026-06-05.
+
 ## [0.10.0] - 2026-06-04
 
 ### Added

--- a/ios/fastlane/metadata/de-DE/release_notes.txt
+++ b/ios/fastlane/metadata/de-DE/release_notes.txt
@@ -1,11 +1,6 @@
-Neu in Version 0.9.0:
-- Paginiertes Videoraster mit wischbaren Seiten
-- Sprechermodus mit dominantem Sprecher
-- Intelligente Video-Abonnements mit Anti-Jitter
-- Ende-zu-Ende-verschlüsselter Chat (AES-256-GCM)
-- Dynamische Feature-Flags über Unleash-Proxy
-- Verbesserte Wiederverbindung mit Token-Cache
-- Verbesserte Bluetooth-Audio-Routing-Zuverlässigkeit
-- Teilnehmer-Sortierung nach Sprachaktivität mit Anti-Flicker
-- Bildschirmfreigabe immer in hoher Qualität
-- Übersetzungs-Pipeline und 100% i18n-Abdeckung
+Neu in Version 0.10.0:
+- Sichere Anmeldung über OAuth 2.0 mit PKCE-Authentifizierung
+- Verschlüsselte Anmeldedaten-Speicherung im iOS-Schlüsselbund
+- Verstärkte Netzwerksicherheit (striktes HTTPS, keine Umleitungen)
+- Drei unabhängige Sicherheitsaudits veröffentlicht
+- Verschiedene Stabilitäts- und Leistungsverbesserungen

--- a/ios/fastlane/metadata/en-US/release_notes.txt
+++ b/ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,11 +1,6 @@
-What's new in 0.9.0:
-- Paginated video grid with swipeable pages
-- Speaker mode with dominant speaker tile
-- Smart video subscriptions with anti-jitter delays
-- End-to-end encrypted chat (AES-256-GCM)
-- Runtime feature flags via Unleash proxy
-- Improved reconnection with token cache
-- Bluetooth audio routing reliability improvements
-- Voice-activity participant sorting with anti-flicker
-- Screen share always at high quality
-- Translation pipeline and 100% i18n coverage
+What's new in 0.10.0:
+- Secure OAuth 2.0 login with PKCE authentication
+- Encrypted credential storage in the iOS Keychain
+- Hardened network security (strict HTTPS, no redirects)
+- Three independent security audits published
+- Various stability and performance improvements

--- a/ios/fastlane/metadata/es-ES/release_notes.txt
+++ b/ios/fastlane/metadata/es-ES/release_notes.txt
@@ -1,11 +1,6 @@
-Novedades de la versión 0.9.0:
-- Cuadrícula de vídeo paginada con páginas deslizantes
-- Modo ponente con orador dominante
-- Suscripciones de vídeo inteligentes con anti-jitter
-- Chat cifrado de extremo a extremo (AES-256-GCM)
-- Feature flags dinámicos vía proxy Unleash
-- Reconexión mejorada con caché de tokens
-- Mejoras en la fiabilidad del enrutamiento de audio Bluetooth
-- Ordenación de participantes por actividad de voz con anti-parpadeo
-- Pantalla compartida siempre en alta calidad
-- Pipeline de traducción y cobertura i18n al 100%
+Novedades de la versión 0.10.0:
+- Inicio de sesión seguro con OAuth 2.0 y autenticación PKCE
+- Almacenamiento cifrado de credenciales en el Llavero iOS
+- Seguridad de red reforzada (HTTPS estricto, sin redirecciones)
+- Tres auditorías de seguridad independientes publicadas
+- Diversas mejoras de estabilidad y rendimiento

--- a/ios/fastlane/metadata/fr-FR/release_notes.txt
+++ b/ios/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,11 +1,6 @@
-Nouveautés de la version 0.9.0 :
-- Grille vidéo paginée avec pages glissantes
-- Mode intervenant avec locuteur dominant
-- Abonnements vidéo intelligents avec anti-saccades
-- Chat chiffré de bout en bout (AES-256-GCM)
-- Feature flags dynamiques via proxy Unleash
-- Reconnexion améliorée avec cache de tokens
-- Fiabilité améliorée du routage audio Bluetooth
-- Tri des participants par activité vocale avec anti-clignotement
-- Partage d'écran toujours en haute qualité
-- Pipeline de traduction et couverture i18n à 100%
+Nouveautés de la version 0.10.0 :
+- Connexion sécurisée par OAuth 2.0 avec authentification PKCE
+- Stockage chiffré des identifiants dans le Trousseau iOS
+- Sécurité réseau renforcée (HTTPS strict, sans redirections)
+- Trois audits de sécurité indépendants publiés
+- Diverses améliorations de stabilité et de performance

--- a/ios/fastlane/metadata/it/release_notes.txt
+++ b/ios/fastlane/metadata/it/release_notes.txt
@@ -1,11 +1,6 @@
-Novità della versione 0.9.0:
-- Griglia video paginata con pagine scorrevoli
-- Modalità relatore con oratore dominante
-- Abbonamenti video intelligenti con anti-jitter
-- Chat crittografata end-to-end (AES-256-GCM)
-- Feature flag dinamici tramite proxy Unleash
-- Riconnessione migliorata con cache token
-- Migliorata affidabilità routing audio Bluetooth
-- Ordinamento partecipanti per attività vocale con anti-flicker
-- Condivisione schermo sempre in alta qualità
-- Pipeline di traduzione e copertura i18n al 100%
+Novità della versione 0.10.0:
+- Accesso sicuro con OAuth 2.0 e autenticazione PKCE
+- Archiviazione cifrata delle credenziali nel Portachiavi iOS
+- Sicurezza di rete rafforzata (HTTPS rigoroso, senza reindirizzamenti)
+- Tre audit di sicurezza indipendenti pubblicati
+- Diversi miglioramenti di stabilità e prestazioni

--- a/ios/fastlane/metadata/nl-NL/release_notes.txt
+++ b/ios/fastlane/metadata/nl-NL/release_notes.txt
@@ -1,11 +1,6 @@
-Nieuw in versie 0.9.0:
-- Gepagineerd videoraster met veegbare pagina's
-- Sprekermodus met dominante spreker
-- Slimme video-abonnementen met anti-jitter
-- End-to-end versleutelde chat (AES-256-GCM)
-- Dynamische feature flags via Unleash-proxy
-- Verbeterde herverbinding met tokencache
-- Verbeterde betrouwbaarheid Bluetooth-audioroutering
-- Deelnemersortering op spraakactiviteit met anti-flicker
-- Schermdeling altijd in hoge kwaliteit
-- Vertaalpijplijn en 100% i18n-dekking
+Nieuw in versie 0.10.0:
+- Veilige aanmelding met OAuth 2.0 en PKCE-authenticatie
+- Versleutelde opslag van inloggegevens in de iOS-Sleutelhanger
+- Versterkte netwerkbeveiliging (strikt HTTPS, geen omleidingen)
+- Drie onafhankelijke beveiligingsaudits gepubliceerd
+- Diverse stabiliteits- en prestatieverbeteringen


### PR DESCRIPTION
## Summary

Apple rejected the build 110 submission on **2026-06-05** (Guideline 2.3.10 - Performance - Accurate Metadata) for references to a third-party platform in the What's New text.

Investigation showed the on-disk `release_notes.txt` files were already clean of any third-party mention (commit `ee6bb3d` from April removed them all). What was NOT clean is that they still described **0.9.0** features ("Paginated video grid", "Speaker mode", "Smart subscriptions"…) while we submitted a **0.10.0** build. Apple's reviewer may have keyed off a stale localization, a cached What's New value in ASC, or simply rejected because the text didn't match the version. Either way the cleanest unblock is to ship release notes that actually describe 0.10.0.

## Content (same 5 bullets across all 6 languages)

```
- Secure OAuth 2.0 login with PKCE authentication
- Encrypted credential storage in the iOS Keychain
- Hardened network security (strict HTTPS, no redirects)
- Three independent security audits published
- Various stability and performance improvements
```

Rules followed:
- Zero mention of any third-party platform name.
- No internal-only terminology (FFI, UniFFI, "rotating refresh tokens").
- No mention of the `docs/security/` paths (App Store users don't have a repo).
- Same five bullets in all six languages so any localization difference is purely translation, not feature drift.
- Aligned with what 0.10.0 actually shipped per the repo CHANGELOG.

## Next steps after merge

1. **Re-dispatch the iOS workflow with `publish=true`** on `main`. Fastlane will:
   - Upload a new build (111) to TestFlight.
   - Push the updated metadata to ASC (these new release notes).
2. **Go back to ASC** → Visio Mobile → Distribution → 0.10.0 → click "Soumettre à nouveau à l'équipe de vérification des apps".
3. Apple's review on resubmission is typically faster (~24h since they already know the app).

## Test plan

- [ ] No "android" / "google play" / "windows" / "linux" string survives in `ios/fastlane/metadata/`.
- [ ] All 6 release_notes.txt files start with the localized equivalent of "What's new in 0.10.0".
- [ ] After merge + re-dispatch + resubmission, App Store review accepts (or sends a different rejection — at which point this PR's premise was correct that the Android wording was the only blocker).