### PR TITLE
fix(desktop): iter-18 — trigger TCC request to break empty Settings loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,16 @@ and this project adheres to
 
 ### Fixed
 
+- Desktop (macOS): screen sharing now recovers from the "empty
+  Settings list" loop. When `CGPreflightScreenCaptureAccess()`
+  reports no permission, the app now calls
+  `CGRequestScreenCaptureAccess()` before its restart modal so
+  macOS creates the TCC entry tied to the current binary's cdhash.
+  Previously, on a fresh install or after a code-signing identity
+  change, the System Settings → Screen Recording list was empty
+  and the user had no toggle to flip. The app appeared installed,
+  the modal said "enable in Settings", and Settings showed nothing
+  to enable.
 - Core: `scheme_for` now parses bare hosts via `IpAddr` so
   `10.attacker.com` no longer downgrades to plaintext HTTP, and
   IPv6 literals (`::1`, `[::1]:8080`) are handled correctly

--- a/crates/visio-desktop/frontend/e2e/tauri-mock.ts
+++ b/crates/visio-desktop/frontend/e2e/tauri-mock.ts
@@ -207,6 +207,14 @@ export async function mockTauriCall(
             return state.videoInputDevices;
           case 'list_screen_sources':
             return state.screenSources;
+          case 'has_screen_recording_permission':
+            return true;
+          case 'request_screen_recording_permission':
+            return true;
+          case 'open_screen_recording_settings':
+            return;
+          case 'restart_app':
+            return;
           case 'toggle_mic':
             micEnabled = args?.enabled ?? !micEnabled;
             return;

--- a/crates/visio-desktop/frontend/src/screens/CallScreen.tsx
+++ b/crates/visio-desktop/frontend/src/screens/CallScreen.tsx
@@ -1519,19 +1519,26 @@ export function CallScreen(props: CallScreenProps) {
       invoke('stop_screen_share').catch(() => {})
       return
     }
-    // Permission gating, take three.
+    // Permission gating, take four.
     //
     // iter-13 raced our modal with the macOS native dialog (double prompt).
     // iter-15 dropped the preflight, opening the picker even when xcap can
-    // only see monitors → user clicks Screen 1 → start_screen_share runs →
-    // macOS shows its "permission required" dialog at capture time and the
-    // share never starts.
+    // only see monitors. iter-16 restored CGPreflight as the strict gate.
     //
-    // The cleanest gate is still CGPreflightScreenCaptureAccess: it returns
-    // true iff the user has the toggle ON in Réglages Système →
-    // Confidentialité → Enregistrement de l'écran AND the running process
-    // started after that grant. We trust it: if it's false we never call
-    // xcap at all and instead show our restart-required modal once.
+    // iter-17 reports surfaced a stuck state: on a fresh install (or after
+    // `tccutil reset ScreenCapture io.visio.desktop`, or after a code-signing
+    // identity change between two installed builds), the TCC database has
+    // *no* entry for our bundle. CGPreflight returns false, we show the
+    // restart modal, the user opens Settings → and the Screen Recording list
+    // is empty: there is no toggle to flip because no entry has ever been
+    // recorded for the current cdhash. They restart, retry, same loop.
+    //
+    // iter-18 fix: when preflight reports false, call
+    // CGRequestScreenCaptureAccess() first. That call creates the TCC entry
+    // tied to the current binary's cdhash and, if the entry is new, surfaces
+    // the macOS native consent dialog. Either way, Settings will from now on
+    // show a Visio Mobile toggle the user can manage. After they respond we
+    // still need a process restart for the grant to take effect.
     let hasPerm = false
     try {
       hasPerm = await invoke<boolean>('has_screen_recording_permission')
@@ -1540,6 +1547,11 @@ export function CallScreen(props: CallScreenProps) {
       hasPerm = false
     }
     if (!hasPerm) {
+      try {
+        await invoke('request_screen_recording_permission')
+      } catch (e) {
+        console.error('request_screen_recording_permission failed:', e)
+      }
       const ok = await confirm({
         title: t('share.permission.title'),
         message: t('share.permission.message'),


### PR DESCRIPTION
## Summary

- Fixes the macOS screen-share stuck state where users land in an infinite "Settings shows empty list" loop.
- Frontend now calls `request_screen_recording_permission` before showing the restart modal, so macOS creates the TCC entry tied to the current binary's cdhash.
- Playwright Tauri mock updated to handle the screen-recording commands (current e2e tests would otherwise hit the modal path).

## Repro of the bug (iter-17)

1. Install a build of Visio Mobile signed with identity A (or unsigned dev build).
2. Grant screen recording for it in System Settings.
3. Install iter-17, signed with identity B (Developer ID + notarization).
4. Open a call, click Partager.
5. App shows "Autorisation requise" modal → click "Ouvrir Réglages et relancer".
6. Settings opens to Screen Recording → list is empty (or shows a stale entry the toggle of which does nothing).
7. App restarts. Same modal. Loop.

The root cause is that macOS keys TCC entries on the executable's cdhash. When the cdhash changes between two installs of the same bundle ID, the existing entry no longer applies and `CGPreflightScreenCaptureAccess()` returns false — but the user has no way to grant permission because no flow ever calls `CGRequestScreenCaptureAccess()`, which is what actually creates the TCC entry surfaced as a togglable row in Settings.

Confirmed today on Michel's MacBook against iter-17 with cdhash `b98016c8…` and signing identity `Developer ID Application: Linagora (KUT463DS29)`.

## Fix

```diff
 if (!hasPerm) {
+  try {
+    await invoke('request_screen_recording_permission')
+  } catch (e) {
+    console.error('request_screen_recording_permission failed:', e)
+  }
   const ok = await confirm({ title: 'Autorisation requise', ... })
   ...
 }
```

The `request_screen_recording_permission` Tauri command was already exposed in `lib.rs` (binding to `CGRequestScreenCaptureAccess`) but never called from anywhere — that omission is iter-17's gap.

We `await` the request so the native macOS dialog cannot race the in-app modal (the iter-13 double-prompt issue). After the user responds to the native dialog, our modal walks them through verifying the toggle and restarting the process so the new permission takes effect at the next process start (which is when TCC grants are read on macOS).

## Test plan

- [ ] CI green (Playwright e2e suite — mocks now handle the new and existing screen-recording commands).
- [ ] Manual on macOS Sequoia 15 with fresh install (no prior TCC entry): clicking Partager triggers the native consent dialog. Click Allow → Settings shows Visio Mobile toggled ON → restart → picker opens with the source list.
- [ ] Manual on macOS after `tccutil reset ScreenCapture io.visio.desktop`: same as above.
- [ ] Manual when user clicks Deny on the native dialog: in-app modal still shows, "Ouvrir Réglages et relancer" opens Settings → user can toggle ON manually → restart → picker opens.
- [ ] No regression on path where permission was already granted before launch: picker opens immediately, no extra dialog.