### PR TITLE
fix(desktop): surface an error when the OIDC callback never arrives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ and this project adheres to
 - Desktop: explicit type="button" on all buttons (SonarCloud S9011)
 - Desktop: reduced function nesting in search/access handlers
   (SonarCloud S2004)
+- Desktop: OIDC sign-in now shows a clear error after a 2-minute
+  timeout instead of waiting forever when the Meet instance does not
+  support the PKCE mobile flow (no deployed instance has it yet)
 
 ## [0.10.0] - 2026-06-04
 

--- a/crates/visio-desktop/frontend/e2e/auth-required.spec.ts
+++ b/crates/visio-desktop/frontend/e2e/auth-required.spec.ts
@@ -120,4 +120,23 @@ test.describe('Join flow requiring OIDC authentication', () => {
     // instead of staying stuck on "Authenticating…" forever.
     await expect(signInButton(page)).toBeVisible();
   });
+
+  test('shows an error and recovers when the OIDC callback never arrives', async ({
+    page,
+  }) => {
+    // Shorten the app-side callback timeout for the test (the production
+    // value is 120 s — the app honors this test hook).
+    await page.evaluate(() => {
+      (window as any).__OIDC_TIMEOUT_MS = 500;
+    });
+    await signInButton(page).click();
+
+    // No deep link ever arrives (e.g. an instance without PKCE support):
+    // the app must surface an error and offer sign-in again instead of
+    // waiting silently forever.
+    await expect(page.getByTestId('home-auth-error')).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(signInButton(page)).toBeVisible();
+  });
 });

--- a/crates/visio-desktop/frontend/src/App.tsx
+++ b/crates/visio-desktop/frontend/src/App.tsx
@@ -231,6 +231,11 @@ const SUPPORTED_LANGS = Object.keys(translations)
 
 const SLUG_REGEX = /^[a-z]{3}-[a-z]{4}-[a-z]{3}$/
 
+// How long the desktop waits for the visio://auth-callback deep link after
+// opening the browser before surfacing an error (instances without PKCE
+// support never redirect back).
+const OIDC_CALLBACK_TIMEOUT_MS = 120_000
+
 function extractSlug(input: string): string | null {
   const trimmed = input.trim().replace(/\/$/, '')
   const candidate = trimmed.includes('/')
@@ -831,6 +836,7 @@ function HomeView({
   authenticatedMeetInstance,
   displayNameFromOidc,
   emailFromOidc,
+  authError,
   onLaunchOidc,
   onLogout,
   meetInstances,
@@ -854,6 +860,7 @@ function HomeView({
   authenticatedMeetInstance: string
   displayNameFromOidc: string
   emailFromOidc: string
+  authError: string | null
   onLaunchOidc: (meetInstance: string) => void
   onLogout: () => void
   meetInstances: string[]
@@ -1413,6 +1420,11 @@ function HomeView({
               </button>
             )}
             <div className="error-msg">{error}</div>
+            {authError && (
+              <div className="error-msg" data-testid="home-auth-error">
+                {t(authError)}
+              </div>
+            )}
             {visioHistory.length > 0 && (
               <div className="room-history">
                 <h4>{t('home.recentRooms')}</h4>
@@ -4902,6 +4914,9 @@ export default function App() {
   const [authenticatedMeetInstance, setAuthenticatedMeetInstance] = useState('')
   const [meetInstances, setMeetInstances] = useState<string[]>([])
   const pendingOidcRef = useRef<string | null>(null)
+  // Error key shown when the OIDC callback never arrives (watchdog timeout).
+  const [authError, setAuthError] = useState<string | null>(null)
+  const oidcTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   // One-shot action run once the OIDC flow settles — after a successful code
   // exchange, or after a launch/exchange failure so the UI recovers (e.g.
   // HomeView re-validating a room that required authentication).
@@ -4977,6 +4992,11 @@ export default function App() {
           const meetInstance = pendingOidcRef.current
           if (code && stateParam && meetInstance) {
             pendingOidcRef.current = null
+            if (oidcTimeoutRef.current) {
+              clearTimeout(oidcTimeoutRef.current)
+              oidcTimeoutRef.current = null
+            }
+            setAuthError(null)
             invoke<{
               display_name?: string
               email?: string
@@ -5673,10 +5693,26 @@ export default function App() {
               authenticatedMeetInstance={authenticatedMeetInstance}
               displayNameFromOidc={displayNameFromOidc}
               emailFromOidc={emailFromOidc}
+              authError={authError}
               onLaunchOidc={async (meetInstance: string) => {
                 try {
                   pendingOidcRef.current = meetInstance
+                  setAuthError(null)
                   await invoke('launch_oidc_browser', { meetInstance })
+                  // Watchdog: if no auth-callback deep link arrives in time
+                  // (e.g. an instance without PKCE support, which never
+                  // redirects back), stop waiting and tell the user instead
+                  // of hanging on "Authenticating…" forever.
+                  const timeoutOverride = (
+                    window as unknown as { __OIDC_TIMEOUT_MS?: number }
+                  ).__OIDC_TIMEOUT_MS
+                  oidcTimeoutRef.current = setTimeout(() => {
+                    if (pendingOidcRef.current) {
+                      pendingOidcRef.current = null
+                      setAuthError('home.authTimeout')
+                      postAuthActionRef.current?.()
+                    }
+                  }, timeoutOverride ?? OIDC_CALLBACK_TIMEOUT_MS)
                 } catch (e) {
                   console.error('Failed to open browser for OIDC:', e)
                   pendingOidcRef.current = null

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -14,6 +14,7 @@
   "home.room.authRequired": "Authentifizierung erforderlich",
   "home.room.authenticating": "Authentifizierung...",
   "home.signIn": "Anmelden",
+  "home.authTimeout": "Keine Antwort vom Server — diese Instanz unterstützt die mobile Anmeldung möglicherweise noch nicht. Bitte versuchen Sie es erneut.",
   "action.close": "Schließen",
   "action.back": "Zurück",
   "action.remove": "Entfernen",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -14,6 +14,7 @@
   "home.room.authRequired": "Authentication required",
   "home.room.authenticating": "Authenticating...",
   "home.signIn": "Sign in",
+  "home.authTimeout": "No answer from the server — this instance may not support mobile sign-in yet. Please try again.",
   "action.close": "Close",
   "action.back": "Back",
   "action.remove": "Remove",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -14,6 +14,7 @@
   "home.room.authRequired": "Autenticación requerida",
   "home.room.authenticating": "Autenticando...",
   "home.signIn": "Iniciar sesión",
+  "home.authTimeout": "Sin respuesta del servidor: es posible que esta instancia aún no admita el inicio de sesión móvil. Inténtelo de nuevo.",
   "action.close": "Cerrar",
   "action.back": "Volver",
   "action.remove": "Eliminar",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -14,6 +14,7 @@
   "home.room.authRequired": "Authentification requise",
   "home.room.authenticating": "Authentification...",
   "home.signIn": "Se connecter",
+  "home.authTimeout": "Pas de réponse du serveur — cette instance ne prend peut-être pas encore en charge la connexion mobile. Veuillez réessayer.",
   "action.close": "Fermer",
   "action.back": "Retour",
   "action.remove": "Supprimer",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -14,6 +14,7 @@
   "home.room.authRequired": "Autenticazione richiesta",
   "home.room.authenticating": "Autenticazione...",
   "home.signIn": "Accedi",
+  "home.authTimeout": "Nessuna risposta dal server: questa istanza potrebbe non supportare ancora l'accesso mobile. Riprova.",
   "action.close": "Chiudi",
   "action.back": "Indietro",
   "action.remove": "Rimuovi",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -14,6 +14,7 @@
   "home.room.authRequired": "Authenticatie vereist",
   "home.room.authenticating": "Authenticeren...",
   "home.signIn": "Inloggen",
+  "home.authTimeout": "Geen antwoord van de server — deze instantie ondersteunt mobiel inloggen mogelijk nog niet. Probeer het opnieuw.",
   "action.close": "Sluiten",
   "action.back": "Terug",
   "action.remove": "Verwijderen",


### PR DESCRIPTION
## Summary

Live debugging of the PKCE login against real Meet instances showed a **server-side gap**: no deployed Meet backend implements the PKCE mobile views (`/api/v1.0/oauth/token/` → 404 on meet.linagora.com, visio.numerique.gouv.fr, dev-meet.linagora.com; the views only exist in suitenumerique/dictaphone). The browser completes SSO, then lands on `/mobile-login` with no code/state — a route the Meet SPA doesn't have — and **no `visio://auth-callback` deep link ever fires**. The app waited silently forever.

This PR makes the failure visible instead of silent:

- **2-minute watchdog** (`OIDC_CALLBACK_TIMEOUT_MS`) started by `onLaunchOidc`; if no auth-callback deep link arrives in time, the pending flow is cleared, the registered post-auth action returns HomeView to the sign-in state, and a clear error is shown (new i18n key `home.authTimeout`, 6 locales)
- Timer cancelled on callback arrival; error cleared on retry/success
- Test hook `window.__OIDC_TIMEOUT_MS` for the E2E spec (production stays 120 s)
- New regression test: "shows an error and recovers when the OIDC callback never arrives"

Server-side fix (out of scope, other repo): port the dictaphone PKCE views (`PKCEOIDCAuthenticationRequestView`, callback, token exchange) into suitenumerique/meet.

## Test plan
- [x] New test fails without the fix (RED verified), passes with it
- [x] `npx playwright test` — 45/45 passed
- [x] `npm run lint`, `format:check`, `tsc --noEmit`, `check-i18n.sh` — clean
